### PR TITLE
fix(storybook): prevent static dir to be ignored on build

### DIFF
--- a/packages/tools/storybook/.storybook/get-docs-api-directories.js
+++ b/packages/tools/storybook/.storybook/get-docs-api-directories.js
@@ -18,7 +18,6 @@ module.exports = function getDocsApiDirectories() {
     "libraries/*",
     "stencil/components/flag/dist/flags",
     "tools/storybook/public",
-    "components/*"
   ]
 
   try {

--- a/packages/tools/storybook/.storybook/main.js
+++ b/packages/tools/storybook/.storybook/main.js
@@ -7,13 +7,7 @@ module.exports = {
     buildStoriesJson: true
   },
   framework: '@storybook/react',
-  stories: [
-    '../**/*.stories.@(md|mdx|ts|tsx)',
-    {
-      directory: '../../../../packages-new/components',
-      files: '**/*.stories.@(md|mdx|ts|tsx)',
-    },
-  ],
+  stories: ['../**/*.stories.@(md|mdx|ts|tsx)'],
   addons: [
     // contains actions, backgrounds, controls, docs, viewport and toolbars addons
     {


### PR DESCRIPTION
This fix the flags rendering, among other issues