### PR TITLE
fix(modal): switch to dialog element

### DIFF
--- a/packages/components/modal/src/components/osds-modal/constants/default-attributes.ts
+++ b/packages/components/modal/src/components/osds-modal/constants/default-attributes.ts
@@ -1,7 +1,5 @@
 import type { OdsModalAttribute } from '../interfaces/attributes';
-
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-
 
 const DEFAULT_ATTRIBUTE: OdsModalAttribute = Object.freeze({
   color: ODS_THEME_COLOR_INTENT.info,

--- a/packages/components/modal/src/components/osds-modal/interfaces/events.ts
+++ b/packages/components/modal/src/components/osds-modal/interfaces/events.ts
@@ -5,6 +5,6 @@ interface OdsModalEvent {
   odsModalOpen: EventEmitter<void>;
 }
 
-export {
+export type {
   OdsModalEvent,
 };

--- a/packages/components/modal/src/components/osds-modal/interfaces/methods.ts
+++ b/packages/components/modal/src/components/osds-modal/interfaces/methods.ts
@@ -10,6 +10,6 @@ interface OdsModalMethod {
   open(): Promise<void>;
 }
 
-export {
+export type {
   OdsModalMethod,
 };

--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.screenshot.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.screenshot.ts
@@ -24,8 +24,8 @@ describe('e2e:osds-modal', () => {
     await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
 
     await page.evaluate(() => {
-      const wrapperElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.wrapper') as HTMLElement;
-      wrapperElement.style.setProperty('animation', 'none');
+      const modalElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.wrapper') as HTMLDialogElement;
+      modalElement.style.setProperty('animation', 'none');
     });
   }
 

--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -227,16 +227,6 @@ describe('e2e:osds-modal', () => {
       expect(focusedElementId).toBe('insideModalButton1');
     });
 
-    it('should keep focus within modal when open', async() => {
-      for (let i = 0; i < 10; i++) {
-        await page.keyboard.press('Tab');
-      }
-      await page.waitForChanges();
-
-      const focusedElementId = await page.evaluate(() => document.activeElement?.closest('osds-modal') ? document.activeElement.id : null);
-      expect(focusedElementId).not.toBeNull();
-    });
-
     it('should return focus to the outside button if modal is closed', async() => {
       await el.callMethod('close');
       await page.waitForChanges();

--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -216,27 +216,50 @@ describe('e2e:osds-modal', () => {
       insideModalButton2 = await page.find('#insideModalButton2');
     });
 
-    it('should focus on first inside modal button when modal is active', async() => {
+    it('should move focus to first button inside modal on first tab press', async() => {
       await el.callMethod('open');
       await page.waitForChanges();
 
       await page.keyboard.press('Tab');
+      await page.waitForChanges();
 
-      let focusedElementId = await page.evaluate(() => document.activeElement?.id);
+      const focusedElementId = await page.evaluate(() => document.activeElement?.id);
       expect(focusedElementId).toBe('insideModalButton1');
-
-      await page.keyboard.press('Tab');
-
-      focusedElementId = await page.evaluate(() => document.activeElement?.id);
-      expect(focusedElementId).toBe('insideModalButton2');
-      expect(focusedElementId).not.toBe('OVHcloud');
     });
 
-    it('should focus on outside button when modal is closed', async() => {
+    it('should loop focus back to first button inside modal on continued tabbing', async() => {
+      await el.callMethod('open');
+      await page.waitForChanges();
+
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Tab');
+      await page.waitForChanges();
+
+      const focusedElementId = await page.evaluate(() => document.activeElement?.id);
+      expect(focusedElementId).toBe('insideModalButton1');
+    });
+
+    it('should keep focus within modal when open', async() => {
+      await el.callMethod('open');
+      await page.waitForChanges();
+
+      for (let i = 0; i < 10; i++) {
+        await page.keyboard.press('Tab');
+      }
+      await page.waitForChanges();
+
+      const focusedElementId = await page.evaluate(() => document.activeElement?.closest('osds-modal') ? document.activeElement.id : null);
+      expect(focusedElementId).not.toBeNull();
+    });
+
+    it('should return focus to the outside button if modal is closed', async() => {
       await el.callMethod('close');
       await page.waitForChanges();
 
       await page.keyboard.press('Tab');
+      await page.waitForChanges();
 
       const focusedElementId = await page.evaluate(() => document.activeElement?.id);
       expect(focusedElementId).toBe('outsideButton');

--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -23,8 +23,8 @@ describe('e2e:osds-modal', () => {
     el = await page.find('osds-modal');
 
     await page.evaluate(() => {
-      const wrapperElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.wrapper') as HTMLElement;
-      wrapperElement.style.setProperty('animation', 'none');
+      const modalElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.wrapper') as HTMLDialogElement;
+      modalElement.style.setProperty('animation', 'none');
     });
   }
 
@@ -195,6 +195,8 @@ describe('e2e:osds-modal', () => {
 
   describe('keyboard navigation', () => {
     let outsideButton: E2EElement;
+    let insideModalButton1: E2EElement;
+    let insideModalButton2: E2EElement;
 
     beforeEach(async() => {
       page = await newE2EPage();
@@ -210,22 +212,34 @@ describe('e2e:osds-modal', () => {
 
       el = await page.find('osds-modal');
       outsideButton = await page.find('#outsideButton');
+      insideModalButton1 = await page.find('#insideModalButton1');
+      insideModalButton2 = await page.find('#insideModalButton2');
     });
 
-    it('should have inert attribute on outsideButton when modal is active', async() => {
+    it('should focus on first inside modal button when modal is active', async() => {
       await el.callMethod('open');
       await page.waitForChanges();
 
-      const inert = outsideButton.getAttribute('inert');
-      expect(inert).not.toBeNull();
+      await page.keyboard.press('Tab');
+
+      let focusedElementId = await page.evaluate(() => document.activeElement?.id);
+      expect(focusedElementId).toBe('insideModalButton1');
+
+      await page.keyboard.press('Tab');
+
+      focusedElementId = await page.evaluate(() => document.activeElement?.id);
+      expect(focusedElementId).toBe('insideModalButton2');
+      expect(focusedElementId).not.toBe('OVHcloud');
     });
 
-    it('should not have inert attribute on outsideButton when modal is closed', async() => {
+    it('should focus on outside button when modal is closed', async() => {
       await el.callMethod('close');
       await page.waitForChanges();
 
-      const inert = outsideButton.getAttribute('inert');
-      expect(inert).toBeNull();
+      await page.keyboard.press('Tab');
+
+      const focusedElementId = await page.evaluate(() => document.activeElement?.id);
+      expect(focusedElementId).toBe('outsideButton');
     });
   });
 });

--- a/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -9,7 +9,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 
 describe('e2e:osds-modal', () => {
-  const baseAttribute = { color: ODS_THEME_COLOR_INTENT.info, dismissible: true, headline: '', masked: false };
+  const baseAttribute = { color: ODS_THEME_COLOR_INTENT.info, dismissible: false, headline: '', masked: false };
   let page: E2EPage;
   let el: E2EElement;
 
@@ -211,29 +211,15 @@ describe('e2e:osds-modal', () => {
       await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
 
       el = await page.find('osds-modal');
+
+      await el.callMethod('open');
+      await page.waitForChanges();
       outsideButton = await page.find('#outsideButton');
       insideModalButton1 = await page.find('#insideModalButton1');
       insideModalButton2 = await page.find('#insideModalButton2');
     });
 
     it('should move focus to first button inside modal on first tab press', async() => {
-      await el.callMethod('open');
-      await page.waitForChanges();
-
-      await page.keyboard.press('Tab');
-      await page.waitForChanges();
-
-      const focusedElementId = await page.evaluate(() => document.activeElement?.id);
-      expect(focusedElementId).toBe('insideModalButton1');
-    });
-
-    it('should loop focus back to first button inside modal on continued tabbing', async() => {
-      await el.callMethod('open');
-      await page.waitForChanges();
-
-      await page.keyboard.press('Tab');
-      await page.keyboard.press('Tab');
-      await page.keyboard.press('Tab');
       await page.keyboard.press('Tab');
       await page.waitForChanges();
 
@@ -242,9 +228,6 @@ describe('e2e:osds-modal', () => {
     });
 
     it('should keep focus within modal when open', async() => {
-      await el.callMethod('open');
-      await page.waitForChanges();
-
       for (let i = 0; i < 10; i++) {
         await page.keyboard.press('Tab');
       }
@@ -258,6 +241,7 @@ describe('e2e:osds-modal', () => {
       await el.callMethod('close');
       await page.waitForChanges();
 
+      await page.click('body');
       await page.keyboard.press('Tab');
       await page.waitForChanges();
 

--- a/packages/components/modal/src/components/osds-modal/osds-modal.scss
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.scss
@@ -37,10 +37,10 @@
   .wrapper {
     position: absolute;
     z-index: 1;
-    overflow: hidden;
-    animation: modal-appear 0.2s ease-in-out;
     outline: none;
     border: none;
+    overflow: hidden;
+    animation: modal-appear 0.2s ease-in-out;
 
     .header {
       display: flex;

--- a/packages/components/modal/src/components/osds-modal/osds-modal.scss
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.scss
@@ -35,9 +35,12 @@
   }
 
   .wrapper {
+    position: absolute;
     z-index: 1;
     overflow: hidden;
     animation: modal-appear 0.2s ease-in-out;
+    outline: none;
+    border: none;
 
     .header {
       display: flex;

--- a/packages/components/modal/src/components/osds-modal/osds-modal.spec.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.spec.ts
@@ -8,7 +8,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { OsdsModal } from './osds-modal';
 
-
 describe('spec:osds-modal', () => {
   const baseAttribute = { color: ODS_THEME_COLOR_INTENT.info, dismissible: true, headline: '', masked: false };
   let page: SpecPage;
@@ -24,11 +23,14 @@ describe('spec:osds-modal', () => {
 
     page = await newSpecPage({
       components: [OsdsModal],
-      html: `<osds-modal ${odsStringAttributes2Str(stringAttributes)}>My Modal</osds-modal>`,
+      html: `<osds-modal ${odsStringAttributes2Str(stringAttributes)}>Modal</osds-modal>`,
     });
 
     root = page.root;
     instance = page.rootInstance;
+    instance.modal = {
+      showModal: jest.fn(),
+    } as unknown as HTMLDialogElement;
   }
 
   it('should render', async() => {

--- a/packages/components/modal/src/components/osds-modal/osds-modal.spec.ts
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.spec.ts
@@ -28,9 +28,6 @@ describe('spec:osds-modal', () => {
 
     root = page.root;
     instance = page.rootInstance;
-    instance.modal = {
-      showModal: jest.fn(),
-    } as unknown as HTMLDialogElement;
   }
 
   it('should render', async() => {

--- a/packages/components/modal/src/components/osds-modal/osds-modal.tsx
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.tsx
@@ -41,7 +41,6 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod, OdsModalEve
 
   @Listen('keydown', { target: 'window' })
   handleKeyDown(event: KeyboardEvent): void {
-    console.log(document.activeElement);
     if (event.key === 'Escape') {
       event.stopPropagation();
       event.preventDefault();

--- a/packages/components/modal/src/components/osds-modal/osds-modal.tsx
+++ b/packages/components/modal/src/components/osds-modal/osds-modal.tsx
@@ -3,6 +3,7 @@ import type { OdsModalEvent } from './interfaces/events';
 import type { OdsModalMethod } from './interfaces/methods';
 import type { EventEmitter } from '@stencil/core';
 import { ODS_THEME_COLOR_INTENT, ODS_THEME_TYPOGRAPHY_SIZE } from '@ovhcloud/ods-common-theming';
+import { ODS_BUTTON_VARIANT } from '@ovhcloud/ods-component-button';
 import { ODS_ICON_NAME, ODS_ICON_SIZE } from '@ovhcloud/ods-component-icon';
 import { ODS_TEXT_LEVEL } from '@ovhcloud/ods-component-text';
 import { Component, Element, Event, Host, Listen, Method, Prop, Watch, h } from '@stencil/core';
@@ -40,6 +41,7 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod, OdsModalEve
 
   @Listen('keydown', { target: 'window' })
   handleKeyDown(event: KeyboardEvent): void {
+    console.log(document.activeElement);
     if (event.key === 'Escape') {
       event.stopPropagation();
       event.preventDefault();
@@ -82,7 +84,7 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod, OdsModalEve
     this.handleShownState();
   }
 
-  render(): void {
+  render(): JSX.Element {
     const { color, headline, dismissible, masked } = this;
 
     return (
@@ -96,7 +98,7 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod, OdsModalEve
           }}>
           <div class="header">
             {dismissible && (
-              <osds-button onClick={(): Promise<void> => this.close()} color={color} circle variant='ghost'>
+              <osds-button onClick={(): Promise<void> => this.close()} color={color} circle variant={ODS_BUTTON_VARIANT.ghost}>
                 <osds-icon ariaName={ODS_ICON_NAME.CLOSE + ' icon'} name={ODS_ICON_NAME.CLOSE} size={ODS_ICON_SIZE.sm} color={color}></osds-icon>
               </osds-button>
             )}

--- a/packages/components/modal/src/components/osds-modal/styles/osds-modal.color.scss
+++ b/packages/components/modal/src/components/osds-modal/styles/osds-modal.color.scss
@@ -3,12 +3,10 @@
 
 @mixin osds-modal-theme-color-variant-default() {
   @include ods-and-all-hue-foreach-theme-color((
-          color: '800',
-          background-color: '100'
+    color: '800',
+    background-color: '100'
   )) using($colors) {
     @include osds-modal-on-selected-host {
-      // color: map_get($colors, color);
-
       .wrapper {
         .header {
           background-color: map_get($colors, background-color);
@@ -30,6 +28,10 @@
 
     .wrapper {
       background: #fff;
+    }
+
+    .wrapper::backdrop {
+      opacity: 0;
     }
   }
 

--- a/packages/components/modal/src/components/osds-modal/styles/osds-modal.color.scss
+++ b/packages/components/modal/src/components/osds-modal/styles/osds-modal.color.scss
@@ -28,10 +28,10 @@
 
     .wrapper {
       background: #fff;
-    }
 
-    .wrapper::backdrop {
-      opacity: 0;
+      &::backdrop {
+        opacity: 0;
+      }
     }
   }
 

--- a/packages/components/modal/src/components/osds-modal/styles/osds-modal.size.scss
+++ b/packages/components/modal/src/components/osds-modal/styles/osds-modal.size.scss
@@ -18,10 +18,10 @@
 
         .wrapper {
             border-radius: var(--ods-size-04);
+            padding: 0;
             width: 70%;
             min-width: 50%;
             max-width: clamp(36rem, 70%, 70%);
-            padding: 0;
 
             .header {
                 padding: 0 calc(var(--ods-size-04) / 2);

--- a/packages/components/modal/src/components/osds-modal/styles/osds-modal.size.scss
+++ b/packages/components/modal/src/components/osds-modal/styles/osds-modal.size.scss
@@ -17,11 +17,11 @@
         }
 
         .wrapper {
-            margin: var(--ods-size-04);
             border-radius: var(--ods-size-04);
             width: 70%;
             min-width: 50%;
             max-width: clamp(36rem, 70%, 70%);
+            padding: 0;
 
             .header {
                 padding: 0 calc(var(--ods-size-04) / 2);

--- a/packages/components/modal/src/index.html
+++ b/packages/components/modal/src/index.html
@@ -35,7 +35,7 @@
     id="modal-1"
     color="info"
     headline="On Vous Héberge ?"
-    dismissible="true"
+    dismissible="false"
     masked="true"
   >
     <osds-text color="text">


### PR DESCRIPTION
- `OsdsModal` is now using a `HTMLDialogElement` and is no longer appended to the body. (_fixes react children problem)_
- `OsdsModal` is now reactive to `Escape` key. _(will close the modal if dismissible)_
- `OsdsModal`'s icon has been fixed and no longer features a colored background.
- Tests have been added to check if focus is well applied.

