### PR TITLE
feat(lib): upgrade to Stencil 4.7 && add clean command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:prod:slow": "lerna run --stream --concurrency 1 build:prod",
     "build:slow": "lerna run --concurrency 1 build",
     "build:storybook": "lerna run --stream build:storybook",
+    "clean": "lerna run clean",
     "dev:clear:dist": "rm -rf $(find packages -type d \\( -name dist -or -name custom-elements -or -name custom-elements-bundle -or -name www -or -name docs-api -or -name loader \\) -not -path \"*/node_modules/*\"  -not -path \"*/stencil/scripts/*\" -not -path \"*/cdk/dev/scripts/*\")",
     "dev:clear:node_modules": "rm -rf $(find packages -type d -name node_modules -not -path \"packages/storybook/*\")",
     "doc": "lerna run doc",

--- a/packages/cdk/dev/package.json
+++ b/packages/cdk/dev/package.json
@@ -13,10 +13,11 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "scripts": {
-    "start": "stencil build --docs --dev --watch --serve",
     "build:prod": "npm run build:stencil",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
-    "build:storybook": "npm run build:prod"
+    "build:storybook": "npm run build:prod",
+    "clean": "rimraf .stencil custom-elements dist loader react/src/components vue/src/components",
+    "start": "stencil build --docs --dev --watch --serve"
   },
   "dependencies": {
     "@ovhcloud/ods-cdk": "16.2.1",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -15,6 +15,7 @@
     "build:prod:amd": "tsc -p tsconfig.amd.prod.json",
     "build:prod:cjs": "tsc -p tsconfig.cjs.prod.json",
     "build:prod:esm": "tsc -p tsconfig.esm.prod.json",
+    "clean": "rimraf dist docs-api",
     "doc:api": "typedoc --plugin none src/*",
     "ignore:rm": "git clean -Xdf",
     "start": "stencil build --docs --dev --watch --serve",

--- a/packages/common/core/package.json
+++ b/packages/common/core/package.json
@@ -12,6 +12,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:prod": "npm run build",
+    "clean": "rimraf dist",
     "doc": "typedoc --plugin none src/* && typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs true --hideInPageTOC true && typedoc --json ./typedoc/typedoc.json --pretty",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "ignore:rm": "git clean -Xdf",

--- a/packages/common/stencil/package.json
+++ b/packages/common/stencil/package.json
@@ -11,6 +11,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:prod": "npm run build",
+    "clean": "rimraf dist docs-api",
     "doc:api": "typedoc --plugin none src/*",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "ignore:rm": "git clean -Xdf",
@@ -19,7 +20,7 @@
   "dependencies": {
     "@ovhcloud/ods-common-core": "16.2.1",
     "@ovhcloud/ods-theme-blue-jeans": "16.2.1",
-    "@stencil/core": "4.5.0"
+    "@stencil/core": "4.7.0"
   },
   "devDependencies": {
     "@ovhcloud/ods-common-testing": "16.2.1",

--- a/packages/common/testing/package.json
+++ b/packages/common/testing/package.json
@@ -12,6 +12,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:prod": "npm run build",
+    "clean": "rimraf dist",
     "doc": "typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs true --hideInPageTOC true",
     "doc:api": "typedoc --plugin none src/*",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/common/theming/package.json
+++ b/packages/common/theming/package.json
@@ -13,6 +13,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:prod": "npm run build",
+    "clean": "rimraf dist",
     "doc": "typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs true --hideInPageTOC true",
     "doc:api": "typedoc --plugin none src/*",
     "doc:sass": "sassdoc color size typography reset ods-theme.scss -d sassdoc",

--- a/packages/components-ovh/location-tile/package.json
+++ b/packages/components-ovh/location-tile/package.json
@@ -18,6 +18,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "yarn run doc:accordion && yarn run doc:accordion-group && node ../../../scripts/generate-typedoc-md.js --multiple",
     "doc:accordion": "typedoc src/components/osds-accordion/public-api.ts --out ./docs-api/accordion --json ./docs-api/accordion/typedoc.json",
     "doc:accordion-group": "typedoc src/components/osds-accordion-group/public-api.ts --out ./docs-api/accordion-group --json ./docs-api/accordion-group/typedoc.json",

--- a/packages/components/breadcrumb/package.json
+++ b/packages/components/breadcrumb/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/cart/package.json
+++ b/packages/components/cart/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/checkbox-button/package.json
+++ b/packages/components/checkbox-button/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/chip/package.json
+++ b/packages/components/chip/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/clipboard/package.json
+++ b/packages/components/clipboard/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/code/package.json
+++ b/packages/components/code/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/content-addon/package.json
+++ b/packages/components/content-addon/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/flag/package.json
+++ b/packages/components/flag/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/form-field/package.json
+++ b/packages/components/form-field/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/message/package.json
+++ b/packages/components/message/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/password/package.json
+++ b/packages/components/password/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/phone-number/package.json
+++ b/packages/components/phone-number/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/quantity/package.json
+++ b/packages/components/quantity/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/radio-button/package.json
+++ b/packages/components/radio-button/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "yarn run doc:radio && yarn run doc:radio-group && node ../../../scripts/generate-typedoc-md.js --multiple",
     "doc:api": "typedoc",
     "doc:radio": "typedoc src/components/osds-radio/public-api.ts --out ./docs-api/radio --json ./docs-api/radio/typedoc.json",

--- a/packages/components/range/package.json
+++ b/packages/components/range/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/search-bar/package.json
+++ b/packages/components/search-bar/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/textarea/package.json
+++ b/packages/components/textarea/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/tile/package.json
+++ b/packages/components/tile/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/toggle/package.json
+++ b/packages/components/toggle/package.json
@@ -16,6 +16,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -17,6 +17,7 @@
     "build:react": "npm --prefix react run build",
     "build:stencil": "stencil build --docs --prod --config stencil.config.ts",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
     "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../scripts/generate-typedoc-md.js",
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",

--- a/packages/examples/react/package.json
+++ b/packages/examples/react/package.json
@@ -7,9 +7,9 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
     "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
-    "build:prod": "DISABLE_ESLINT_PLUGIN=true npm run build"
+    "build:prod": "DISABLE_ESLINT_PLUGIN=true npm run build",
+    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start"
   },
   "dependencies": {
     "@ovhcloud/ods-common-core": "16.2.1",

--- a/packages/themes/blue-jeans/package.json
+++ b/packages/themes/blue-jeans/package.json
@@ -9,6 +9,7 @@
     "build:ci": "npm run build:prod",
     "build:prod": "yarn run build:sass:prefix",
     "build:sass:prefix": "yarn run generate:theme && yarn run generate:prefix",
+    "clean": "rimraf dist",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "generate:prefix": "postcss dist/**/*.css --dir dist --use autoprefixer --parser postcss-scss",
     "generate:theme": "node-sass --importer ../../../node_modules/node-sass-package-importer/dist/cli.js src/index.scss -o dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4240,7 +4240,7 @@ __metadata:
     "@ovhcloud/ods-stencil-dev": 16.2.1
     "@ovhcloud/ods-style-dev": 16.2.1
     "@ovhcloud/ods-theme-blue-jeans": 16.2.1
-    "@stencil/core": 4.5.0
+    "@stencil/core": 4.7.0
   languageName: unknown
   linkType: soft
 
@@ -6336,12 +6336,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:4.5.0":
-  version: 4.5.0
-  resolution: "@stencil/core@npm:4.5.0"
+"@stencil/core@npm:4.7.0":
+  version: 4.7.0
+  resolution: "@stencil/core@npm:4.7.0"
   bin:
     stencil: bin/stencil
-  checksum: 2bdd960af33a52565c297ef2ac65fed017b2fbe5ec228b2bdaafa48b1d99a6fe41e4c3ffe429437d27f3ea9b410e361714d088cedd6e13bb035f4b96b0310038
+  checksum: 53842a15a8f620cce0b5b9cded462f460b6082fbd7afcd337716b8523d0fc121b950b7acc904674a2ae2638841a0d80dfad1a7c55020448959ffed0d952d8efc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`clean` command delete generated director to get the project in a pristine state (usefull when debugging CI for example)