### PR TITLE
fix(popover): remove useless code in lifecycle

### DIFF
--- a/packages/components/popover/src/components/osds-popover/core/controller.ts
+++ b/packages/components/popover/src/components/osds-popover/core/controller.ts
@@ -1,27 +1,16 @@
 import type { OsdsPopover } from '../osds-popover';
-import { OdsLogger } from '@ovhcloud/ods-common-core';
 
 class OdsPopoverController {
   private component: OsdsPopover;
-  private readonly logger = new OdsLogger('OdsPopoverController');
 
   constructor(component: OsdsPopover) {
     this.component = component
   }
 
   /**
-   * Attributes validation documentation
-   */
-  validateAttributes(): void {
-      return;
-  }
-
-  /**
    * Handle click event on Trigger
    */
   handleTriggerClick(): void {
-    this.logger.log('Click on trigger');
-
     if (!this.component.surface) {
       return;
     }
@@ -33,8 +22,6 @@ class OdsPopoverController {
    */
   handleTriggerKey(event: KeyboardEvent): void {
     if((event.key === " " || event.key === "Enter")) {
-      this.logger.log('Key on trigger');
-
       if (!this.component.surface) {
         return;
       }
@@ -42,7 +29,6 @@ class OdsPopoverController {
     }
 
     if(event.key === "Escape") {
-      this.logger.log('EscapeKey on trigger');
       this.closeSurface();
     }
   }
@@ -52,7 +38,6 @@ class OdsPopoverController {
    */
   handleSurfaceKey(event: KeyboardEvent): void {
     if (event.key === "Escape") {
-      this.logger.log('EscapeKey in surface');
       this.closeSurface();
     }
   }
@@ -64,7 +49,6 @@ class OdsPopoverController {
     if (this.component.el.contains(event.target) || this.component.surface === undefined || !this.component.surface.opened) {
       return;
     } else {
-      this.logger.log('Click outside component while it is opened');
       this.closeSurface();
     }
   }

--- a/packages/components/popover/src/components/osds-popover/osds-popover.tsx
+++ b/packages/components/popover/src/components/osds-popover/osds-popover.tsx
@@ -15,9 +15,8 @@ ocdkDefineCustomElements();
   shadow: true
 })
 export class OsdsPopover implements OdsPopoverMethod {
-  controller: OdsPopoverController = new OdsPopoverController(this);
-  title: HTMLElement | null = null;
   anchor!: HTMLDivElement;
+  controller: OdsPopoverController = new OdsPopoverController(this);
   surface: OcdkSurface | undefined = undefined;
 
   @Element() el!: HTMLStencilElement;
@@ -34,10 +33,6 @@ export class OsdsPopover implements OdsPopoverMethod {
   @Method()
   async closeSurface() {
     this.controller.closeSurface();
-  }
-
-  componentDidRender() {
-    this.title = this.el.querySelector('[slot=popover-trigger]');
   }
 
   handleTriggerClick() {


### PR DESCRIPTION
Popover does not work on a React App.
Removing the lifecycle code (which is useless btw) fixes the issue.