### PR TITLE
Fix/qa wcb inputs safari

### DIFF
--- a/packages/components/select/src/components/osds-select/osds-select.scss
+++ b/packages/components/select/src/components/osds-select/osds-select.scss
@@ -26,6 +26,7 @@
     display: flex;
     align-items: center;
     border-style: solid;
+    width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/components/textarea/src/components/osds-textarea/osds-textarea.scss
+++ b/packages/components/textarea/src/components/osds-textarea/osds-textarea.scss
@@ -16,6 +16,11 @@
   }
 
   outline: none;
+
+  textarea {
+    box-sizing: border-box;
+    width: 100%;
+  }
 }
 
 :host([inline]) {


### PR DESCRIPTION
Fixing Safari bugs related to Select and Textarea components regarding:

- width on non inline mode
- box-sizing on textarea

Implementation tested manually on real usage context