### PR TITLE
fix(button): remove extra buttons on Storybook story

### DIFF
--- a/packages/tools/storybook/stories/components/button/button.web-components.stories.ts
+++ b/packages/tools/storybook/stories/components/button/button.web-components.stories.ts
@@ -104,19 +104,6 @@ const TemplateDefault = (args: any) => html`
     ${unsafeHTML(args.buttonContent || 'Button')}
     <span slot="end">${unsafeHTML(args.end)}</span>
   </osds-button>
-
-
-  <osds-button ...=${getTagAttributes(args)}>
-    <span slot="start"><osds-icon size="sm" name="plus" color="${args.color}" contrasted></osds-icon></span>
-    Button
-  </osds-button>
-
-
-  <osds-button ...=${getTagAttributes(args)}>
-    <span slot="start"></span>
-    Button
-    <span slot="end"><osds-icon size="sm" name="plus" color="${args.color}" contrasted></osds-icon></span>
-  </osds-button>
 `;
 export const Default = TemplateDefault.bind({});
 Default.args = {


### PR DESCRIPTION
In each Storybook stories, we need to have a single component to handle. 
On the Button story, there was specific cases displayed as well.
They need to be removed.