### PR TITLE
fix(select): shift tab now focus trigger on first

### DIFF
--- a/packages/components/select/src/components/osds-select/core/controller.ts
+++ b/packages/components/select/src/components/osds-select/core/controller.ts
@@ -115,9 +115,15 @@ class OdsSelectController {
     }
     if (event.code === 'ArrowUp' || (event.code === 'Tab' && event.shiftKey)) {
       const index = hasSelectedOption ? selectedSelectOptionIndex - 1 : 0;
-      if (index < 0 && (event.code === 'Tab' && event.shiftKey)) {
+      if (!hasSelectedOption && (event.code === 'Tab' && event.shiftKey)) {
         return;
-      } else if (index < 0) {
+      }
+      if (index < 0 && (event.code === 'Tab' && event.shiftKey)) {
+        event.preventDefault();
+        this.component.anchor.focus();
+        return;
+      }
+      if (index < 0) {
         return focusSelectOption(this.selectOptions.length -1);
       }
       return focusSelectOption(index);


### PR DESCRIPTION
ODS-771
When on first option, shift + tab now focused the trigger and don't stay on first option anymore