### PR TITLE
fix(menu): replace initialized element with getter

### DIFF
--- a/packages/components/menu/src/components/osds-menu/core/controller.spec.ts
+++ b/packages/components/menu/src/components/osds-menu/core/controller.spec.ts
@@ -43,9 +43,9 @@ describe('spec:ods-menu-controller', () => {
   }
 
   beforeEach(() => {
-    item1 = document.createElement('osds-menu-item') as OdsMenuItem & HTMLElement;
+    item1 = document.createElement('osds-menu-item') as OsdsMenuItem & HTMLElement;
     item1.innerHTML = `<osds-button><span slot="start">Action 1</span></osds-button>`;
-    item2 = document.createElement('osds-menu-item') as OdsMenuItem & HTMLElement;
+    item2 = document.createElement('osds-menu-item') as OsdsMenuItem & HTMLElement;
     item2.innerHTML = `<osds-button><span slot="start">Action 2</span></osds-button>`;
 
     const loggerMocked = new OdsLogger('myLoggerMocked');

--- a/packages/components/menu/src/components/osds-menu/osds-menu.tsx
+++ b/packages/components/menu/src/components/osds-menu/osds-menu.tsx
@@ -1,10 +1,10 @@
-import type { OdsMenuAttribute } from './interfaces/attributes';
 import type { HTMLStencilElement } from '@stencil/core/internal';
-import { Component, Prop, h, Host, Watch, Element, Listen, State } from '@stencil/core';
-import { OdsMenuController } from './core/controller';
-import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
-import { OsdsMenuItem } from '../osds-menu-item/osds-menu-item'
+import type { OdsMenuAttribute } from './interfaces/attributes';
+import type { OsdsMenuItem } from '../osds-menu-item/osds-menu-item';
 import { ocdkDefineCustomElements, ocdkIsSurface, OcdkSurface, } from '@ovhcloud/ods-cdk';
+import { Component, Listen, Prop, h, Host, Element, Watch } from '@stencil/core';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { OdsMenuController } from './core/controller';
 
 ocdkDefineCustomElements();
 
@@ -14,16 +14,22 @@ ocdkDefineCustomElements();
   shadow: true,
 })
 export class OsdsMenu implements OdsMenuAttribute {
-  controller: OdsMenuController = new OdsMenuController(this);
-  title: HTMLElement | null = null;
   anchor!: HTMLDivElement;
+  controller: OdsMenuController = new OdsMenuController(this);
   surface: OcdkSurface | undefined = undefined;
 
   @Element() el!: HTMLStencilElement;
 
-  @Prop({ reflect: true }) public disabled: boolean | undefined = DEFAULT_ATTRIBUTE.disabled;
+  @Prop({ reflect: true }) public disabled?: boolean = DEFAULT_ATTRIBUTE.disabled;
 
-  @State() tabindex = 0;
+  get title(): HTMLElement | null {
+    return this.el.querySelector('[slot=menu-title]')
+  }
+
+  componentDidLoad() {
+    this.setMenuItemsButtons();
+    this.controller.afterInit();
+  }
 
   @Watch('disabled')
   propagateDisabledToChild(disabled: boolean | undefined): void {
@@ -35,60 +41,47 @@ export class OsdsMenu implements OdsMenuAttribute {
     this.controller.checkForClickOutside(event);
   }
 
+  getMenuItemButtonList(): (HTMLElement & OsdsMenuItem)[] {
+    return Array.from(this.el.querySelectorAll<OsdsMenuItem & HTMLElement>('osds-menu-item > osds-button'));
+  }
+
   handleKeyDown(event: KeyboardEvent): void {
     event.stopPropagation();
     this.controller.handleKeyDown(event);
-  }
-
-  componentDidRender() {
-    this.title = this.el.querySelector('[slot=menu-title]');
   }
 
   handleTriggerClick() {
     this.controller.handleTriggerClick();
   }
 
-  syncReferences() {
-    this.controller.syncReferences()
-  }
-
-  afterInit() {
-    this.controller.afterInit();
-  }
-
-  async componentDidLoad() {
-    this.setMenuItemsButtons();
-    this.afterInit();
-  }
-
   setMenuItemsButtons() {
     this.controller.menuItems = this.getMenuItemButtonList();
   }
 
-  getMenuItemButtonList(): (HTMLElement & OsdsMenuItem)[] {
-    return Array.from(this.el.querySelectorAll<OsdsMenuItem & HTMLElement>('osds-menu-item > osds-button'));
+  syncReferences() {
+    this.controller.syncReferences()
   }
 
   render() {
     return (
       <Host>
         <div class="trigger"
-             onClick={this.handleTriggerClick.bind(this)}
-             onKeyDown={this.handleKeyDown.bind(this)}
-             ref={(el?: HTMLElement | null) => {
+             onClick={ this.handleTriggerClick.bind(this) }
+             onKeyDown={ this.handleKeyDown.bind(this) }
+             ref={ (el?: HTMLElement | null) => {
                this.anchor = el as HTMLDivElement;
                this.syncReferences()
              }}>
           <slot name={'menu-title'} />
         </div>
-        <ocdk-surface
-          onKeyDown={this.handleKeyDown.bind(this)}
-          ref={(el: HTMLElement) => {
-            if (ocdkIsSurface(el)) {
-              this.surface = el as OcdkSurface;
-              this.syncReferences()
-            }
-          }}>
+
+        <ocdk-surface onKeyDown={ this.handleKeyDown.bind(this) }
+                      ref={ (el: HTMLElement) => {
+                        if (ocdkIsSurface(el)) {
+                          this.surface = el as OcdkSurface;
+                          this.syncReferences()
+                        }
+                      }}>
           <slot/>
         </ocdk-surface>
       </Host>


### PR DESCRIPTION
A bit of cleaning and reordering, but the main issue was from:
```
  title: HTMLElement | null = null;
```
which was causing React component to fail due to unallowed DOM operation. Seems like the `= null` initializer is causing the issue.
I've replaced it with a dynamic getter as the previous code was causing other issues.