### PR TITLE
fix(flag): fixing display on Safari browser by adding default width and height

### DIFF
--- a/packages/components/flag/src/components/osds-flag/osds-flag.scss
+++ b/packages/components/flag/src/components/osds-flag/osds-flag.scss
@@ -7,11 +7,11 @@
 .flag {
   &__svg {
     display: flex;
+    width: 100%;
+    height: 100%;
 
     &--default {
       background: var(--ods-color-gray-200);
-      width: 100%;
-      height: 100%;
     }
   }
 }


### PR DESCRIPTION
📐 Fixing display on Safari browser by adding default width and height