### PR TITLE
fix(select): change label on slot change

### DIFF
--- a/packages/components/select/src/components/osds-select-option/osds-select-option.tsx
+++ b/packages/components/select/src/components/osds-select-option/osds-select-option.tsx
@@ -4,8 +4,7 @@ import type { OdsSelectOptionAttribute } from './interfaces/attributes';
 import type { OdsSelectOptionEvent, OdsSelectOptionClickEventDetail } from './interfaces/events';
 import type { OdsSelectOptionMethod } from './interfaces/methods';
 import type { OsdsSelect } from '../osds-select/osds-select';
-import { Component, Element, Event, EventEmitter, Host, Method, Prop, State, Watch, h } from '@stencil/core';
-import { OdsLogger } from '@ovhcloud/ods-common-core';
+import { Component, Element, Event, EventEmitter, Host, Method, Prop, State, h } from '@stencil/core';
 import { DEFAULT_ATTRIBUTE as SELECT_DEFAULT_ATTRIBUTE } from '../osds-select/constants/default-attributes';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
@@ -18,7 +17,6 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
   shadow: true,
 })
 export class OsdsSelectOption implements OdsSelectOptionAttribute, OdsSelectOptionEvent, OdsSelectOptionMethod {
-  private logger = new OdsLogger('OsdsSelectOption');
   private selectParent: (HTMLStencilElement & OsdsSelect) | null = null;
 
   @Element() el!: HTMLStencilElement;
@@ -73,23 +71,12 @@ export class OsdsSelectOption implements OdsSelectOptionAttribute, OdsSelectOpti
     return this.el.innerText;
   }
 
-  @Watch('value')
-  watchValue(value: OdsInputValue) {
-    this.logger.log(`[select=${this.value}]`, 'value changed', { value });
-  }
-
-  @Watch('selected')
-  updateSelectGroupValue(selected: boolean) {
-    this.logger.log(`[select=${this.value}]`, 'selected changed.', { selected });
-  }
-
   emitClick(value: OdsInputValue) {
     this.odsSelectOptionClick.emit({ value });
   }
 
   handleClick(event: MouseEvent) {
     event.stopPropagation();
-    this.logger.log(`[select=${this.value}]`, 'option clicked.');
     this.emitClick(this.value);
   }
 

--- a/packages/components/select/src/components/osds-select/osds-select.e2e.ts
+++ b/packages/components/select/src/components/osds-select/osds-select.e2e.ts
@@ -88,6 +88,20 @@ describe('e2e:osds-select', () => {
 
       expect(selectedLabel).toBe(null);
     });
+
+    it('should change the selected value text', async () => {
+      await setup({ attributes: { value: '42' } });
+      await page.waitForChanges();
+
+      const options = await page.findAll('osds-select > osds-select-option');
+      options.forEach((option) => {
+        option.innerHTML = `NewValue${option.getAttribute('value')}`
+      });
+      await page.waitForChanges();
+
+      const label = await page.find('osds-select >>> .select-trigger__label');
+      expect(label.innerText.trim()).toBe('NewValue42');
+    });
   });
 
     // TODO getValidity

--- a/packages/components/select/src/components/osds-select/osds-select.spec.ts
+++ b/packages/components/select/src/components/osds-select/osds-select.spec.ts
@@ -9,6 +9,17 @@ import { DEFAULT_VALIDITY_STATE } from './constants/default-validity-state';
 import { ODS_SELECT_SIZE } from './constants/select-size';
 import { OsdsSelect } from './osds-select';
 
+const mutationObserverMock = jest.fn(function MutationObserver(callback) {
+  this.observe = jest.fn();
+  this.disconnect = jest.fn();
+  // Optionally add a trigger() method to manually trigger a change
+  this.trigger = (mockedMutationsList) => {
+      callback(mockedMutationsList, this);
+  };
+});
+// @ts-ignore
+global.MutationObserver = mutationObserverMock;
+
 const logger = new OdsLogger('osds-select-spec');
 
 // mock validity property that does not exist when stencil mock HTMLInputElement

--- a/packages/components/select/src/components/osds-select/osds-select.tsx
+++ b/packages/components/select/src/components/osds-select/osds-select.tsx
@@ -120,6 +120,8 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
   async componentDidLoad() {
     this.setSelectOptions();
     await this.updateSelectOptionStates(this.value);
+    this.observer = new MutationObserver(async () => this.selectedOptionLabel = await this.optionSelected?.getLabel() || '');
+    this.observer?.observe(this.controller.selectOptions[0], { childList: true });
   }
 
   @Watch('opened')
@@ -282,8 +284,6 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
 
   setSelectOptions() {
     this.controller.selectOptions = this.getSelectOptionList();
-    this.observer = new MutationObserver(async() => await this.updateSelectOptionStates(this.value));
-    this.controller.selectOptions.forEach((option) => this.observer?.observe(option, { childList: true }))
   }
 
   getSelectOptionList(): (HTMLElement & OsdsSelectOption)[] {

--- a/packages/components/select/src/components/osds-select/osds-select.tsx
+++ b/packages/components/select/src/components/osds-select/osds-select.tsx
@@ -121,6 +121,9 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
     this.setSelectOptions();
     await this.updateSelectOptionStates(this.value);
     this.observer = new MutationObserver(async () => this.selectedOptionLabel = await this.optionSelected?.getLabel() || '');
+    if (!this.controller.selectOptions[0]) {
+      return;
+    }
     this.observer?.observe(this.controller.selectOptions[0], { childList: true });
   }
 

--- a/packages/components/select/src/components/osds-select/osds-select.tsx
+++ b/packages/components/select/src/components/osds-select/osds-select.tsx
@@ -33,7 +33,7 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
   /** is the select was touched by the user */
   dirty = false;
   selectedLabelSlot: HTMLElement | null = null;
-  observer?: MutationObserver = undefined;
+  observer?: MutationObserver;
 
   @Element() el!: HTMLStencilElement;
 
@@ -118,13 +118,9 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
    * in order to synchronize the already set value with the placeholder
    */
   async componentDidLoad() {
+    this.observer = new MutationObserver(async () => this.selectedOptionLabel = await this.optionSelected?.getLabel() || '');
     this.setSelectOptions();
     await this.updateSelectOptionStates(this.value);
-    this.observer = new MutationObserver(async () => this.selectedOptionLabel = await this.optionSelected?.getLabel() || '');
-    if (!this.controller.selectOptions[0]) {
-      return;
-    }
-    this.observer?.observe(this.controller.selectOptions[0], { childList: true });
   }
 
   @Watch('opened')
@@ -287,6 +283,7 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
 
   setSelectOptions() {
     this.controller.selectOptions = this.getSelectOptionList();
+    this.controller.selectOptions.forEach((option) => this.observer?.observe(option, { childList: true }))
   }
 
   getSelectOptionList(): (HTMLElement & OsdsSelectOption)[] {

--- a/packages/components/select/src/global.dev.ts
+++ b/packages/components/select/src/global.dev.ts
@@ -96,6 +96,11 @@ Object.keys(examples).forEach(k => {
   // todo
   // examples.select1.component && (examples.select1.component.opened = !examples.select1.component.opened);
   // evt.stopPropagation()
+  const options = document.querySelectorAll('#select1 > osds-select-option');
+  options.forEach((option) => {
+    option.innerHTML = `NewValue${option.getAttribute('value')}`;
+  });
+  // const select = document.querySelector('#select1');
 };
 
 (window as any).select6Clear = function () {


### PR DESCRIPTION
Fix: select-option content change but the label of a selected value don't change.
- no fix with the slot `selectedLabel` because it's up to the client to change the slot
- event `onSlotChange` don't work when just the text change