### PR TITLE
fix(modal): trigger inert at modal open and fix e2e test

### DIFF
--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -185,12 +185,12 @@ describe('e2e:osds-modal', () => {
 
       el = await page.find('osds-modal');
       outsideButton = await page.find('#outsideButton');
-
-      await page.waitForChanges();
     });
 
-    // FIXME
-    xit('should have inert attribute on outsideButton when modal is active', () => {
+    it('should have inert attribute on outsideButton when modal is active', async () => {
+      await el.callMethod('open');
+      await page.waitForChanges();
+
       const inert = outsideButton.getAttribute('inert');
       expect(inert).not.toBeNull();
     });

--- a/packages/components/modal/src/components/osds-modal/osds-modal.tsx
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.tsx
@@ -43,7 +43,6 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod {
   @Method()
   async open(): Promise<void> {
     this.masked = false;
-    this.inertBodyChildren(this.masked);
   }
 
   @Watch('masked')
@@ -51,13 +50,13 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod {
     this.inertBodyChildren(masked);
   }
 
-  inertBodyChildren(masked: boolean = false) {
+  inertBodyChildren(masked = false) {
     const directChildren = Array.from(document.body.children);
     for (const child of directChildren) {
       if (child !== this.el && child.nodeName !== 'SCRIPT') {
-        if (!masked && !child.getAttribute('inert')) {
+        if (!masked) {
           child.setAttribute('inert', '');
-        } else if (child.getAttribute('inert')) {
+        } else {
           child.removeAttribute('inert');
         }
       }
@@ -66,6 +65,7 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod {
 
   componentWillLoad(): void {
     document.body.appendChild(this.el);
+    this.watchOpenedStateHandler(this.masked ?? false);
   }
 
   render() {

--- a/packages/components/modal/src/components/osds-modal/osds-modal.tsx
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.tsx
@@ -43,16 +43,21 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod {
   @Method()
   async open(): Promise<void> {
     this.masked = false;
+    this.inertBodyChildren(this.masked);
   }
 
   @Watch('masked')
   watchOpenedStateHandler(masked: boolean) {
+    this.inertBodyChildren(masked);
+  }
+
+  inertBodyChildren(masked: boolean = false) {
     const directChildren = Array.from(document.body.children);
     for (const child of directChildren) {
       if (child !== this.el && child.nodeName !== 'SCRIPT') {
-        if (!masked) {
+        if (!masked && !child.getAttribute('inert')) {
           child.setAttribute('inert', '');
-        } else {
+        } else if (child.getAttribute('inert')) {
           child.removeAttribute('inert');
         }
       }


### PR DESCRIPTION
Fixed end-to-end tests for modal component:

- trigger inert at modal open (masked is false on component create and masked is also false on open, so it did not trigger the inert watcher)
- fix e2e test by adding open to the test for inert attribute