### PR TITLE
fix(select): disable click when disabled is set

### DIFF
--- a/packages/stencil/components/select/src/components/osds-select/osds-select.tsx
+++ b/packages/stencil/components/select/src/components/osds-select/osds-select.tsx
@@ -219,8 +219,10 @@ export class OsdsSelect implements OdsSelect<OdsStencilMethods<OdsSelectMethods>
   // Toggle overlay when we click on the Select.
   private handleSelectClick() {
     this.logger.log('[handleSelectClick]', arguments, { validity: this.validityState });
-    this.dirty = true;
-    this.opened = !this.opened;
+    if (!this.disabled) {
+      this.dirty = true;
+      this.opened = !this.opened;
+    }
   }
 
   // Hide overlay when we click anywhere else in the window.


### PR DESCRIPTION
The select `disabled` prop was only working thanks to the fact it was not focusable.

But when using the component in another shadow DOM, the click goes through anyway, so we need to prevent its behavior.