### PR TITLE
refactor(flag): fix ts lint issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,11 +16,13 @@
     "**/packages/components/**/loader",
     "**/packages/components/**/react",
     "**/packages/components/**/vue",
-    "**/packages/components/**/www"
+    "**/packages/components/**/www",
+    "**/*.d.ts"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,
+    "project": ["tsconfig.json", "tsconfig.test.json"],
     "sourceType": "module"
   },
   "plugins": [
@@ -33,6 +35,8 @@
   "rules": {
     "@typescript-eslint/ban-types": "error",
     "@typescript-eslint/consistent-indexed-object-style": "error",
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "h" }],
@@ -63,7 +67,7 @@
           "index", // <- index imports
           "unknown" // <- unknown
         ],
-        "newlines-between": "always",
+        "newlines-between": "never",
         "alphabetize": {
           /* sort in ascending order. Options: ["ignore", "asc", "desc"] */
           "order": "asc",
@@ -75,15 +79,15 @@
     "indent": ["error", 2],
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-depth": ["error", {"max": 4}],
-    "max-len": ["error", { "code": 200 }],
+    "max-len": ["error", { "code": 300 }],
     "max-params": ["error", 4],
     "newline-per-chained-call": "off",
     "no-array-constructor": "error",
     "no-await-in-loop": "error",
     "no-console": "error",
     "no-extra-bind": "error",
-    "no-magic-numbers": "error",
     "no-multi-spaces": "error",
+    "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-nested-ternary": "error",
     "no-trailing-spaces": "error",
     "object-curly-spacing": ["error", "always"],
@@ -97,7 +101,7 @@
         "ignoreDeclarationSort": true,
         "ignoreMemberSort": false,
         "memberSyntaxSortOrder": ["none", "all", "multiple", "single"],
-        "allowSeparatedGroups": true
+        "allowSeparatedGroups": false
       }
     ],
     "sort-keys": ["error", "asc"],

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -23,7 +23,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/breadcrumb/package.json
+++ b/packages/components/breadcrumb/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/cart/package.json
+++ b/packages/components/cart/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/checkbox-button/package.json
+++ b/packages/components/checkbox-button/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/chip/package.json
+++ b/packages/components/chip/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/clipboard/package.json
+++ b/packages/components/clipboard/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/code/package.json
+++ b/packages/components/code/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/content-addon/package.json
+++ b/packages/components/content-addon/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/flag/package.json
+++ b/packages/components/flag/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/flag/src/components/osds-flag/constants/default-attributes.ts
+++ b/packages/components/flag/src/components/osds-flag/constants/default-attributes.ts
@@ -1,5 +1,4 @@
 import type { OdsFlagAttribute } from '../interfaces/attributes';
-
 import { ODS_FLAG_ISO_CODE } from './flag-iso-code';
 
 const DEFAULT_ATTRIBUTE: OdsFlagAttribute = Object.freeze({

--- a/packages/components/flag/src/components/osds-flag/constants/flag-iso-code.ts
+++ b/packages/components/flag/src/components/osds-flag/constants/flag-iso-code.ts
@@ -11,8 +11,8 @@ type ODS_FLAG_ISO_CODE_UNION = typeof ODS_FLAG_ISO_CODE[keyof typeof ODS_FLAG_IS
 
 const ODS_FLAG_ISO_CODES = Object.freeze(Object.values(ODS_FLAG_ISO_CODE).sort());
 
+export type { ODS_FLAG_ISO_CODE_UNION };
 export {
   ODS_FLAG_ISO_CODE,
   ODS_FLAG_ISO_CODES,
-  ODS_FLAG_ISO_CODE_UNION,
 };

--- a/packages/components/flag/src/components/osds-flag/core/controller.spec.ts
+++ b/packages/components/flag/src/components/osds-flag/core/controller.spec.ts
@@ -5,17 +5,16 @@ const mockWaitUntilVisible = jest.fn();
 
 jest.mock('@ovhcloud/ods-common-core', () => ({
   ...jest.requireActual('@ovhcloud/ods-common-core'),
-  odsGetAssetPath: jest.fn(),
-  odsGetSrc: mockOdsGetSrc,
   OdsLoadContent: jest.fn().mockImplementation(() => ({
-    onDestroy: mockOnDestroy,
     load: mockLoad,
+    onDestroy: mockOnDestroy,
     waitUntilVisible: mockWaitUntilVisible,
   })),
+  odsGetAssetPath: jest.fn(),
+  odsGetSrc: mockOdsGetSrc,
 }));
 
 import type { OdsLoggerSpyReferences } from '@ovhcloud/ods-common-testing';
-
 import {
   Ods,
   OdsLogger,
@@ -23,7 +22,6 @@ import {
   odsGetSrc,
 } from '@ovhcloud/ods-common-core';
 import { OdsClearLoggerSpy, OdsInitializeLoggerSpy } from '@ovhcloud/ods-common-testing';
-
 import { OdsFlagController } from './controller';
 import { ODS_FLAG_ISO_CODE, ODS_FLAG_ISO_CODES } from '../constants/flag-iso-code';
 import { OsdsFlag } from '../osds-flag';
@@ -52,7 +50,7 @@ describe('ods-flag-controller', () => {
 
   Ods.instance().logging(false);
 
-  function setup(attributes: Partial<OsdsFlag> = {}) {
+  function setup(attributes: Partial<OsdsFlag> = {}): void {
     component = new OdsFlagMock(attributes);
     controller = new OdsFlagController(component);
   }
@@ -123,7 +121,7 @@ describe('ods-flag-controller', () => {
         const dummyUrl = 'dummy url';
         setup();
         // @ts-ignore to spy private method
-        spyOnGetUrl = jest.spyOn<any>(controller, 'getUrl').mockReturnValueOnce(dummyUrl);
+        spyOnGetUrl = jest.spyOn<any>(controller, 'getUrl').mockReturnValueOnce(dummyUrl); // eslint-disable-line
 
         controller.load(false, false);
 

--- a/packages/components/flag/src/components/osds-flag/core/controller.ts
+++ b/packages/components/flag/src/components/osds-flag/core/controller.ts
@@ -1,6 +1,5 @@
 import type { ODS_FLAG_ISO_CODE_UNION } from '../constants/flag-iso-code';
 import type { OsdsFlag } from '../osds-flag';
-
 import {
   OdsLoadContent,
   OdsLogger,
@@ -9,15 +8,13 @@ import {
   odsGetSrc,
   odsIsTermInEnum,
 } from '@ovhcloud/ods-common-core';
-
 import { ODS_FLAG_ISO_CODE, ODS_FLAG_ISO_CODES } from '../constants/flag-iso-code';
-
 
 class OdsFlagController {
   private readonly logger = new OdsLogger('OdsFlagController');
   protected component: OsdsFlag;
   private svgLoadContent = new OdsLoadContent([
-    (content) => OdsSvgValidator.validateContent(content),
+    (content): string => OdsSvgValidator.validateContent(content),
   ]);
 
   constructor(component: OsdsFlag) {
@@ -72,7 +69,7 @@ class OdsFlagController {
    * in case of `src` specified on the component, the url is replaced with this one.
    * in the other cases, it gets the url corresponding to the iso code
    */
-  private getUrl() {
+  private getUrl(): string | undefined {
     const url = odsGetSrc(this.component.src);
     if (url) {
       return url;
@@ -91,7 +88,7 @@ class OdsFlagController {
    * @param iso - iso code of the flag
    * @param customPath - optional override path
    */
-  private getUrlForIso(iso: ODS_FLAG_ISO_CODE_UNION, customPath?: string) {
+  private getUrlForIso(iso: ODS_FLAG_ISO_CODE_UNION, customPath?: string): string {
     const path = odsGetAssetPath(`${iso}.svg`, customPath);
     return this.component.getAssetPath(path);
   }

--- a/packages/components/flag/src/components/osds-flag/interfaces/attributes.ts
+++ b/packages/components/flag/src/components/osds-flag/interfaces/attributes.ts
@@ -20,6 +20,6 @@ interface OdsFlagAttribute {
   src?: string;
 }
 
-export {
+export type {
   OdsFlagAttribute,
 };

--- a/packages/components/flag/src/components/osds-flag/osds-flag.e2e.screenshot.ts
+++ b/packages/components/flag/src/components/osds-flag/osds-flag.e2e.screenshot.ts
@@ -1,20 +1,20 @@
 import type { E2EPage } from '@stencil/core/testing';
-
 import { newE2EPage } from '@stencil/core/testing';
-
 import { ODS_FLAG_ISO_CODES } from './constants/flag-iso-code';
+
+const ratio = 3 / 4;
 
 describe('e2e:osds-flag', () => {
   const flagWidth = 64;
-  const flagHeight = flagWidth * (3 / 4);
+  const flagHeight = flagWidth * ratio;
   const isoList = [...ODS_FLAG_ISO_CODES, 'dummyIso'];
   let page: E2EPage;
 
-  async function setup(content: string) {
+  async function setup(content: string): Promise<void> {
     page = await newE2EPage();
 
     await page.setContent(content);
-    await page.setViewport({ width: flagWidth, height: flagHeight * isoList.length });
+    await page.setViewport({ height: flagHeight * isoList.length, width: flagWidth });
     await page.evaluate(() => {
       document.body.style.setProperty('margin', '0px');
     });

--- a/packages/components/flag/src/components/osds-flag/osds-flag.e2e.ts
+++ b/packages/components/flag/src/components/osds-flag/osds-flag.e2e.ts
@@ -2,16 +2,12 @@ import type { ODS_FLAG_ISO_CODE_UNION } from './constants/flag-iso-code';
 import type { OdsFlagAttribute } from './interfaces/attributes';
 import type { E2EElement, E2EPage } from '@stencil/core/testing';
 import type { HTTPRequest as pRequest } from 'puppeteer';
-
 import { odsSetE2eInterceptRequest } from '@ovhcloud/ods-common-stencil';
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { Build } from '@stencil/core';
 import { newE2EPage } from '@stencil/core/testing';
-
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_FLAG_ISO_CODE } from './constants/flag-iso-code';
-
 
 describe('e2e:osds-flag', () => {
   const baseAttribute = { iso: ODS_FLAG_ISO_CODE.FR, lazy: false };
@@ -21,7 +17,7 @@ describe('e2e:osds-flag', () => {
   let url: string;
   let myCbk: (request: pRequest) => void;
 
-  async function setup({ attributes = {}, cbkInterceptorRequest, outsideViewport }: { attributes: Partial<OdsFlagAttribute>, cbkInterceptorRequest?: (request: pRequest) => void, outsideViewport?: boolean }) {
+  async function setup({ attributes = {}, cbkInterceptorRequest, outsideViewport }: { attributes: Partial<OdsFlagAttribute>, cbkInterceptorRequest?: (request: pRequest) => void, outsideViewport?: boolean }): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsFlagAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
     let spaceBefore = '';
 
@@ -43,11 +39,11 @@ describe('e2e:osds-flag', () => {
   beforeEach(async() => {
     url = '';
 
-    myCbk = (request) => {
+    myCbk = (request): void => {
       if (request.url().includes('fr.svg')) {
         request.respond({
-          headers: { 'Access-Control-Allow-Origin': '*' },
           body: 'myContent',
+          headers: { 'Access-Control-Allow-Origin': '*' },
         });
         url = request.url();
       } else {
@@ -61,7 +57,7 @@ describe('e2e:osds-flag', () => {
     jest.clearAllMocks();
   });
 
-  async function updateReferences() {
+  async function updateReferences(): Promise<void> {
     isoProperty = await el.getProperty('iso');
   }
 
@@ -87,18 +83,18 @@ describe('e2e:osds-flag', () => {
     });
 
     it('should load with custom path', async() => {
-      await setup({ attributes: { iso: ODS_FLAG_ISO_CODE.FR, assetPath: '../flags-custom-path/' }, cbkInterceptorRequest: myCbk });
-      const pattern = /^https?:\/\/localhost(:\d+)?\/[\w\/]*flags-custom-path\/fr\.svg/;
+      await setup({ attributes: { assetPath: '../flags-custom-path/', iso: ODS_FLAG_ISO_CODE.FR }, cbkInterceptorRequest: myCbk });
+      const pattern = /^https?:\/\/localhost(:\d+)?[\w/]*flags-custom-path\/fr\.svg/;
 
       expect(url).toMatch(pattern);
     });
 
     it('should load custom src', async() => {
-      myCbk = (request) => {
+      myCbk = (request): void => {
         if (request.url().includes('it.svg')) {
           request.respond({
-            headers: { 'Access-Control-Allow-Origin': '*' },
             body: 'myContent',
+            headers: { 'Access-Control-Allow-Origin': '*' },
           });
           url = request.url();
         } else {
@@ -130,11 +126,11 @@ describe('e2e:osds-flag', () => {
   it('should have flag svg content in dom', async() => {
     const old = Build.isBrowser;
     Build.isBrowser = true;
-    myCbk = (request) => {
+    myCbk = (request): void => {
       if (request.url().includes('fr.svg')) {
         request.respond({
-          headers: { 'Access-Control-Allow-Origin': '*' },
           body: '<svg></svg>',
+          headers: { 'Access-Control-Allow-Origin': '*' },
         });
         url = request.url();
       } else {

--- a/packages/components/flag/src/components/osds-flag/osds-flag.spec.ts
+++ b/packages/components/flag/src/components/osds-flag/osds-flag.spec.ts
@@ -2,11 +2,9 @@ jest.mock('./core/controller');
 
 import type { OdsFlagAttribute } from './interfaces/attributes';
 import type { SpecPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str, odsUnitTestAttribute } from '@ovhcloud/ods-common-testing';
 import { Build } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_FLAG_ISO_CODE } from './constants/flag-iso-code';
 import { OdsFlagController } from './core/controller';
@@ -21,7 +19,7 @@ describe('spec:osds-flag', () => {
   let shadowRoot: ShadowRoot | null | undefined;
   let controller: OdsFlagController;
 
-  async function setup({ attributes = {} }: { attributes?: Partial<OdsFlagAttribute> } = {}) {
+  async function setup({ attributes = {} }: { attributes?: Partial<OdsFlagAttribute> } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsFlagAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
 
     page = await newSpecPage({
@@ -32,7 +30,7 @@ describe('spec:osds-flag', () => {
     root = page.root;
     instance = page.rootInstance;
     shadowRoot = page.root?.shadowRoot;
-    controller = (OdsFlagController as unknown as jest.SpyInstance<OdsFlagController, unknown[]>).mock.instances[ 0 ];
+    controller = (OdsFlagController as unknown as jest.SpyInstance<OdsFlagController, unknown[]>).mock.instances[0];
 
     divEl = shadowRoot?.querySelector('.flag__svg');
   }
@@ -55,52 +53,52 @@ describe('spec:osds-flag', () => {
 
   describe('attributes', () => {
     const config = {
-      page: () => page,
-      instance: () => instance,
-      root: () => page.root,
-      wait: () => page.waitForChanges(),
+      instance: (): OsdsFlag => instance,
+      page: (): SpecPage => page,
+      root: (): SpecPage['root'] => page.root,
+      wait: (): Promise<void> => page.waitForChanges(),
     };
 
     describe('iso', () => {
       odsUnitTestAttribute<OdsFlagAttribute, 'iso'>({
-        name: 'iso',
         defaultValue: DEFAULT_ATTRIBUTE.iso,
+        name: 'iso',
         newValue: ODS_FLAG_ISO_CODE.ES,
-        value: ODS_FLAG_ISO_CODE.FR,
         setup: (value) => setup({ attributes: { ['iso']: value } }),
+        value: ODS_FLAG_ISO_CODE.FR,
         ...config,
       });
     });
 
     describe('src', () => {
       odsUnitTestAttribute<OdsFlagAttribute, 'src'>({
-        name: 'src',
         defaultValue: DEFAULT_ATTRIBUTE.src,
+        name: 'src',
         newValue: '',
-        value: 'my/path.svg',
         setup: (value) => setup({ attributes: { ['src']: value } }),
+        value: 'my/path.svg',
         ...config,
       });
     });
 
     describe('assetPath', () => {
       odsUnitTestAttribute<OdsFlagAttribute, 'assetPath'>({
-        name: 'assetPath',
         defaultValue: DEFAULT_ATTRIBUTE.assetPath,
+        name: 'assetPath',
         newValue: '',
-        value: 'my/path',
         setup: (value) => setup({ attributes: { ['assetPath']: value } }),
+        value: 'my/path',
         ...config,
       });
     });
 
     describe('lazy', () => {
       odsUnitTestAttribute<OdsFlagAttribute, 'lazy'>({
-        name: 'lazy',
         defaultValue: DEFAULT_ATTRIBUTE.lazy,
+        name: 'lazy',
         newValue: false,
-        value: true,
         setup: (value) => setup({ attributes: { ['lazy']: value } }),
+        value: true,
         ...config,
       });
     });

--- a/packages/components/flag/src/components/osds-flag/osds-flag.tsx
+++ b/packages/components/flag/src/components/osds-flag/osds-flag.tsx
@@ -1,17 +1,15 @@
 import type { ODS_FLAG_ISO_CODE_UNION } from './constants/flag-iso-code';
 import type { OdsFlagAttribute } from './interfaces/attributes';
-
+import type { FunctionalComponent } from '@stencil/core';
 import { odsHasAriaHidden } from '@ovhcloud/ods-common-core';
 import { Build, Component, Element, Host, Prop, State, Watch, h } from '@stencil/core';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { OdsFlagController } from './core/controller';
 
-
 @Component({
-  tag: 'osds-flag',
-  styleUrl: 'osds-flag.scss',
   shadow: true,
+  styleUrl: 'osds-flag.scss',
+  tag: 'osds-flag',
 })
 export class OsdsFlag implements OdsFlagAttribute {
   controller: OdsFlagController = new OdsFlagController(this);
@@ -19,7 +17,7 @@ export class OsdsFlag implements OdsFlagAttribute {
   @Element() hostElement!: HTMLElement;
 
   @Prop({ reflect: true }) assetPath = DEFAULT_ATTRIBUTE.assetPath;
-  @Prop({ reflect: true, mutable: true }) iso?: ODS_FLAG_ISO_CODE_UNION = DEFAULT_ATTRIBUTE.iso;
+  @Prop({ mutable: true, reflect: true }) iso?: ODS_FLAG_ISO_CODE_UNION = DEFAULT_ATTRIBUTE.iso;
   @Prop({ reflect: true }) lazy = DEFAULT_ATTRIBUTE.lazy;
   @Prop({ reflect: true }) src = DEFAULT_ATTRIBUTE.src;
 
@@ -27,15 +25,15 @@ export class OsdsFlag implements OdsFlagAttribute {
   @State() private visible = false;
   @State() private svgContent?: string;
 
-  connectedCallback() {
+  connectedCallback(): void {
     this.onInit();
   }
 
-  disconnectedCallback() {
+  disconnectedCallback(): void {
     this.onDestroy();
   }
 
-  getAssetPath(url: string) {
+  getAssetPath(url: string): string {
     // TODO currently we are not using getAssetPath from stencil since it doesn't work in React integration
     //return getAssetPath(url);
     return url;
@@ -44,22 +42,22 @@ export class OsdsFlag implements OdsFlagAttribute {
   @Watch('iso')
   @Watch('assetPath')
   @Watch('src')
-  async load() {
+  async load(): Promise<void> {
     this.svgContent = await this.controller.load(this.visible, Build.isBrowser) || '';
     this.ariaLabel = this.iso;
   }
 
-  onDestroy() {
+  onDestroy(): void {
     this.controller.onDestroy();
   }
 
-  onInit() {
+  onInit(): void {
     this.controller.onInit(() => {
       this.visible = true;
     }, Build.isBrowser);
   }
 
-  render() {
+  render(): FunctionalComponent {
     const { ariaLabel } = this;
     return (
       <Host class="flag"

--- a/packages/components/form-field/package.json
+++ b/packages/components/form-field/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/message/package.json
+++ b/packages/components/message/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/password/package.json
+++ b/packages/components/password/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/phone-number/package.json
+++ b/packages/components/phone-number/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/quantity/package.json
+++ b/packages/components/quantity/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/radio-button/package.json
+++ b/packages/components/radio-button/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -22,7 +22,7 @@
     "doc:radio-group": "typedoc src/components/osds-radio-group/public-api.ts --out ./docs-api/radio-group --json ./docs-api/radio-group/typedoc.json",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/range/package.json
+++ b/packages/components/range/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/search-bar/package.json
+++ b/packages/components/search-bar/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/text/src/components/osds-text/constants/default-attributes.ts
+++ b/packages/components/text/src/components/osds-text/constants/default-attributes.ts
@@ -1,5 +1,4 @@
 import type { OdsTextAttribute } from '../interfaces/attributes';
-
 import { ODS_TEXT_COLOR_HUE, ODS_TEXT_COLOR_INTENT } from './text-color';
 import { ODS_TEXT_LEVEL } from './text-level';
 import { ODS_TEXT_SIZE } from './text-size';

--- a/packages/components/text/src/components/osds-text/interfaces/attributes.ts
+++ b/packages/components/text/src/components/osds-text/interfaces/attributes.ts
@@ -16,6 +16,10 @@ interface OdsTextAttribute {
    */
   contrasted?: boolean
   /**
+   * Text hue
+   */
+  hue?: ODS_TEXT_COLOR_HUE
+  /**
    * Text level
    */
   level?: ODS_TEXT_LEVEL
@@ -23,12 +27,8 @@ interface OdsTextAttribute {
    * Text size
    */
   size?: ODS_TEXT_SIZE
-  /**
-   * Text hue
-   */
-  hue?: ODS_TEXT_COLOR_HUE
 }
 
-export {
+export type {
   OdsTextAttribute,
 };

--- a/packages/components/text/src/components/osds-text/osds-text.e2e.screenshot.ts
+++ b/packages/components/text/src/components/osds-text/osds-text.e2e.screenshot.ts
@@ -1,15 +1,11 @@
 import type { OdsTextAttribute } from './interfaces/attributes';
 import type { E2EPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { newE2EPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_TEXT_COLOR_HUES, ODS_TEXT_COLOR_INTENTS } from './constants/text-color';
 import { ODS_TEXT_LEVELS } from './constants/text-level';
 import { ODS_TEXT_SIZES } from './constants/text-size';
-
-
 
 const slotContent = 'Text';
 

--- a/packages/components/text/src/components/osds-text/osds-text.e2e.ts
+++ b/packages/components/text/src/components/osds-text/osds-text.e2e.ts
@@ -1,15 +1,11 @@
 import type { OdsTextAttribute } from './interfaces/attributes';
 import type { E2EElement, E2EPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { newE2EPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_TEXT_COLOR_HUE, ODS_TEXT_COLOR_INTENT } from './constants/text-color';
 import { ODS_TEXT_LEVEL } from './constants/text-level';
 import { ODS_TEXT_SIZE } from './constants/text-size';
-
-
 
 const slotContent = 'Text';
 

--- a/packages/components/text/src/components/osds-text/osds-text.spec.ts
+++ b/packages/components/text/src/components/osds-text/osds-text.spec.ts
@@ -1,15 +1,12 @@
 import type { OdsTextAttribute } from './interfaces/attributes';
 import type { SpecPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str, odsUnitTestAttribute } from '@ovhcloud/ods-common-testing';
 import { newSpecPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_TEXT_COLOR_INTENT, ODS_TEXT_COLOR_INTENTS } from './constants/text-color';
 import { ODS_TEXT_LEVEL, ODS_TEXT_LEVELS } from './constants/text-level';
 import { ODS_TEXT_SIZE, ODS_TEXT_SIZES } from './constants/text-size';
 import { OsdsText } from './osds-text';
-
 
 describe('spec:osds-text', () => {
   let page: SpecPage;
@@ -59,7 +56,7 @@ describe('spec:osds-text', () => {
     const config = {
       instance: (): OsdsText => instance,
       page: (): SpecPage => page,
-      root: (): AnyHTMLElement => page.root,
+      root: (): SpecPage['root'] => page.root,
       wait: (): Promise<void> => page.waitForChanges(),
     };
 

--- a/packages/components/text/src/components/osds-text/osds-text.tsx
+++ b/packages/components/text/src/components/osds-text/osds-text.tsx
@@ -1,12 +1,10 @@
-
 import type { ODS_TEXT_COLOR_HUE, ODS_TEXT_COLOR_INTENT } from './constants/text-color';
 import type { ODS_TEXT_LEVEL } from './constants/text-level';
 import type { ODS_TEXT_SIZE } from './constants/text-size';
 import type { OdsTextAttribute } from './interfaces/attributes';
-
+import type { FunctionalComponent } from '@stencil/core';
 import { odsGenerateColorVariable } from '@ovhcloud/ods-common-theming';
-import { Component, FunctionalComponent, Host, Prop, h } from '@stencil/core';
-
+import { Component, Host, Prop, h } from '@stencil/core';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 /**

--- a/packages/components/textarea/package.json
+++ b/packages/components/textarea/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/tile/package.json
+++ b/packages/components/tile/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/toggle/package.json
+++ b/packages/components/toggle/package.json
@@ -20,7 +20,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -21,7 +21,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint '*/**/*.{js,ts,tsx}'",
+    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --docs --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",


### PR DESCRIPTION
While adapting flag code, I've come accross a few changes I would like to propose to the eslint configuration:

- [x] add `@typescript-eslint/consistent-type-exports`
ex:
```
export {
  ODS_FLAG_ISO_CODE,
  ODS_FLAG_ISO_CODES,
  ODS_FLAG_ISO_CODE_UNION,
};
// =>
export type { ODS_FLAG_ISO_CODE_UNION };
export {
  ODS_FLAG_ISO_CODE,
  ODS_FLAG_ISO_CODES,
};
```

- [x] add `@typescript-eslint/consistent-type-imports`
ex:
```
import { OdsFlagAttribute } from '../interfaces/attributes';
// =>
import type { OdsFlagAttribute } from '../interfaces/attributes';
```

- [x] increase (or remove) `max-len` as we have verbose function + return type (especially on tests)
- [x] prevent more than one blank line
- [x] remove magic number, it's more pain than gain, especially on test, ex:
```
const ratio = 3 / 4; // => error
....hasBeenCalledTimes(1) // => error
```

- [x] no blank line on import
```
// import type first - though there is an issue that prevent sorting by groups inside type; so they're sorted alphabetically)
// (see https://github.com/import-js/eslint-plugin-import/issues/2683)
// import the rest, following group order
// ex:
import type { ODS_FLAG_ISO_CODE_UNION } from './constants/flag-iso-code';
import type { OdsFlagAttribute } from './interfaces/attributes';
import type { FunctionalComponent } from '@stencil/core';
import { odsHasAriaHidden } from '@ovhcloud/ods-common-core';
import { Build, Component, Element, Host, Prop, State, Watch, h } from '@stencil/core';
import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
import { OdsFlagController } from './core/controller';
```

Give me your opinion and I'll update flag and text accordingly.