### PR TITLE
chore(storybook): add stories.json

### DIFF
--- a/packages/tools/storybook/.storybook/main.js
+++ b/packages/tools/storybook/.storybook/main.js
@@ -1,6 +1,7 @@
 module.exports = {
   features: {
     postcss: false,
+    buildStoriesJson: true
   },
   stories: ['../**/*.stories.@(md|mdx)', '../**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [


### PR DESCRIPTION
In order to be linked with external tools, we need to add stories.json generation in Storybook configuration