### PR TITLE
feat(datepicker): step 2, styling the component

### DIFF
--- a/packages/components/datepicker/src/components/osds-datepicker/constants/default-attributes.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/constants/default-attributes.ts
@@ -1,10 +1,13 @@
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { OdsDatepickerAttribute } from '../interfaces/attributes';
 
 const DEFAULT_ATTRIBUTE: OdsDatepickerAttribute = Object.freeze({
   clearable: false,
+  color: ODS_THEME_COLOR_INTENT.primary,
   disabled: false,
   error: false,
   format: 'dd/mm/yyyy',
+  inline: false,
   placeholder: '',
   value: null,
 });

--- a/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
@@ -22,6 +22,7 @@ class OdsDatepickerController {
     if(!this.component.disabled) {
       if (newValue === undefined || newValue === null || isNaN(newValue.getTime())) {
         this.component.value = null;
+        this.component.datepickerInstance?.setDate({ clear: true });
       } else {
         this.component.value = newValue;
         this.component.datepickerInstance?.setDate(newValue);

--- a/packages/components/datepicker/src/components/osds-datepicker/interfaces/attributes.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/interfaces/attributes.ts
@@ -1,8 +1,14 @@
+import type { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+
 interface OdsDatepickerAttribute {
   /**
    * Defines if the Datepicker should be clearable or not (displays a clear button)
    */
   clearable?: boolean;
+  /**
+   * Defines the Datepicker's color (see component principles)
+   */
+  color?: ODS_THEME_COLOR_INTENT;
   /**
    * Defines if the Datepicker should be disabled or not (lower opacity and not interactable)
    */
@@ -15,6 +21,10 @@ interface OdsDatepickerAttribute {
    * Defines which format the Datepicker should be applying (supported formats: https://mymth.github.io/vanillajs-datepicker/#/date-string+format?id=date-format)
    */
   format?: string;
+  /**
+   * Defines if the Datepicker should be displayed inline or not
+   */
+  inline?: boolean;
   /**
    * Defines if the Datepicker should display a placeholder message
    */

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
@@ -1,5 +1,6 @@
 import type { E2EPage } from '@stencil/core/testing';
 import type { OdsDatepickerAttribute } from './interfaces/attributes';
+import type { OsdsDatepicker } from './osds-datepicker';
 import { newE2EPage } from '@stencil/core/testing';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
@@ -20,6 +21,14 @@ describe('e2e:osds-datepicker', () => {
       const pickerElement = document.querySelector('osds-datepicker')?.shadowRoot?.querySelector('.datepicker') as HTMLElement;
       pickerElement.style.setProperty('animation', 'none');
     });
+
+    if (attributes.value) {
+      const dateStr = attributes.value.toISOString();
+      await page.evaluate((dateStr) => {
+          const datepicker = document.querySelector('osds-datepicker') as unknown as OsdsDatepicker;
+          datepicker.value = new Date(dateStr);
+      }, dateStr);
+    }
   }
 
   const attributeConfigurations = [
@@ -29,7 +38,7 @@ describe('e2e:osds-datepicker', () => {
     { name: 'format', options: ['dd/mm/yyyy', 'mm/dd/yyyy'] },
     { name: 'inline', options: [true, false] },
     { name: 'placeholder', options: ['', 'placeholder message'] },
-    { name: 'value', options: ['', new Date('2021-02-02')] },
+    { name: 'value', options: ['', new Date('1999-11-02')] },
   ];
 
   function generateCombinations(attributes: typeof attributeConfigurations): Array<Partial<OdsDatepickerAttribute>> {

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
@@ -3,7 +3,6 @@ import type { OdsDatepickerAttribute } from './interfaces/attributes';
 import { newE2EPage } from '@stencil/core/testing';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
-import { ODS_THEME_COLOR_INTENTS } from '@ovhcloud/ods-common-theming';
 
 describe('e2e:osds-datepicker', () => {
   let page: E2EPage;

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
@@ -8,43 +8,102 @@
 // CSS targeted only for this component
 // /!\ for theming purposes, it has to be done in theming files
 // (i.e. packages/libraries/theming/...)
-:host(.osds-datepicker) {
-  display: flex;
-  flex-direction: column;
-}
-
-.osds-datepicker {
-  &__hidden-input {
-    display: none;
+@keyframes datepicker-appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 
 :host {
-  .datepicker {
+  .osds-datepicker__hidden-input {
     display: none;
+  }
+
+:host([hasFocus]) {
+  .datepicker {
     width: 50%;
     max-width: clamp(36rem, 50%, 50%);
     margin-top: var(--ods-size-04);
     height: 0;
     position: relative;
+    display: flex;
 
     .datepicker-picker {
-      width: 100%;
-      height: fit-content;
-      background: gray;
       position: absolute;
+      border-style: solid;
+
+      .datepicker-header,
+      .datepicker-controls {
+        display: flex;
+        justify-content: space-between;
+
+        .prev-btn,
+        .next-btn {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border: none;
+          cursor: pointer;
+        }
+
+        .view-switch {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border: none;
+          cursor: pointer;
+        }
+      }
+
+      .datepicker-main {
+        .datepicker-view {
+          .days {
+            .days-of-week {
+              display: grid;
+
+              .dow {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                cursor: default;
+              }
+            }
+
+            .datepicker-grid {
+              display: grid;
+
+              .datepicker-cell {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                border: none;
+                cursor: pointer;
+              }
+
+              .prev,
+              .next {
+                opacity: 50%;
+              }
+            }
+          }
+        }
+
+        .datepicker-grid {
+          display: grid;
+
+          .datepicker-cell {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border: none;
+            cursor: pointer;
+          }
+        }
+      }
     }
-  }
-}
-
-:host([disabled]) {
-  opacity: .5;
-  cursor: not-allowed;
-}
-
-:host([hasFocus]) {
-  .datepicker {
-    display: flex;
   }
 }
 

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
@@ -124,13 +124,10 @@
   display: inline-block;
 }
 
-[disabled] {
-  @include osds-datepicker-on-selected-host() {
-    opacity: .5;
-    cursor: not-allowed;
+:host([disabled]) {
+  .datepicker {
+    display: none;
   }
-
-  cursor: not-allowed;
 }
 
 // apply the theme template for the component

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
@@ -17,19 +17,26 @@
   }
 }
 
-:host {
-  .osds-datepicker__hidden-input {
+:host(.osds-datepicker) {
+  display: flex;
+  flex-direction: column;
+}
+
+.osds-datepicker {
+  &__hidden-input {
     display: none;
   }
+}
 
-:host([hasFocus]) {
+:host {
   .datepicker {
-    width: 50%;
-    max-width: clamp(36rem, 50%, 50%);
-    margin-top: var(--ods-size-04);
-    height: 0;
     position: relative;
-    display: flex;
+    display: none;
+    animation: datepicker-appear 0.2s ease-in-out;
+
+    * {
+      transition: background-color 0.1s ease-in-out;
+    }
 
     .datepicker-picker {
       position: absolute;
@@ -105,6 +112,25 @@
       }
     }
   }
+}
+
+:host([hasFocus]) {
+  .datepicker {
+    display: flex;
+  }
+}
+
+:host([inline]) {
+  display: inline-block;
+}
+
+[disabled] {
+  @include osds-datepicker-on-selected-host() {
+    opacity: .5;
+    cursor: not-allowed;
+  }
+
+  cursor: not-allowed;
 }
 
 // apply the theme template for the component

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.spec.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.spec.ts
@@ -1,10 +1,11 @@
-jest.mock('./core/controller'); // keep jest.mock before any
+jest.mock('./core/controller');
 
 import type { SpecPage } from '@stencil/core/testing';
 import type { OdsDatepickerAttribute } from './interfaces/attributes';
 import { newSpecPage } from '@stencil/core/testing';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str, odsUnitTestAttribute } from '@ovhcloud/ods-common-testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { OsdsDatepicker } from './osds-datepicker';
 import { OdsDatepickerController } from './core/controller';
 
@@ -13,6 +14,8 @@ describe('spec:osds-datepicker', () => {
   let root: HTMLElement | undefined;
   let instance: OsdsDatepicker;
   let controller: OdsDatepickerController;
+
+  jest.spyOn(OsdsDatepicker.prototype, 'componentDidLoad').mockImplementation(jest.fn());
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -56,6 +59,17 @@ describe('spec:osds-datepicker', () => {
       });
     });
 
+    describe('color', () => {
+      odsUnitTestAttribute<OdsDatepickerAttribute, 'color'>({
+        name: 'color',
+        defaultValue: DEFAULT_ATTRIBUTE.color,
+        newValue: ODS_THEME_COLOR_INTENT.primary,
+        value: ODS_THEME_COLOR_INTENT.success,
+        setup: (value) => setup({ attributes: { ['color']: value } }),
+        ...config,
+      });
+    });
+
     describe('disabled', () => {
       odsUnitTestAttribute<OdsDatepickerAttribute, 'disabled'>({
         name: 'disabled',
@@ -85,6 +99,17 @@ describe('spec:osds-datepicker', () => {
         newValue: 'dd/mm/yyyy',
         value: 'yyyy-mm-dd',
         setup: (value) => setup({ attributes: { ['format']: value } }),
+        ...config,
+      });
+    });
+
+    describe('inline', () => {
+      odsUnitTestAttribute<OdsDatepickerAttribute, 'inline'>({
+        name: 'inline',
+        defaultValue: DEFAULT_ATTRIBUTE.inline,
+        newValue: true,
+        value: false,
+        setup: (value) => setup({ attributes: { ['inline']: value } }),
         ...config,
       });
     });

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -47,7 +47,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   @Prop({ reflect: true }) placeholder?: string = DEFAULT_ATTRIBUTE.placeholder;
 
   /** @see OdsDatepickerAttribute.value */
-  @Prop({ reflect: true, mutable: true }) value?: Date = DEFAULT_ATTRIBUTE.value;
+  @Prop({ reflect: true, mutable: true }) value?: Date | undefined | null = DEFAULT_ATTRIBUTE.value;
 
   /** @see OdsDatepickerEvent.odsDatepickerBlur */
   @Event() odsDatepickerBlur!: EventEmitter<void>;
@@ -59,7 +59,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   @Event() odsDatepickerValueChange!: EventEmitter<OdsDatepickerValueChangeEventDetail>;
 
   @Watch('value')
-  onValueChange(value: Date, oldValue?: Date) {
+  onValueChange(value: Date | undefined | null, oldValue?: Date) {
     this.controller.onValueChange(value, oldValue);
   }
 
@@ -68,7 +68,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
     if (this.format && event.detail.value.length === this.format.length) {
       this.onChange(new Date(Datepicker.parseDate(event.detail.value, this.format)))
     } else if (event.detail.value.length === 0) {
-      this.onChange(undefined)
+      this.onChange(null)
     }
   }
 
@@ -96,7 +96,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   /**
    * @see OdsDatepickerBehavior.onChange
    */
-  onChange(newValue: Date | undefined): void {
+  onChange(newValue: Date | undefined | null): void {
     this.controller.onChange(newValue, this.value);
   }
 
@@ -190,7 +190,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
     }
   }
 
-  formatDate(date?: Date | undefined) {
+  formatDate(date?: Date | undefined | null) {
     if (this.format && date && this.el.shadowRoot) {
       return Datepicker.formatDate(date, this.format);
     } else {
@@ -233,165 +233,6 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
           && error.length > 0
           && <osds-text color={ODS_THEME_COLOR_INTENT.error}>{error}</osds-text>
         }
-      </Host>
-    );
-  }
-}
-import type { EventEmitter } from '@stencil/core';
-import type { OdsDatepickerAttribute } from './interfaces/attributes';
-import type { OdsDatepickerEvent, OdsDatepickerValueChangeEventDetail } from './interfaces/events';
-import { Component, Element, Event, Host, h, Listen, Prop, State, Watch } from '@stencil/core';
-import { ODS_INPUT_TYPE } from '@ovhcloud/ods-component-input';
-import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-import { ODS_ICON_NAME } from '@ovhcloud/ods-component-icon';
-import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
-import { Datepicker } from 'vanillajs-datepicker'
-import { OdsDatepickerController } from './core/controller';
-
-/**
- * @slot (unnamed) - Datepicker content
- */
-@Component({
-  tag: 'osds-datepicker',
-  styleUrl: 'osds-datepicker.scss',
-  shadow: true
-})
-export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEvent {
-  controller: OdsDatepickerController = new OdsDatepickerController(this);
-
-  @Element() el!: HTMLElement;
-
-  @State() hasFocus = false;
-  @State() datepickerInstance: Datepicker | undefined = undefined;
-  @State() hiddenInput: HTMLInputElement | undefined = undefined;
-
-  /** Attributes */
-
-  /** @see OdsDatepickerAttribute.clearable */
-  @Prop({ reflect: true }) clearable?: boolean = DEFAULT_ATTRIBUTE.clearable;
-
-  /** @see OdsDatepickerAttribute.disabled */
-  @Prop({ reflect: true }) disabled?: boolean = DEFAULT_ATTRIBUTE.disabled;
-
-  /** @see OdsDatepickerAttribute.error */
-  @Prop({ reflect: true }) error?: boolean = DEFAULT_ATTRIBUTE.error;
-
-  /** @see OdsDatepickerAttribute.format */
-  @Prop({ reflect: true }) format?: string = DEFAULT_ATTRIBUTE.format;
-
-  /** @see OdsDatepickerAttribute.placeholder */
-  @Prop({ reflect: true }) placeholder?: string = DEFAULT_ATTRIBUTE.placeholder;
-
-  /** @see OdsDatepickerAttribute.value */
-  @Prop({ reflect: true, mutable: true }) value?: Date | null = DEFAULT_ATTRIBUTE.value;
-
-  /** Events */
-
-  /** @see OdsDatepickerEvent.odsDatepickerBlur */
-  @Event() odsDatepickerBlur!: EventEmitter<void>;
-
-  /** @see OdsDatepickerEvent.odsDatepickerFocus */
-  @Event() odsDatepickerFocus!: EventEmitter<void>;
-
-  /** @see OdsDatepickerEvent.odsDatepickerValueChange */
-  @Event() odsDatepickerValueChange!: EventEmitter<OdsDatepickerValueChangeEventDetail>;
-
-  /** Listening to user's manual input */
-  @Listen('odsValueChange')
-  handleInputValueChange(event: CustomEvent) {
-    if (this.format && event.detail.value.length === this.format.length) {
-      this.onChange(new Date(Datepicker.parseDate(event.detail.value, this.format)))
-    } else if (event.detail.value.length === 0) {
-      this.onChange(null)
-    }
-  }
-
-  emitBlur(): void {
-    this.odsDatepickerBlur.emit();
-  }
-
-  emitFocus(): void {
-    this.odsDatepickerFocus.emit();
-  }
-
-  emitValueChange(newValue: Date | undefined | null, oldValue?: Date | undefined | null): void {
-    this.odsDatepickerValueChange.emit({ value: newValue, oldValue: oldValue });
-  }
-
-  onBlur(): void {
-    this.controller.onBlur();
-  }
-
-  onChange(newValue: Date | undefined | null): void {
-    this.controller.onChange(newValue, this.value);
-  }
-
-  onFocus(): void {
-    this.controller.onFocus();
-  }
-
-  componentDidLoad() {
-    if(!this.el.shadowRoot) {
-      return;
-    }
-
-    if (this.hiddenInput && !this.hiddenInput.getAttribute('initialized')) {
-      this.datepickerInstance = new Datepicker(this.hiddenInput, {
-        format: this.format,
-        nextArrow: `<osds-icon name="triangle-right" size="sm" color="${ODS_THEME_COLOR_INTENT.primary}"></osds-icon>`,
-        prevArrow: `<osds-icon name="triangle-left" size="sm" color="${ODS_THEME_COLOR_INTENT.primary}"></osds-icon>`,
-        maxView: 2,
-      });
-
-      this.hiddenInput.addEventListener('changeDate', (e: Event) => {
-        const customEvent = e as CustomEvent;
-        this.onChange(customEvent.detail.date);
-      });
-
-      this.hiddenInput.setAttribute('initialized', 'true');
-    }
-  }
-
-  private formatDate(date?: Date | undefined | null) {
-    if (this.format && date) {
-      return Datepicker.formatDate(date, this.format);
-    }
-    return '';
-  }
-
-  render() {
-    const {
-      clearable,
-      disabled,
-      error,
-      hasFocus,
-      placeholder,
-      value,
-    } = this;
-
-    return (
-      <Host {...{
-        class: 'osds-datepicker',
-        disabled,
-        error,
-        hasFocus,
-        onBlur: () => this.onBlur(),
-        onFocus: () => this.onFocus(),
-      }}>
-        <osds-input
-          clearable={clearable}
-          error={error}
-          disabled={disabled}
-          icon={ODS_ICON_NAME.CALENDAR}
-          placeholder={placeholder}
-          type={ODS_INPUT_TYPE.text}
-          value={this.formatDate(value)}
-        ></osds-input>
-        <input
-          tabindex={-1}
-          class="osds-datepicker__hidden-input"
-          ref={(el?: HTMLInputElement) => this.hiddenInput = el || this.hiddenInput}
-        ></input>
       </Host>
     );
   }

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -3,6 +3,166 @@ import type { OdsDatepickerAttribute } from './interfaces/attributes';
 import type { OdsDatepickerEvent, OdsDatepickerValueChangeEventDetail } from './interfaces/events';
 import { Component, Element, Event, Host, h, Listen, Prop, State } from '@stencil/core';
 import { ODS_INPUT_TYPE } from '@ovhcloud/ods-component-input';
+import { ODS_ICON_NAME } from '@ovhcloud/ods-component-icon';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { Datepicker } from 'vanillajs-datepicker'
+import { OdsDatepickerController } from './core/controller';
+
+/**
+ * @slot (unnamed) - Datepicker content
+ */
+@Component({
+  tag: 'osds-datepicker',
+  styleUrl: 'osds-datepicker.scss',
+  shadow: true
+})
+export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEvent {
+  controller: OdsDatepickerController = new OdsDatepickerController(this);
+
+  @Element() el!: HTMLElement;
+
+  @State() hasFocus = false;
+
+  /** @see OdsDatepickerAttribute.clearable */
+  @Prop({ reflect: true }) clearable?: boolean = DEFAULT_ATTRIBUTE.clearable;
+
+  /** @see OdsDatepickerAttribute.disabled */
+  @Prop({ reflect: true }) disabled?: boolean = DEFAULT_ATTRIBUTE.disabled;
+
+  /** @see OdsDatepickerAttribute.error */
+  @Prop({ reflect: true }) error?: string = DEFAULT_ATTRIBUTE.error;
+
+  /** @see OdsDatepickerAttribute.format */
+  @Prop({ reflect: true }) format?: string = DEFAULT_ATTRIBUTE.format;
+
+  /** @see OdsDatepickerAttribute.placeholder */
+  @Prop({ reflect: true }) placeholder?: string = DEFAULT_ATTRIBUTE.placeholder;
+
+  /** @see OdsDatepickerAttribute.value */
+  @Prop({ reflect: true, mutable: true }) value?: Date = DEFAULT_ATTRIBUTE.value;
+
+  /** @see OdsDatepickerEvents.odsValueChange */
+  @Event() odsValueChange!: EventEmitter<OdsDatepickerValueChangeEventDetail>;
+
+  /** @see OdsDatepickerEvents.odsDatepickerBlur */
+  @Event() odsDatepickerBlur!: EventEmitter<void>;
+
+  /** @see OdsDatepickerEvents.odsDatepickerFocus */
+  @Event() odsDatepickerFocus!: EventEmitter<void>;
+
+  @Watch('value')
+  onValueChange(value: Date, oldValue?: Date) {
+    this.controller.onValueChange(value, oldValue);
+  }
+
+  @Listen('odsValueChange', { target: 'body' })
+  handleInputValueChange(event: CustomEvent) {
+    if (this.format && event.detail.value.length === this.format.length) {
+      this.onChange(new Date(Datepicker.parseDate(event.detail.value, this.format)))
+    } else if (event.detail.value.length === 0) {
+      this.onChange(undefined)
+    }
+  }
+
+  /**
+   * @see OdsDatepickerBehavior.emitBlur
+   */
+  emitBlur(): void {
+    this.odsDatepickerBlur.emit();
+  }
+
+  /**
+   * @see OdsDatepickerBehavior.emitFocus
+   */
+  emitFocus(): void {
+    this.odsDatepickerFocus.emit();
+  }
+
+  /**
+   * @see OdsDatepickerBehavior.onBlur
+   */
+  onBlur(): void {
+    this.controller.onBlur();
+  }
+
+  /**
+   * @see OdsDatepickerBehavior.onChange
+   */
+  onChange(newValue: Date | undefined): void {
+    this.controller.onChange(newValue, this.value);
+  }
+
+  /**
+   * @see OdsDatepickerBehavior.onFocus
+   */
+  onFocus(): void {
+    this.controller.onFocus();
+  }
+
+  componentDidLoad() {
+    if(!this.el.shadowRoot) {
+      return;
+    }
+
+    const datepickerElement = this.el.shadowRoot.querySelector('.osds-datepicker__hidden-input') as HTMLInputElement;
+
+    if (!datepickerElement.getAttribute('initialized')) {
+      new Datepicker(datepickerElement, {
+        format: this.format,
+      });
+
+      datepickerElement.addEventListener('changeDate', (e: Event) => {
+        const customEvent = e as CustomEvent;
+        this.onChange(customEvent.detail.date);
+      });
+
+      datepickerElement.setAttribute('initialized', 'true');
+    }
+  }
+
+  formatDate(date?: Date | undefined) {
+    if (this.format && date) {
+      return Datepicker.formatDate(date, this.format);
+    } else {
+      return '';
+    }
+  }
+
+  render() {
+    const {
+      clearable,
+      disabled,
+      error,
+      hasFocus,
+      placeholder,
+      value,
+    } = this;
+
+    return (
+      <Host {...{
+        hasFocus,
+        onBlur: () => this.onBlur(),
+        onFocus: () => this.onFocus(),
+      }}>
+        <osds-input
+          type={ODS_INPUT_TYPE.text}
+          clearable={clearable}
+          disabled={disabled}
+          error={error}
+          icon={ODS_ICON_NAME.CALENDAR}
+          placeholder={placeholder}
+          value={this.formatDate(value)}
+        ></osds-input>
+        <input tabindex={-1} class="osds-datepicker__hidden-input"></input>
+      </Host>
+    );
+  }
+}
+import type { EventEmitter } from '@stencil/core';
+import type { OdsDatepickerAttribute } from './interfaces/attributes';
+import type { OdsDatepickerEvent, OdsDatepickerValueChangeEventDetail } from './interfaces/events';
+import { Component, Element, Event, Host, h, Listen, Prop, State, Watch } from '@stencil/core';
+import { ODS_INPUT_TYPE } from '@ovhcloud/ods-component-input';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { ODS_ICON_NAME } from '@ovhcloud/ods-component-icon';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -101,8 +101,6 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
       return;
     }
 
-    this.hiddenInput = this.el.shadowRoot.querySelector('.osds-datepicker__hidden-input') as HTMLInputElement;
-
     if (this.hiddenInput && !this.hiddenInput.getAttribute('initialized')) {
       this.datepickerInstance = new Datepicker(this.hiddenInput, {
         format: this.format,
@@ -219,7 +217,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
           type={ODS_INPUT_TYPE.text}
           value={this.formatDate(value)}
         ></osds-input>
-        <input tabindex={-1} class="osds-datepicker__hidden-input"></input>
+        <input tabindex={-1} class="osds-datepicker__hidden-input" ref={(el?: HTMLInputElement) => this.hiddenInput = el || this.hiddenInput}></input>
       </Host>
     );
   }

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -211,6 +211,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
         <osds-input
           clearable={clearable}
           color={color}
+          disabled={disabled}
           error={error}
           icon={ODS_ICON_NAME.CALENDAR}
           placeholder={placeholder}

--- a/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.color.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.color.scss
@@ -3,12 +3,63 @@
 
 @mixin osds-datepicker-theme-color-variant-default() {
   @include ods-and-all-hue-foreach-theme-color((
-          color: '800',
-          background-color: '100'
+    selected: '800',
+    color: '500',
+    border-color: '200',
+    background-color: '100'
   )) using($colors) {
     @include osds-datepicker-on-selected-host() {
-      //color: map_get($colors, color);
-      //background-color: map_get($colors, background-color);
+      .datepicker {
+        * {
+          color: map_get($colors, color);
+        }
+
+        .datepicker-picker {
+          border-color: map_get($colors, border-color);
+
+          .datepicker-header,
+          .datepicker-controls {
+
+            .prev-btn:hover,
+            .next-btn:hover {
+              background: map_get($colors, background-color);
+            }
+
+            .view-switch:hover {
+              background: map_get($colors, background-color);
+            }
+          }
+
+          .datepicker-main {
+            .datepicker-view {
+              .days {
+                .datepicker-grid {
+                  .datepicker-cell:hover,
+                  .selected {
+                    background: map_get($colors, background-color);
+                  }
+
+                  .selected,
+                  .selected:hover {
+                    background: map_get($colors, selected);
+                  }
+                }
+              }
+            }
+
+            .datepicker-grid {
+              .datepicker-cell:hover {
+                background: map_get($colors, background-color);
+              }
+
+              .selected,
+              .selected:hover {
+                background: map_get($colors, selected);
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -17,7 +68,57 @@
 @mixin osds-datepicker-theme-color() {
   /** base colors */
   :host {
-    border-color: transparent;
+    .datepicker {
+      .datepicker-picker {
+        background-color: var(--ods-color-gray-000);
+
+        .datepicker-header,
+        .datepicker-controls {
+          .prev-btn,
+          .next-btn {
+            background: none;
+          }
+
+          .view-switch {
+            background: none;
+          }
+        }
+
+        .datepicker-main {
+          .datepicker-view {
+            .days {
+              .days-of-week {
+                .dow {
+                  color: var(--ods-color-text-500);
+                }
+              }
+
+              .datepicker-grid {
+                .datepicker-cell {
+                  background: none;
+                }
+
+                .selected,
+                .selected:hover {
+                  color: var(--ods-color-gray-000);
+                }
+              }
+            }
+          }
+
+          .datepicker-grid {
+            .datepicker-cell {
+              background: none;
+            }
+
+            .selected,
+            .selected:hover {
+              color: var(--ods-color-gray-000);
+            }
+          }
+        }
+      }
+    }
   }
 
   /** no variant specified: default variant colors */

--- a/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.size.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.size.scss
@@ -3,5 +3,105 @@
 
 // Main CSS mixin for sizes
 @mixin osds-datepicker-theme-size() {
+  /** sizes */
+  :host {
+    osds-input {
+        width: 100%;
+        min-width: calc((var(--ods-size-10) - var(--ods-size-03)) * 7 + var(--ods-size-07) * 2 + var(--ods-size-01) * 2);
+    }
 
+    .osds-datepicker__hidden-input {
+        width: 0;
+    }
+
+    .datepicker {
+        width: 0;
+        height: 0;
+
+        .datepicker-picker {
+            height: fit-content;
+            border-width: var(--ods-size-01);
+            border-top-width: 0;
+            border-bottom-left-radius: var(--ods-size-03);
+            border-bottom-right-radius: var(--ods-size-03);
+            padding: var(--ods-size-04) var(--ods-size-07) calc(var(--ods-size-04) * 2) var(--ods-size-07);
+
+            .datepicker-header,
+            .datepicker-controls {
+                width: 100%;
+
+                .prev-btn,
+                .next-btn {
+                    width: calc(var(--ods-size-10) - var(--ods-size-03));
+                    height: calc(var(--ods-size-10) - var(--ods-size-03));
+                    min-width: calc(var(--ods-size-10) - var(--ods-size-03));
+                    min-height: calc(var(--ods-size-10) - var(--ods-size-03));
+                    border-radius: 50%;
+                }
+
+                .view-switch {
+                    width: 100%;
+                    border-radius: var(--ods-size-03);
+                }
+            }
+        }
+
+        .datepicker-main {
+            margin-top: var(--ods-size-04);
+
+            .datepicker-view {
+              .days {
+                .days-of-week {
+                  grid-template-columns: repeat(7, 1fr);
+
+                  .dow {
+                    width: calc(var(--ods-size-10) - var(--ods-size-03));
+                    height: calc(var(--ods-size-10) - var(--ods-size-03));
+                  }
+                }
+
+                .datepicker-grid {
+                  grid-template-columns: repeat(7, 1fr);
+                  grid-template-rows: repeat(6, 1fr);
+
+                  .datepicker-cell {
+                    width: calc(var(--ods-size-10) - var(--ods-size-03));
+                    height: calc(var(--ods-size-10) - var(--ods-size-03));
+                    border-radius: 50%;
+                  }
+                }
+              }
+            }
+
+            .datepicker-grid {
+              grid-template-columns: repeat(4, 1fr);
+              grid-template-rows: repeat(3, 1fr);
+
+              .datepicker-cell {
+                width: calc(calc(var(--ods-size-10) - var(--ods-size-03)) * 1.75);
+                height: calc(var(--ods-size-10) - var(--ods-size-03));
+                border-radius: var(--ods-size-03);
+              }
+            }
+        }
+    }
+  }
+
+  :host([inline]) {
+    osds-input {
+      width: calc((var(--ods-size-10) - var(--ods-size-03)) * 7 + var(--ods-size-07) * 2 + var(--ods-size-01) * 2);
+    }
+  }
+
+  :host([hasFocus]) {
+    osds-input {
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  :host([inline][hasFocus]) {
+    osds-input {
+      border-bottom-right-radius: 0;
+    }
+  }
 }

--- a/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.size.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.size.scss
@@ -6,84 +6,84 @@
   /** sizes */
   :host {
     osds-input {
-        width: 100%;
-        min-width: calc((var(--ods-size-10) - var(--ods-size-03)) * 7 + var(--ods-size-07) * 2 + var(--ods-size-01) * 2);
+      width: 100%;
+      min-width: calc((var(--ods-size-10) - var(--ods-size-03)) * 7 + var(--ods-size-07) * 2 + var(--ods-size-01) * 2);
     }
 
     .osds-datepicker__hidden-input {
-        width: 0;
+      width: 0;
     }
 
     .datepicker {
-        width: 0;
-        height: 0;
+      width: 0;
+      height: 0;
 
-        .datepicker-picker {
-            height: fit-content;
-            border-width: var(--ods-size-01);
-            border-top-width: 0;
-            border-bottom-left-radius: var(--ods-size-03);
-            border-bottom-right-radius: var(--ods-size-03);
-            padding: var(--ods-size-04) var(--ods-size-07) calc(var(--ods-size-04) * 2) var(--ods-size-07);
+      .datepicker-picker {
+        height: fit-content;
+        border-width: var(--ods-size-01);
+        border-top-width: 0;
+        border-bottom-left-radius: var(--ods-size-03);
+        border-bottom-right-radius: var(--ods-size-03);
+        padding: var(--ods-size-04) var(--ods-size-07) calc(var(--ods-size-04) * 2) var(--ods-size-07);
 
-            .datepicker-header,
-            .datepicker-controls {
-                width: 100%;
+        .datepicker-header,
+        .datepicker-controls {
+          width: 100%;
 
-                .prev-btn,
-                .next-btn {
-                    width: calc(var(--ods-size-10) - var(--ods-size-03));
-                    height: calc(var(--ods-size-10) - var(--ods-size-03));
-                    min-width: calc(var(--ods-size-10) - var(--ods-size-03));
-                    min-height: calc(var(--ods-size-10) - var(--ods-size-03));
-                    border-radius: 50%;
-                }
+          .prev-btn,
+          .next-btn {
+            width: calc(var(--ods-size-10) - var(--ods-size-03));
+            height: calc(var(--ods-size-10) - var(--ods-size-03));
+            min-width: calc(var(--ods-size-10) - var(--ods-size-03));
+            min-height: calc(var(--ods-size-10) - var(--ods-size-03));
+            border-radius: 50%;
+          }
 
-                .view-switch {
-                    width: 100%;
-                    border-radius: var(--ods-size-03);
-                }
-            }
+          .view-switch {
+            width: 100%;
+            border-radius: var(--ods-size-03);
+          }
         }
+      }
 
-        .datepicker-main {
-            margin-top: var(--ods-size-04);
+      .datepicker-main {
+        margin-top: var(--ods-size-04);
 
-            .datepicker-view {
-              .days {
-                .days-of-week {
-                  grid-template-columns: repeat(7, 1fr);
+        .datepicker-view {
+          .days {
+            .days-of-week {
+              grid-template-columns: repeat(7, 1fr);
 
-                  .dow {
-                    width: calc(var(--ods-size-10) - var(--ods-size-03));
-                    height: calc(var(--ods-size-10) - var(--ods-size-03));
-                  }
-                }
-
-                .datepicker-grid {
-                  grid-template-columns: repeat(7, 1fr);
-                  grid-template-rows: repeat(6, 1fr);
-
-                  .datepicker-cell {
-                    width: calc(var(--ods-size-10) - var(--ods-size-03));
-                    height: calc(var(--ods-size-10) - var(--ods-size-03));
-                    border-radius: 50%;
-                  }
-                }
+              .dow {
+                width: calc(var(--ods-size-10) - var(--ods-size-03));
+                height: calc(var(--ods-size-10) - var(--ods-size-03));
               }
             }
 
             .datepicker-grid {
-              grid-template-columns: repeat(4, 1fr);
-              grid-template-rows: repeat(3, 1fr);
+              grid-template-columns: repeat(7, 1fr);
+              grid-template-rows: repeat(6, 1fr);
 
               .datepicker-cell {
-                width: calc(calc(var(--ods-size-10) - var(--ods-size-03)) * 1.75);
+                width: calc(var(--ods-size-10) - var(--ods-size-03));
                 height: calc(var(--ods-size-10) - var(--ods-size-03));
-                border-radius: var(--ods-size-03);
+                border-radius: 50%;
               }
             }
+          }
         }
+
+        .datepicker-grid {
+          grid-template-columns: repeat(4, 1fr);
+          grid-template-rows: repeat(3, 1fr);
+
+          .datepicker-cell {
+            width: calc(calc(var(--ods-size-10) - var(--ods-size-03)) * 1.75);
+            height: calc(var(--ods-size-10) - var(--ods-size-03));
+            border-radius: var(--ods-size-03);
+          }
+        }
+      }
     }
   }
 

--- a/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.typography.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/styles/osds-datepicker.typography.scss
@@ -4,13 +4,11 @@
 
 // Main CSS mixin for typography
 @mixin osds-datepicker-theme-typography() {
-  :host([size='md']) .datepicker__wrapper {
-    //$typography-properties: ods-get-typography-properties(body, '400');
-    //font-family: ods-get-typography-property($typography-properties, font-family);
-    //font-size: ods-get-typography-property($typography-properties, font-size);
-    //font-style: ods-get-typography-property($typography-properties, font-style);
-    //font-weight: ods-get-typography-property($typography-properties, font-weight);
-    //letter-spacing: ods-get-typography-property($typography-properties, letter-spacing);
-    //line-height: ods-get-typography-property($typography-properties, line-height);
+  :host .datepicker * {
+    font-family: var(--ods-font-family);
+    font-size: var(--ods-typo-size-03);
+    line-height: var(--ods-line-height-size-03);
+    letter-spacing: var(--ods-letter-spacing-size-02);
+    font-weight: var(--ods-typo-weight-semibold);
   }
 }

--- a/packages/components/datepicker/src/global.dev.ts
+++ b/packages/components/datepicker/src/global.dev.ts
@@ -10,6 +10,7 @@ import { OdsLogger } from '@ovhcloud/ods-common-core';
 // Input dependencies
 import '@ovhcloud/ods-component-input';
 import '@ovhcloud/ods-component-icon';
+import '@ovhcloud/ods-component-text';
 
 const logger = new OdsLogger('global-dev');
 logger.log('init');

--- a/packages/components/datepicker/src/global.test.ts
+++ b/packages/components/datepicker/src/global.test.ts
@@ -8,3 +8,4 @@ import './global';
 // Input dependencies
 import '@ovhcloud/ods-component-input';
 import '@ovhcloud/ods-component-icon';
+import '@ovhcloud/ods-component-text';

--- a/packages/components/datepicker/src/index.html
+++ b/packages/components/datepicker/src/index.html
@@ -15,7 +15,9 @@
 </head>
 <body>
 
-<osds-datepicker placeholder="dd/mm/yyyy" clearable="true"></osds-datepicker>
+<!-- <osds-datepicker placeholder="dd/mm/yyyy" clearable ></osds-datepicker> -->
+<osds-datepicker placeholder="dd/mm/yyyy" clearable inline></osds-datepicker>
+<!-- <osds-datepicker placeholder="dd/mm/yyyy" clearable inline></osds-datepicker> -->
 
 <p>Hello</p>
 

--- a/packages/components/datepicker/src/index.html
+++ b/packages/components/datepicker/src/index.html
@@ -15,9 +15,7 @@
 </head>
 <body>
 
-<!-- <osds-datepicker placeholder="dd/mm/yyyy" clearable ></osds-datepicker> -->
-<osds-datepicker placeholder="dd/mm/yyyy" clearable inline></osds-datepicker>
-<!-- <osds-datepicker placeholder="dd/mm/yyyy" clearable inline></osds-datepicker> -->
+<osds-datepicker placeholder="dd/mm/yyyy" clearable></osds-datepicker>
 
 <p>Hello</p>
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,6 +16,7 @@
     "@ovhcloud/ods-component-code": "16.0.1",
     "@ovhcloud/ods-component-collapsible": "16.0.1",
     "@ovhcloud/ods-component-content-addon": "16.0.1",
+    "@ovhcloud/ods-component-datepicker": "16.0.1",
     "@ovhcloud/ods-component-divider": "16.0.1",
     "@ovhcloud/ods-component-flag": "16.0.1",
     "@ovhcloud/ods-component-form-field": "16.0.1",

--- a/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
+++ b/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
@@ -1,6 +1,8 @@
 import { html } from 'lit-html';
 import { defineCustomElements } from '@ovhcloud/ods-components/datepicker/loader';
 import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
+import { DEFAULT_ATTRIBUTE } from '@ovhcloud/ods-components/datepicker/src/components/osds-datepicker/constants/default-attributes';
+import { ODS_THEME_COLOR_INTENTS } from '@ovhcloud/ods-common-theming';
 // @ts-ignore
 import changelog from '@ovhcloud/ods-components/datepicker/CHANGELOG.md';
 // @ts-ignore
@@ -14,6 +16,12 @@ const storyParams = {
     category: 'General',
     defaultValue: false,
   },
+  color: {
+    category: 'General',
+    defaultValue: DEFAULT_ATTRIBUTE.color,
+    options: ODS_THEME_COLOR_INTENTS,
+    control: { type: 'select' },
+  },
   disabled: {
     category: 'General',
     defaultValue: false,
@@ -25,6 +33,10 @@ const storyParams = {
   format: {
     category: 'General',
     defaultValue: 'dd/mm/yyyy',
+  },
+  inline: {
+    category: 'General',
+    defaultValue: false,
   },
   placeholder: {
     category: 'General',
@@ -39,18 +51,24 @@ export default {
     notes: {
       changelog,
     },
-    docs: { page }
+    docs: { page },
+    options: {
+      enableShortcuts: false,
+    },
   },
   argTypes: extractArgTypes(storyParams)
 };
 
 /* Default */
-const TemplateDefault = (args:any) => {
-  return html`<osds-datepicker ...=${getTagAttributes(args)}></osds-datepicker>`;
-}
-
+const OsdsDatepickerDefault = (args: Record<string, unknown>) => html`
+  <osds-datepicker ...=${getTagAttributes(args)}>
+  </osds-datepicker>
+`;
+const TemplateDefault = (args: Record<string, unknown>) => OsdsDatepickerDefault(args);
 export const Default = TemplateDefault.bind({});
-// @ts-ignore
-Default.args = {
-  ...extractStoryParams(storyParams),
+type DefaultProps = {
+  args: Record<string, unknown>;
+};
+(Default as unknown as DefaultProps).args = {
+  ...(extractStoryParams(storyParams) as Record<string, unknown>)
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,48 +4692,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ovhcloud/ods-component-datepicker-react@workspace:packages/components/datepicker/react":
-  version: 0.0.0-use.local
-  resolution: "@ovhcloud/ods-component-datepicker-react@workspace:packages/components/datepicker/react"
-  dependencies:
-    "@ovhcloud/ods-component-datepicker": ^15.0.1
-    "@ovhcloud/ods-react-dev": ^15.0.1
-  peerDependencies:
-    react: ">=16.8.6"
-    react-dom: ">=16.8.6"
-  languageName: unknown
-  linkType: soft
-
-"@ovhcloud/ods-component-datepicker-vue@workspace:packages/components/datepicker/vue":
-  version: 0.0.0-use.local
-  resolution: "@ovhcloud/ods-component-datepicker-vue@workspace:packages/components/datepicker/vue"
-  dependencies:
-    "@ovhcloud/ods-component-datepicker": ^15.0.1
-    "@ovhcloud/ods-vue-dev": ^15.0.1
-  peerDependencies:
-    vue: ">=3"
-  languageName: unknown
-  linkType: soft
-
-"@ovhcloud/ods-component-datepicker@^15.0.1, @ovhcloud/ods-component-datepicker@workspace:packages/components/datepicker":
-  version: 0.0.0-use.local
-  resolution: "@ovhcloud/ods-component-datepicker@workspace:packages/components/datepicker"
-  dependencies:
-    "@ovhcloud/ods-common-core": ^15.0.1
-    "@ovhcloud/ods-common-stencil": ^15.0.1
-    "@ovhcloud/ods-common-testing": ^15.0.1
-    "@ovhcloud/ods-common-theming": ^15.0.1
-    "@ovhcloud/ods-component-input": ^15.0.1
-    "@ovhcloud/ods-component-link": ^15.0.1
-    "@ovhcloud/ods-component-text": ^15.0.1
-    "@ovhcloud/ods-component-textarea": ^15.0.1
-    "@ovhcloud/ods-component-tooltip": ^15.0.1
-    "@ovhcloud/ods-stencil-dev": ^15.0.1
-    "@types/vanillajs-datepicker": ^1.2.2
-    vanillajs-datepicker: ^1.3.3
-  languageName: unknown
-  linkType: soft
-
 "@ovhcloud/ods-component-divider-react@workspace:packages/components/divider/react":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-divider-react@workspace:packages/components/divider/react"
@@ -8561,13 +8519,6 @@ __metadata:
   linkType: hard
 
 "@types/vanillajs-datepicker@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@types/vanillajs-datepicker@npm:1.2.2"
-  checksum: 4899837a457a62fa9e2606c61788ee98fa24979435a013b8101ec22107cf4e100af9e6eb340049844f2be6e68032d3b226b15bbc909b95410e8e6eb2db0b5939
-  languageName: node
-  linkType: hard
-
-"@types/vanillajs-datepicker@npm:^1.2.2":
   version: 1.2.2
   resolution: "@types/vanillajs-datepicker@npm:1.2.2"
   checksum: 4899837a457a62fa9e2606c61788ee98fa24979435a013b8101ec22107cf4e100af9e6eb340049844f2be6e68032d3b226b15bbc909b95410e8e6eb2db0b5939

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,6 +4692,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ovhcloud/ods-component-datepicker-react@workspace:packages/components/datepicker/react":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-datepicker-react@workspace:packages/components/datepicker/react"
+  dependencies:
+    "@ovhcloud/ods-component-datepicker": ^15.0.1
+    "@ovhcloud/ods-react-dev": ^15.0.1
+  peerDependencies:
+    react: ">=16.8.6"
+    react-dom: ">=16.8.6"
+  languageName: unknown
+  linkType: soft
+
+"@ovhcloud/ods-component-datepicker-vue@workspace:packages/components/datepicker/vue":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-datepicker-vue@workspace:packages/components/datepicker/vue"
+  dependencies:
+    "@ovhcloud/ods-component-datepicker": ^15.0.1
+    "@ovhcloud/ods-vue-dev": ^15.0.1
+  peerDependencies:
+    vue: ">=3"
+  languageName: unknown
+  linkType: soft
+
+"@ovhcloud/ods-component-datepicker@^15.0.1, @ovhcloud/ods-component-datepicker@workspace:packages/components/datepicker":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-datepicker@workspace:packages/components/datepicker"
+  dependencies:
+    "@ovhcloud/ods-common-core": ^15.0.1
+    "@ovhcloud/ods-common-stencil": ^15.0.1
+    "@ovhcloud/ods-common-testing": ^15.0.1
+    "@ovhcloud/ods-common-theming": ^15.0.1
+    "@ovhcloud/ods-component-input": ^15.0.1
+    "@ovhcloud/ods-component-link": ^15.0.1
+    "@ovhcloud/ods-component-text": ^15.0.1
+    "@ovhcloud/ods-component-textarea": ^15.0.1
+    "@ovhcloud/ods-component-tooltip": ^15.0.1
+    "@ovhcloud/ods-stencil-dev": ^15.0.1
+    "@types/vanillajs-datepicker": ^1.2.2
+    vanillajs-datepicker: ^1.3.3
+  languageName: unknown
+  linkType: soft
+
 "@ovhcloud/ods-component-divider-react@workspace:packages/components/divider/react":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-divider-react@workspace:packages/components/divider/react"
@@ -5735,6 +5777,7 @@ __metadata:
     "@ovhcloud/ods-component-code": 16.0.1
     "@ovhcloud/ods-component-collapsible": 16.0.1
     "@ovhcloud/ods-component-content-addon": 16.0.1
+    "@ovhcloud/ods-component-datepicker": 16.0.1
     "@ovhcloud/ods-component-divider": 16.0.1
     "@ovhcloud/ods-component-flag": 16.0.1
     "@ovhcloud/ods-component-form-field": 16.0.1
@@ -8518,6 +8561,13 @@ __metadata:
   linkType: hard
 
 "@types/vanillajs-datepicker@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@types/vanillajs-datepicker@npm:1.2.2"
+  checksum: 4899837a457a62fa9e2606c61788ee98fa24979435a013b8101ec22107cf4e100af9e6eb340049844f2be6e68032d3b226b15bbc909b95410e8e6eb2db0b5939
+  languageName: node
+  linkType: hard
+
+"@types/vanillajs-datepicker@npm:^1.2.2":
   version: 1.2.2
   resolution: "@types/vanillajs-datepicker@npm:1.2.2"
   checksum: 4899837a457a62fa9e2606c61788ee98fa24979435a013b8101ec22107cf4e100af9e6eb340049844f2be6e68032d3b226b15bbc909b95410e8e6eb2db0b5939


### PR DESCRIPTION
Datepicker component styling

2 new attributes:
> color?: defines the color of the Datepicker
> inline?: defines if the component should be inline

The datepicker module is displayed seamlessly border-to-border with the input above, input's bottom right corner radius is adjusted regarding the inline attribute.