### PR TITLE
feat(datepicker): step 3, excluding dates

### DIFF
--- a/packages/components/datepicker/src/components/osds-datepicker/constants/datepicker-day.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/constants/datepicker-day.ts
@@ -1,0 +1,16 @@
+enum ODS_DATEPICKER_DAY {
+    monday = 1,
+    tuesday = 2,
+    wednesday = 3,
+    thursday = 4,
+    friday = 5,
+    saturday = 6,
+    sunday = 0,
+}
+
+const ODS_DATEPICKER_DAYS = Object.freeze(Object.values(ODS_DATEPICKER_DAY));
+
+export {
+    ODS_DATEPICKER_DAY,
+    ODS_DATEPICKER_DAYS,
+};

--- a/packages/components/datepicker/src/components/osds-datepicker/constants/default-attributes.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/constants/default-attributes.ts
@@ -4,10 +4,14 @@ import { OdsDatepickerAttribute } from '../interfaces/attributes';
 const DEFAULT_ATTRIBUTE: OdsDatepickerAttribute = Object.freeze({
   clearable: false,
   color: ODS_THEME_COLOR_INTENT.primary,
+  datesDisabled: [],
+  daysOfWeekDisabled: [],
   disabled: false,
   error: false,
   format: 'dd/mm/yyyy',
   inline: false,
+  maxDate: null,
+  minDate: null,
   placeholder: '',
   value: null,
 });

--- a/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
@@ -23,10 +23,17 @@ class OdsDatepickerController {
       if (newValue === undefined || newValue === null || isNaN(newValue.getTime())) {
         this.component.value = null;
         this.component.datepickerInstance?.setDate({ clear: true });
+        this.component.emitDatepickerValueChange(null, oldValue);
       } else {
-        this.component.value = newValue;
-        this.component.datepickerInstance?.setDate(newValue);
-        this.component.emitValueChange(newValue, oldValue);
+        if (this.validateValue(newValue)) {
+          this.component.value = newValue;
+          this.component.datepickerInstance?.setDate(newValue);
+          this.component.emitDatepickerValueChange(newValue, oldValue);
+        } else {
+          this.component.value = null;
+          this.component.datepickerInstance?.setDate({ clear: true });
+          this.component.emitDatepickerValueChange(null, oldValue);
+        }
       }
     }
   }
@@ -34,6 +41,26 @@ class OdsDatepickerController {
   onBlur() {
     this.component.hasFocus = false;
     this.component.emitBlur();
+  }
+
+  private getMidnightDate(date: Date) {
+    return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  }
+
+  private validateValue(value?: Date) {
+    if (value) {
+      if (!this.component.maxDate || this.getMidnightDate(value).getTime() <= this.getMidnightDate(this.component.maxDate).getTime() ) {
+        if (!this.component.minDate || this.getMidnightDate(value).getTime() >= this.getMidnightDate(this.component.minDate).getTime() ) {
+          if (!this.component.daysOfWeekDisabled || !this.component.daysOfWeekDisabled.includes(value.getDay())) {
+            // Checking if the datesDisabled array exists, and if so checking if it contains the value
+            if (!this.component.datesDisabled || !this.component.datesDisabled.some(d => this.getMidnightDate(d).getTime() === this.getMidnightDate(value).getTime())) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
   }
 }
 

--- a/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/core/controller.ts
@@ -18,22 +18,16 @@ class OdsDatepickerController {
     }
   }
 
-  onChange(newValue: Date | undefined | null, oldValue?: Date | null) {
+  onChange(newValue: Date | undefined | null, oldValue?: Date | null): void {
     if(!this.component.disabled) {
-      if (newValue === undefined || newValue === null || isNaN(newValue.getTime())) {
+      if (!this.validateValue(newValue)) {
         this.component.value = null;
         this.component.datepickerInstance?.setDate({ clear: true });
-        this.component.emitDatepickerValueChange(null, oldValue);
+        this.component.emitDatepickerValueChange(null, oldValue ? oldValue : null);
       } else {
-        if (this.validateValue(newValue)) {
-          this.component.value = newValue;
-          this.component.datepickerInstance?.setDate(newValue);
-          this.component.emitDatepickerValueChange(newValue, oldValue);
-        } else {
-          this.component.value = null;
-          this.component.datepickerInstance?.setDate({ clear: true });
-          this.component.emitDatepickerValueChange(null, oldValue);
-        }
+        this.component.value = newValue;
+        this.component.datepickerInstance?.setDate(newValue);
+        this.component.emitDatepickerValueChange(newValue, oldValue ? oldValue : null);
       }
     }
   }
@@ -43,24 +37,34 @@ class OdsDatepickerController {
     this.component.emitBlur();
   }
 
-  private getMidnightDate(date: Date) {
+  private getMidnightDate(date: Date): Date {
     return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
   }
 
-  private validateValue(value?: Date) {
-    if (value) {
-      if (!this.component.maxDate || this.getMidnightDate(value).getTime() <= this.getMidnightDate(this.component.maxDate).getTime() ) {
-        if (!this.component.minDate || this.getMidnightDate(value).getTime() >= this.getMidnightDate(this.component.minDate).getTime() ) {
-          if (!this.component.daysOfWeekDisabled || !this.component.daysOfWeekDisabled.includes(value.getDay())) {
-            // Checking if the datesDisabled array exists, and if so checking if it contains the value
-            if (!this.component.datesDisabled || !this.component.datesDisabled.some(d => this.getMidnightDate(d).getTime() === this.getMidnightDate(value).getTime())) {
-              return true;
-            }
-          }
-        }
-      }
+  private validateValue(value?: Date | null | undefined): boolean {
+    if (!value || value === null || isNaN(value.getTime())) {
+      return false;
     }
-    return false;
+
+    const midnightValue = this.getMidnightDate(value).getTime();
+
+    if (this.component.datesDisabled && this.component.datesDisabled.some(d => this.getMidnightDate(d).getTime() === midnightValue)) {
+      return false;
+    }
+
+    if (this.component.daysOfWeekDisabled && this.component.daysOfWeekDisabled.includes(value.getDay())) {
+      return false;
+    }
+
+    if (this.component.maxDate && midnightValue > this.getMidnightDate(this.component.maxDate).getTime()) {
+      return false;
+    }
+
+    if (this.component.minDate && midnightValue < this.getMidnightDate(this.component.minDate).getTime()) {
+      return false;
+    }
+
+    return true;
   }
 }
 

--- a/packages/components/datepicker/src/components/osds-datepicker/interfaces/attributes.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/interfaces/attributes.ts
@@ -1,4 +1,5 @@
 import type { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+import type { ODS_DATEPICKER_DAY } from '../constants/datepicker-day';
 
 interface OdsDatepickerAttribute {
   /**
@@ -9,6 +10,14 @@ interface OdsDatepickerAttribute {
    * Defines the Datepicker's color (see component principles)
    */
   color?: ODS_THEME_COLOR_INTENT;
+  /**
+   * Defines the Datepicker's disabled dates
+   */
+  datesDisabled?: Date[];
+  /**
+   * Defines the Datepicker's disabled days of the week (monday, tuesday...)
+   */
+  daysOfWeekDisabled?: ODS_DATEPICKER_DAY[];
   /**
    * Defines if the Datepicker should be disabled or not (lower opacity and not interactable)
    */
@@ -25,6 +34,14 @@ interface OdsDatepickerAttribute {
    * Defines if the Datepicker should be displayed inline or not
    */
   inline?: boolean;
+  /**
+   * Defines the Datepicker's maximum selectable date
+   */
+  maxDate?: Date | undefined | null;
+  /**
+   * Defines the Datepicker's minimum selectable date
+   */
+  minDate?: Date | undefined | null;
   /**
    * Defines if the Datepicker should display a placeholder message
    */

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.screenshot.ts
@@ -4,6 +4,7 @@ import type { OsdsDatepicker } from './osds-datepicker';
 import { newE2EPage } from '@stencil/core/testing';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { ODS_DATEPICKER_DAY } from './constants/datepicker-day';
 
 describe('e2e:osds-datepicker', () => {
   let page: E2EPage;
@@ -22,23 +23,34 @@ describe('e2e:osds-datepicker', () => {
       pickerElement.style.setProperty('animation', 'none');
     });
 
-    if (attributes.value) {
-      const dateStr = attributes.value.toISOString();
-      await page.evaluate((dateStr) => {
-          const datepicker = document.querySelector('osds-datepicker') as unknown as OsdsDatepicker;
-          datepicker.value = new Date(dateStr);
-      }, dateStr);
-    }
+    await page.emulateTimezone('Europe/London');
+
+    await page.evaluate(
+      (datesDisabledJSON, daysOfWeekDisabledJSON, maxDateJSON, minDateJSON, valueJSON) => {
+        const datepicker = document.querySelector('osds-datepicker') as unknown as OsdsDatepicker;
+        datesDisabledJSON && (datepicker.datesDisabled = JSON.parse(datesDisabledJSON).map((str: string) => new Date(str)));
+        daysOfWeekDisabledJSON && (datepicker.daysOfWeekDisabled = JSON.parse(daysOfWeekDisabledJSON));
+        maxDateJSON && (datepicker.maxDate = new Date(JSON.parse(maxDateJSON)));
+        minDateJSON && (datepicker.minDate = new Date(JSON.parse(minDateJSON)));
+        valueJSON && (datepicker.value = new Date(JSON.parse(valueJSON)));
+      },
+      JSON.stringify(attributes.datesDisabled?.map(date => date.toISOString())),
+      JSON.stringify(attributes.daysOfWeekDisabled),
+      JSON.stringify(attributes.maxDate?.toISOString()),
+      JSON.stringify(attributes.minDate?.toISOString()),
+      JSON.stringify(attributes.value?.toISOString()),
+    );
   }
 
   const attributeConfigurations = [
     { name: 'clearable', options: [true, false] },
+    { name: 'daysOfWeekDisabled', options: [[], [ODS_DATEPICKER_DAY.saturday, ODS_DATEPICKER_DAY.sunday]] },
     { name: 'disabled', options: [true, false] },
     { name: 'error', options: [false, true] },
     { name: 'format', options: ['dd/mm/yyyy', 'mm/dd/yyyy'] },
     { name: 'inline', options: [true, false] },
     { name: 'placeholder', options: ['', 'placeholder message'] },
-    { name: 'value', options: ['', new Date('1999-11-02')] },
+    { name: 'value', options: [null, new Date('1999-11-02')] },
   ];
 
   function generateCombinations(attributes: typeof attributeConfigurations): Array<Partial<OdsDatepickerAttribute>> {

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.ts
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.e2e.ts
@@ -1,8 +1,10 @@
 import type { E2EElement, E2EPage } from '@stencil/core/testing';
 import type { OdsDatepickerAttribute } from './interfaces/attributes';
+import type { OsdsDatepicker } from './osds-datepicker';
 import { newE2EPage } from '@stencil/core/testing';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { ODS_DATEPICKER_DAY } from './constants/datepicker-day';
 
 describe('e2e:osds-datepicker', () => {
   let page: E2EPage;
@@ -15,47 +17,97 @@ describe('e2e:osds-datepicker', () => {
     await page.setContent(`<osds-datepicker ${odsStringAttributes2Str(stringAttributes)}></osds-datepicker>`);
     await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
 
+    await page.evaluate(() => {
+      const pickerElement = document.querySelector('osds-datepicker')?.shadowRoot?.querySelector('.datepicker') as HTMLElement;
+      pickerElement.style.setProperty('animation', 'none');
+    });
+
     el = await page.find('osds-datepicker');
+    await page.emulateTimezone('Europe/London');
+
+    await page.evaluate(
+      (datesDisabledJSON, daysOfWeekDisabledJSON, maxDateJSON, minDateJSON, valueJSON) => {
+        const datepicker = document.querySelector('osds-datepicker') as unknown as OsdsDatepicker;
+        datesDisabledJSON && (datepicker.datesDisabled = JSON.parse(datesDisabledJSON).map((str: string) => new Date(str)));
+        daysOfWeekDisabledJSON && (datepicker.daysOfWeekDisabled = JSON.parse(daysOfWeekDisabledJSON));
+        maxDateJSON && (datepicker.maxDate = new Date(JSON.parse(maxDateJSON)));
+        minDateJSON && (datepicker.minDate = new Date(JSON.parse(minDateJSON)));
+        valueJSON && (datepicker.value = new Date(JSON.parse(valueJSON)));
+      },
+      JSON.stringify(attributes.datesDisabled?.map(date => date.toISOString())),
+      JSON.stringify(attributes.daysOfWeekDisabled),
+      JSON.stringify(attributes.maxDate?.toISOString()),
+      JSON.stringify(attributes.minDate?.toISOString()),
+      JSON.stringify(attributes.value?.toISOString()),
+    );
+  }
+
+  async function getDatepickerValue(): Promise<Date | null> {
+    const value = await page.evaluate(() => {
+      const datepicker = document.querySelector('osds-datepicker') as unknown as OsdsDatepicker;
+      return datepicker.value?.toISOString();
+    });
+    return value ? new Date(value) : null;
   }
 
   it('should render', async () => {
     await setup({ attributes: {} });
+    await page.waitForChanges();
     expect(el).not.toBeNull();
     expect(el).toHaveClass('hydrated');
+  });
+
+  it('should render with a value', async () => {
+    const date = new Date('1999-11-02');
+    await setup({ attributes: { value: date } });
+    await page.waitForChanges();
+    expect(el).not.toBeNull();
+    expect(el).toHaveClass('hydrated');
+    const value = await getDatepickerValue();
+    expect(value).toEqual(date);
   });
 
   it('should display a datepicker when focused', async () => {
     await setup({ attributes: {} });
     await el.click();
+    await page.waitForChanges();
     const datepicker = await page.find('osds-datepicker >>> .datepicker');
     expect(datepicker).not.toBeNull();
   });
 
   it('should allow datepicker to be cleared when clearable is true', async () => {
-    await setup({ attributes: { clearable: true, value: new Date('2023-09-11') } });
+    const date = new Date('1999-11-02');
+    await setup({ attributes: { clearable: true, value: date } });
     await el.click();
+    await page.waitForChanges();
+    let value = await getDatepickerValue();
+    expect(value).toEqual(date);
     const clearButton = await page.find('osds-datepicker >>> osds-input >>> osds-icon[name="close"]');
     await clearButton.click();
-    expect(await el.getProperty('value')).toBe(null);
+    await page.waitForChanges();
+    value = await getDatepickerValue();
+    expect(value).toEqual(date);
   });
 
   it('should be disabled when disabled attribute is true', async () => {
     await setup({ attributes: { disabled: true } });
     const datepicker = await page.find('osds-datepicker');
+    await page.waitForChanges();
     expect(datepicker).toHaveAttribute('disabled');
   });
 
   it('should update the value when date is selected from the datepicker', async () => {
     await setup({ attributes: {} });
-    let value = await el.getProperty('value');
+    await page.waitForChanges();
+    let value = await getDatepickerValue();
     expect(value).toBe(null);
     await el.click();
     await page.waitForChanges();
     const dateButton = await page.find('osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:first-child');
     await dateButton.click();
     await page.waitForChanges();
-    value = await el.getProperty('value');
-    expect(value).not.toBe(null);
+    value = await getDatepickerValue();
+    expect(value).toBeInstanceOf(Date);
   });
 
   it('should format date according to format attribute', async () => {
@@ -118,5 +170,75 @@ describe('e2e:osds-datepicker', () => {
     await page.waitForChanges();
     const decadeGrid = await page.find('osds-datepicker >>> .datepicker .decades');
     expect(decadeGrid).toBeNull();
+  });
+
+  it('should disable the desired days of the week', async () => {
+    await setup({ attributes: { daysOfWeekDisabled: [ODS_DATEPICKER_DAY.saturday, ODS_DATEPICKER_DAY.sunday] } });
+    await el.click();
+    await page.waitForChanges();
+    let dateButton = await page.find('osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:nth-child(3)');
+    expect(dateButton).not.toHaveClass('disabled');
+    dateButton = await page.find('osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:first-child');
+    expect(dateButton).toHaveClass('disabled');
+  });
+
+  it('should *not* allow to select out of scope date', async () => {
+    const date = new Date('2024-01-15');
+    await setup({ attributes: {
+      datesDisabled: [new Date('2024-01-11'), new Date('2024-01-17')],
+      daysOfWeekDisabled: [ODS_DATEPICKER_DAY.saturday, ODS_DATEPICKER_DAY.sunday],
+      maxDate: new Date('2024-01-25'),
+      minDate: new Date('2024-01-10'),
+      value: date,
+    } });
+    await page.waitForChanges();
+    await el.click();
+    await page.waitForChanges();
+    let value = await getDatepickerValue();
+    expect(value).toEqual(date);
+    const dateButton = await page.find('osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:nth-child(7)');
+    expect(dateButton).toHaveClass('disabled');
+    await dateButton.click();
+    await page.waitForChanges();
+    value = await getDatepickerValue();
+    expect(value).toEqual(date);
+  });
+
+  it('should allow to select inside of scope date', async () => {
+    const date = new Date('2024-01-15');
+    await setup({ attributes: {
+      datesDisabled: [new Date('2024-01-11'), new Date('2024-01-17')],
+      daysOfWeekDisabled: [ODS_DATEPICKER_DAY.saturday, ODS_DATEPICKER_DAY.sunday],
+      maxDate: new Date('2024-01-25'),
+      minDate: new Date('2024-01-10'),
+      value: date,
+    } });
+    await page.waitForChanges();
+    await el.click();
+    await page.waitForChanges();
+    let value = await getDatepickerValue();
+    expect(value).toEqual(date);
+    const dateButton = await page.find('osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:nth-child(17)');
+    expect(dateButton).not.toHaveClass('disabled');
+    await dateButton.click();
+    await page.waitForChanges();
+    value = await getDatepickerValue();
+    expect(value).toEqual(new Date('2024-01-16'));
+  });
+
+  it('should disable dates before the minDate', async () => {
+    await setup({ attributes: { minDate: new Date('2023-05-10'), value: new Date('2023-05-15') } });
+    await el.click();
+    await page.waitForChanges();
+    const beforeMinDateButton = await page.find(`osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:first-child`);
+    expect(beforeMinDateButton).toHaveClass('disabled');
+  });
+
+  it('should disable dates after the maxDate', async () => {
+    await setup({ attributes: { maxDate: new Date('2023-05-20'), value: new Date('2023-05-15') } });
+    await el.click();
+    await page.waitForChanges();
+    const afterMaxDateButton = await page.find(`osds-datepicker >>> .datepicker .datepicker-grid .datepicker-cell:last-child`);
+    expect(afterMaxDateButton).toHaveClass('disabled');
   });
 });

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.scss
@@ -33,6 +33,7 @@
     position: relative;
     display: none;
     animation: datepicker-appear 0.2s ease-in-out;
+    z-index: 99;
 
     * {
       transition: background-color 0.1s ease-in-out;
@@ -54,6 +55,12 @@
           align-items: center;
           border: none;
           cursor: pointer;
+        }
+
+        .prev-btn[disabled],
+        .next-btn[disabled] {
+          pointer-events: none;
+          opacity: 0.5;
         }
 
         .view-switch {
@@ -91,7 +98,8 @@
               }
 
               .prev,
-              .next {
+              .next,
+              .disabled {
                 opacity: 50%;
               }
             }
@@ -107,6 +115,10 @@
             align-items: center;
             border: none;
             cursor: pointer;
+          }
+
+          .disabled {
+            opacity: 50%;
           }
         }
       }

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -91,21 +91,23 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   @Watch('maxDate')
   @Watch('minDate')
   updateDatepicker() {
-    if (this.datepickerInstance) {
-      this.datepickerInstance.setOptions({
-        datesDisabled: this.datesDisabled
-          ? this.datesDisabled.map(date => Datepicker.formatDate(date, `dd/mm/yyyy`))
-          : undefined,
-        daysOfWeekDisabled: this.daysOfWeekDisabled,
-        format: this.format,
-        maxDate: this.maxDate
-          ? this.maxDate
-          : undefined,
-        minDate: this.minDate
-          ? this.minDate
-          : undefined,
-      });
+    if (!this.datepickerInstance) {
+      return;
     }
+
+    this.datepickerInstance.setOptions({
+      datesDisabled: this.datesDisabled
+        ? this.datesDisabled.map(date => Datepicker.formatDate(date, `dd/mm/yyyy`))
+        : undefined,
+      daysOfWeekDisabled: this.daysOfWeekDisabled,
+      format: this.format,
+      maxDate: this.maxDate
+        ? this.maxDate
+        : undefined,
+      minDate: this.minDate
+        ? this.minDate
+        : undefined,
+    })
   }
 
   emitBlur(): void {

--- a/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
+++ b/packages/components/datepicker/src/components/osds-datepicker/osds-datepicker.tsx
@@ -1,7 +1,8 @@
 import type { EventEmitter } from '@stencil/core';
 import type { OdsDatepickerAttribute } from './interfaces/attributes';
 import type { OdsDatepickerEvent, OdsDatepickerValueChangeEventDetail } from './interfaces/events';
-import { Component, Element, Event, Host, h, Listen, Prop, State } from '@stencil/core';
+import type { ODS_DATEPICKER_DAY } from './constants/datepicker-day';
+import { Component, Element, Event, Host, h, Listen, Prop, State, Watch } from '@stencil/core';
 import { ODS_INPUT_TYPE } from '@ovhcloud/ods-component-input';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
 import { ODS_ICON_NAME } from '@ovhcloud/ods-component-icon';
@@ -33,6 +34,12 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   /** @see OdsDatepickerAttribute.color */
   @Prop({ reflect: true }) color?: ODS_THEME_COLOR_INTENT = DEFAULT_ATTRIBUTE.color;
 
+  /** @see OdsDatepickerAttribute.datesDisabled */
+  @Prop({ reflect: true }) datesDisabled?: Date[] = DEFAULT_ATTRIBUTE.datesDisabled;
+
+  /** @see OdsDatepickerAttribute.daysOfWeekDisabled */
+  @Prop({ reflect: true }) daysOfWeekDisabled?: ODS_DATEPICKER_DAY[] = DEFAULT_ATTRIBUTE.daysOfWeekDisabled;
+
   /** @see OdsDatepickerAttribute.disabled */
   @Prop({ reflect: true }) disabled?: boolean = DEFAULT_ATTRIBUTE.disabled;
 
@@ -44,6 +51,12 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
 
   /** @see OdsDatepickerAttribute.inline */
   @Prop({ reflect: true }) inline?: boolean = DEFAULT_ATTRIBUTE.inline;
+
+  /** @see OdsDatepickerAttribute.maxDate */
+  @Prop({ reflect: true }) maxDate?: Date | null = DEFAULT_ATTRIBUTE.maxDate;
+
+  /** @see OdsDatepickerAttribute.minDate */
+  @Prop({ reflect: true }) minDate?: Date | null = DEFAULT_ATTRIBUTE.minDate;
 
   /** @see OdsDatepickerAttribute.placeholder */
   @Prop({ reflect: true }) placeholder?: string = DEFAULT_ATTRIBUTE.placeholder;
@@ -66,9 +79,32 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
   @Listen('odsValueChange')
   handleInputValueChange(event: CustomEvent) {
     if (this.format && event.detail.value.length === this.format.length) {
-      this.onChange(new Date(Datepicker.parseDate(event.detail.value, this.format)))
+      this.onChange(new Date(Datepicker.parseDate(event.detail.value, this.format)));
     } else if (event.detail.value.length === 0) {
-      this.onChange(null)
+      this.onChange(null);
+    }
+  }
+
+  @Watch('datesDisabled')
+  @Watch('daysOfWeekDisabled')
+  @Watch('format')
+  @Watch('maxDate')
+  @Watch('minDate')
+  updateDatepicker() {
+    if (this.datepickerInstance) {
+      this.datepickerInstance.setOptions({
+        datesDisabled: this.datesDisabled
+          ? this.datesDisabled.map(date => Datepicker.formatDate(date, `dd/mm/yyyy`))
+          : undefined,
+        daysOfWeekDisabled: this.daysOfWeekDisabled,
+        format: this.format,
+        maxDate: this.maxDate
+          ? this.maxDate
+          : undefined,
+        minDate: this.minDate
+          ? this.minDate
+          : undefined,
+      });
     }
   }
 
@@ -80,7 +116,7 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
     this.odsDatepickerFocus.emit();
   }
 
-  emitValueChange(newValue: Date | undefined | null, oldValue?: Date | undefined | null): void {
+  emitDatepickerValueChange(newValue: Date | undefined | null, oldValue?: Date | undefined | null): void {
     this.odsDatepickerValueChange.emit({ value: newValue, oldValue: oldValue });
   }
 
@@ -103,10 +139,20 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
 
     if (this.hiddenInput && !this.hiddenInput.getAttribute('initialized')) {
       this.datepickerInstance = new Datepicker(this.hiddenInput, {
+        datesDisabled: this.datesDisabled
+          ? this.datesDisabled.map(date => Datepicker.formatDate(date, `dd/mm/yyyy`))
+          : undefined,
+        daysOfWeekDisabled: this.daysOfWeekDisabled,
         format: this.format,
+        maxDate: this.maxDate
+          ? this.maxDate
+          : undefined,
+        maxView: 2,
+        minDate: this.minDate
+          ? this.minDate
+          : undefined,
         nextArrow: `<osds-icon name="triangle-right" size="sm" color=${this.color}></osds-icon>`,
         prevArrow: `<osds-icon name="triangle-left" size="sm" color=${this.color}></osds-icon>`,
-        maxView: 2,
       });
 
       this.datepickerElement = this.el.shadowRoot.querySelector('.datepicker-picker') as HTMLElement;
@@ -218,7 +264,11 @@ export class OsdsDatepicker implements OdsDatepickerAttribute, OdsDatepickerEven
           type={ODS_INPUT_TYPE.text}
           value={this.formatDate(value)}
         ></osds-input>
-        <input tabindex={-1} class="osds-datepicker__hidden-input" ref={(el?: HTMLInputElement) => this.hiddenInput = el || this.hiddenInput}></input>
+        <input
+          tabindex={-1}
+          class="osds-datepicker__hidden-input"
+          ref={(el?: HTMLInputElement) => this.hiddenInput = el || this.hiddenInput}
+        ></input>
       </Host>
     );
   }

--- a/packages/components/datepicker/src/index.html
+++ b/packages/components/datepicker/src/index.html
@@ -30,6 +30,7 @@
   document.addEventListener("DOMContentLoaded", () => {
     const datepicker = document.querySelector('#datepicker1');
     datepicker.value = new Date('2024-01-15');
+    datepicker.maxDate = new Date('2024-01-20');
 
     setTimeout(() => {
       console.log(datepicker.value)

--- a/packages/components/datepicker/src/index.html
+++ b/packages/components/datepicker/src/index.html
@@ -15,14 +15,25 @@
 </head>
 <body>
 
-<osds-datepicker placeholder="dd/mm/yyyy" clearable></osds-datepicker>
-
-<p>Hello</p>
+<osds-datepicker placeholder="dd/mm/yyyy" clearable id="datepicker1"></osds-datepicker>
+<div style="width:100%; height: 50px; background: rgb(220, 220, 220); margin: 20px 0;"></div>
+<osds-datepicker format="yyyy-mm-dd" placeholder="yyyy-mm-dd" clearable inline color="success"></osds-datepicker>
+<div style="width:100%; height: 50px; background: rgb(220, 220, 220); margin: 20px 0;"></div>
+<osds-datepicker placeholder="dd/mm/yyyy" inline></osds-datepicker>
+<div style="width:100%; height: 50px; background: rgb(220, 220, 220); margin: 20px 0;"></div>
+<osds-datepicker placeholder="dd/mm/yyyy"></osds-datepicker>
+<div style="width:100%; height: 50px; background: rgb(220, 220, 220); margin: 20px 0;"></div>
+<osds-datepicker placeholder="dd/mm/yyyy" disabled clearable inline></osds-datepicker>
+<div style="width:100%; height: 50px; background: rgb(220, 220, 220); margin: 20px 0;"></div>
 
 <script>
-  const datepicker = document.querySelector('osds-datepicker');
   document.addEventListener("DOMContentLoaded", () => {
-    datepicker.value = new Date('1999-11-02');
+    const datepicker = document.querySelector('#datepicker1');
+    datepicker.value = new Date('2024-01-15');
+
+    setTimeout(() => {
+      console.log(datepicker.value)
+    }, 500);
   });
 </script>
 </body>

--- a/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
+++ b/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
@@ -47,12 +47,14 @@ const storyParams = {
   maxDate: {
     category: 'General',
     defaultValue: null,
-    options: [null, new Date('1999-11-02'), new Date('2024-11-02')],
+    options: ['1999-11-02', '2024-01-01'],
+    control: { type: 'select' },
   },
   minDate: {
     category: 'General',
     defaultValue: null,
-    options: [null, new Date('1999-11-02'), new Date('2024-11-02')],
+    options: ['1999-11-02', '2024-01-01'],
+    control: { type: 'select' },
   },
   placeholder: {
     category: 'General',
@@ -76,8 +78,16 @@ export default {
 };
 
 /* Default */
+const isDateConstructorArg = (value: unknown): value is string | number | Date => {
+  return typeof value === "string" || typeof value === "number" || value instanceof Date;
+};
+
 const OsdsDatepickerDefault = (args: Record<string, unknown>) => html`
-  <osds-datepicker ...=${getTagAttributes(args)}>
+  <osds-datepicker ...=${getTagAttributes({
+    ...args,
+    maxDate: isDateConstructorArg(args.maxDate) ? new Date(args.maxDate) : null,
+    minDate: isDateConstructorArg(args.minDate) ? new Date(args.minDate) : null
+  })}>
   </osds-datepicker>
 `;
 const TemplateDefault = (args: Record<string, unknown>) => OsdsDatepickerDefault(args);

--- a/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
+++ b/packages/storybook/stories/components/datepicker/datepicker.web-components.stories.ts
@@ -2,6 +2,7 @@ import { html } from 'lit-html';
 import { defineCustomElements } from '@ovhcloud/ods-components/datepicker/loader';
 import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
 import { DEFAULT_ATTRIBUTE } from '@ovhcloud/ods-components/datepicker/src/components/osds-datepicker/constants/default-attributes';
+import { ODS_DATEPICKER_DAYS } from '@ovhcloud/ods-components/datepicker/src/components/osds-datepicker/constants/datepicker-day';
 import { ODS_THEME_COLOR_INTENTS } from '@ovhcloud/ods-common-theming';
 // @ts-ignore
 import changelog from '@ovhcloud/ods-components/datepicker/CHANGELOG.md';
@@ -22,6 +23,11 @@ const storyParams = {
     options: ODS_THEME_COLOR_INTENTS,
     control: { type: 'select' },
   },
+  daysOfWeekDisabled: {
+    category: 'General',
+    defaultValue: [],
+    options: ODS_DATEPICKER_DAYS,
+  },
   disabled: {
     category: 'General',
     defaultValue: false,
@@ -37,6 +43,16 @@ const storyParams = {
   inline: {
     category: 'General',
     defaultValue: false,
+  },
+  maxDate: {
+    category: 'General',
+    defaultValue: null,
+    options: [null, new Date('1999-11-02'), new Date('2024-11-02')],
+  },
+  minDate: {
+    category: 'General',
+    defaultValue: null,
+    options: [null, new Date('1999-11-02'), new Date('2024-11-02')],
   },
   placeholder: {
     category: 'General',


### PR DESCRIPTION
Adding options to disable specific dates of the Datepicker.

New enum: 
`ODS_DATEPICKER_DAY`: monday = 1, saturday = 6, etc.

New attributes:
> datesDisabled?: Date[] (specific dates to disable)
> daysOfWeekDisabled?: ODS_DATEPICKER_DAY[] (ex: monday, sunday disabled for all dates)
> maxDate?: Date (maximum date selectable)
> minDate?: Date (minimum date selectable)