### PR TITLE
fix(datagrid): overflowing elements are cut off

### DIFF
--- a/packages/components/datagrid/documentation/usage-guidelines/usage-style.css
+++ b/packages/components/datagrid/documentation/usage-guidelines/usage-style.css
@@ -1,6 +1,0 @@
-:root osds-datagrid {
-    --ods-menu-position: static;
-    --ods-select-position: static;
-    --ods-popover-position: static;
-    --ods-tooltip-position: static;
-}

--- a/packages/components/datagrid/documentation/usage-guidelines/usage.mdx
+++ b/packages/components/datagrid/documentation/usage-guidelines/usage.mdx
@@ -1,5 +1,4 @@
 import GenericStyle from '@ovhcloud/ods-common-core/docs/generic-style.mdx';
-import './usage-style.css';
 <GenericStyle />
 
 ## Usage
@@ -41,7 +40,7 @@ import './usage-style.css';
 ```
 
 ### Selectable columns
-<osds-datagrid 
+<osds-datagrid
   columns='[{"title":"Name","field":"name"},{"title":"Firstname","field":"firstname"},{"title":"Gender","field":"gender"},{"title":"Date Of Birth","field":"dob"}]'
   rows='[{"name":"Dupont","firstname":"Antoine","gender":"male","dob":"15/11/1996"},{"name":"Garnbret","firstname":"Janja","gender":"female","dob":"12/03/1999"}]'
   is-selectable
@@ -50,7 +49,7 @@ import './usage-style.css';
 
 ```html
 <!-- Attributes need to be stringify -->
-<osds-datagrid 
+<osds-datagrid
   columns='[{"title":"Name","field":"name"},{"title":"Firstname","field":"firstname"},{"title":"Gender","field":"gender"},{"title":"Date Of Birth","field":"dob"}]'
   rows='[{"name":"Dupont","firstname":"Antoine","gender":"male","dob":"15/11/1996"},{"name":"Garnbret","firstname":"Janja","gender":"female","dob":"12/03/1999"}]'
   is-selectable
@@ -59,7 +58,7 @@ import './usage-style.css';
 ```
 
 ### With sortable columns
-<osds-datagrid 
+<osds-datagrid
   columns='[{"title":"Name","field":"name", "isSortable": true},{"title":"Firstname","field":"firstname"},{"title":"Gender","field":"gender"},{"title":"Date Of Birth","field":"dob"}]'
   rows='[{"name":"Dupont","firstname":"Antoine","gender":"male","dob":"15/11/1996"},{"name":"Garnbret","firstname":"Janja","gender":"female","dob":"12/03/1999"}]'
   height="150">
@@ -97,8 +96,8 @@ export const datagridFormatter = () => {
       { title: "Firstname", field: "firstname" },
       { title: "Gender", field: "gender" },
       { title: "Date Of Birth", field: "dob", formatter: (value) => {
-          return '<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400">' + value + '</osds-text>' 
-        } 
+          return '<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400">' + value + '</osds-text>'
+        }
       },
     ];
     datagrid.rows = [
@@ -124,8 +123,8 @@ export const datagridFormatter = () => {
       { title: "Firstname", field: "firstname" },
       { title: "Gender", field: "gender" },
       { title: "Date Of Birth", field: "dob", formatter: (value) => {
-          return '<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400"> ' + value + '</osds-text>' 
-        } 
+          return '<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400"> ' + value + '</osds-text>'
+        }
       },
     ];
     datagrid.rows = [
@@ -137,7 +136,7 @@ export const datagridFormatter = () => {
 ```
 
 ### Empty rows
-<osds-datagrid 
+<osds-datagrid
   columns='[{"title":"Name","field":"name", "isSortable": true},{"title":"Firstname","field":"firstname"},{"title":"Gender","field":"gender"},{"title":"Date Of Birth","field":"dob"}]'
   rows='[]'
   no-result-label="Aucun résultat"
@@ -157,102 +156,5 @@ export const datagridFormatter = () => {
     ];
     datagrid.rows = [];
     datagrid.height = 150;
-</script>
-```
-
-### Use Select, Tooltip, Menu or Popover in row formatter
-
-export const datagridWithMenu = () => {
-  setTimeout(() => {
-    const datagrid = document.getElementById('datagridWithMenu');
-    if (!datagrid) {
-      return;
-    }
-    datagrid.columns = [
-      { title: "Name", field: "name", formatter: (cellValue, rowValue) => {
-          return `<osds-menu>
-            <osds-button slot="menu-title" color="primary" variant="stroked">
-              Action menu
-              <osds-icon name="home" size="xs"></osds-icon>
-            </osds-button>
-            <osds-menu-item>
-              <osds-button
-                color="primary"
-                size="sm"
-                variant="ghost"
-                text-align="start"
-                flex=""
-              >
-                <span>Action 1</span>
-              </osds-button>
-            </osds-menu-item>
-          </osds-menu>`
-        }
-      },
-      { title: "Firstname", field: "firstname", isSortable: true },
-      { title: "Gender", field: "gender", isSortable: true },
-      { title: "Date Of Birth", field: "dob", isSortable: true },
-    ];
-    datagrid.rows = [
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-    ];
-    datagrid.height = 300;
-  }, 1000);
-};
-
-<osds-datagrid id="datagridWithMenu">
-</osds-datagrid>
-
-<>{ datagridWithMenu() }</>
-
-```html
-<osds-datagrid id="datagrid" no-result-label="Aucun résultat"></osds-datagrid>
-
-<style>
-  :root osds-datagrid {
-    --ods-menu-position: static;
-    --ods-select-position: static;
-    --ods-popover-position: static;
-    --ods-tooltip-position: static;
-  }
-</style> 
-
-<script>
-    const datagrid = document.querySelector('#datagrid')
-     datagrid.columns = [
-      { title: "Name", field: "name", formatter: (cellValue, rowValue) => {
-          return `<osds-menu>
-            <osds-button slot="menu-title" color="primary" variant="stroked">
-              Action menu
-              <osds-icon name="home" size="xs"></osds-icon>
-            </osds-button>
-            <osds-menu-item>
-              <osds-button
-                color="primary"
-                size="sm"
-                variant="ghost"
-                text-align="start"
-                flex=""
-              >
-                <span>Action 1</span>
-              </osds-button>
-            </osds-menu-item>
-          </osds-menu>`
-        }
-      },
-      { title: "Firstname", field: "firstname", isSortable: true },
-      { title: "Gender", field: "gender", isSortable: true },
-      { title: "Date Of Birth", field: "dob", isSortable: true },
-    ];
-    datagrid.rows = Array.from({ length: 5 }).fill({ name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" });
 </script>
 ```

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.screenshot.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.screenshot.ts
@@ -33,19 +33,19 @@ describe('e2e:osds-datagrid', () => {
         },
         {
           columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }]),
-          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
+          rows: JSON.stringify([{ firstname:'Homer', lastname:'Simpson' }]),
         },
         {
           columns: JSON.stringify([{ field:'firstname', isSortable: true, title:'First name' }, { field:'lastname', title:'Last name' }]),
-          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
+          rows: JSON.stringify([{ firstname:'Homer', lastname:'Simpson' }]),
         },
         {
           columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }]),
           isSelectable: true,
-          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
+          rows: JSON.stringify([{ firstname:'Homer', lastname:'Simpson' }]),
         },
         {
-          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }, { title: "Button", field: "button", formatter: (cellValue, rowValue) => {
+          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }, { field: 'button', formatter: (): string => {
             return `<osds-menu>
         <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
         <osds-menu-group>
@@ -58,9 +58,10 @@ describe('e2e:osds-datagrid', () => {
           <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
         </osds-menu-item>
         <osds-divider color="text" separator="true"></osds-divider>
-      </osds-menu>`}}]),
+      </osds-menu>`;
+          }, title: 'Button' }]),
           hasHideabledColumns: false,
-          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
+          rows: JSON.stringify([{ firstname:'Homer', lastname:'Simpson' }]),
         },
       ].map((attributes) => createContent({ attributes })).join(' ');
       await setup(content);

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.screenshot.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.screenshot.ts
@@ -27,27 +27,40 @@ describe('e2e:osds-datagrid', () => {
         { columns: [], rows: [] },
         { columns: '[]', rows: '[]' },
         {
-          columns: JSON.stringify([{ field:'name', title:'Name' }, { field:'firstname', title:'Firstname' }]),
+          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }]),
           noResultLabel: 'Aucune données de renseignée',
           rows: '[]',
         },
         {
-          columns: JSON.stringify([{ field:'name', title:'Name' }, { field:'firstname', title:'Firstname' }]),
-          rows: JSON.stringify([{ firstname:'Simpson', name:'Homer' }]),
+          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }]),
+          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
         },
         {
-          columns: JSON.stringify([{ field:'name', isSortable: true, title:'Name' }, { field:'firstname', title:'Firstname' }]),
-          rows: JSON.stringify([{ firstname:'Simpson', name:'Homer' }]),
+          columns: JSON.stringify([{ field:'firstname', isSortable: true, title:'First name' }, { field:'lastname', title:'Last name' }]),
+          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
         },
         {
-          columns: JSON.stringify([{ field:'name', title:'Name' }, { field:'firstname', title:'Firstname' }]),
+          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }]),
           isSelectable: true,
-          rows: JSON.stringify([{ firstname:'Simpson', name:'Homer' }]),
+          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
         },
         {
-          columns: JSON.stringify([{ field:'name', title:'Name' }, { field:'firstname', title:'Firstname' }]),
+          columns: JSON.stringify([{ field:'firstname', title:'First name' }, { field:'lastname', title:'Last name' }, { title: "Button", field: "button", formatter: (cellValue, rowValue) => {
+            return `<osds-menu>
+        <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+        <osds-menu-group>
+          <osds-text>Group/Text 1</osds-text>
+        </osds-menu-group>
+        <osds-menu-item>
+          <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 1</span></osds-button>
+        </osds-menu-item>
+        <osds-menu-item>
+          <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
+        </osds-menu-item>
+        <osds-divider color="text" separator="true"></osds-divider>
+      </osds-menu>`}}]),
           hasHideabledColumns: false,
-          rows: JSON.stringify([{ firstname:'Simpson', name:'Homer' }]),
+          rows: JSON.stringify([{ lastname:'Simpson', firstname:'Homer' }]),
         },
       ].map((attributes) => createContent({ attributes })).join(' ');
       await setup(content);

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.ts
@@ -33,7 +33,7 @@ describe('e2e:osds-datagrid', () => {
   it('should render 1 rows & 3 columns', async() => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
     } });
     const columns = await table?.findAll('.tabulator-col');
     expect(columns).toHaveLength(3);
@@ -49,7 +49,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
     } });
 
     const selectableHeader = await table?.find('.tabulator-header input[type="checkbox"]');
@@ -61,7 +61,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
     } });
     const selectableRow = await table?.find('.tabulator-row input[type="checkbox"]');
     await selectableRow?.click();
@@ -76,7 +76,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
 
     const selectableHeader = await table?.find('.tabulator-header input[type="checkbox"]');
@@ -94,7 +94,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
     const rowSelectionChangeSpy = await el.spyOnEvent('odsRowSelectionChange');
 
@@ -109,13 +109,13 @@ describe('e2e:osds-datagrid', () => {
     }) ?? []);
     expect(isAllSelect.includes(false)).toBe(true);
     expect(await selectableHeader?.getProperty('indeterminate')).toBe(true);
-    expect(rowSelectionChangeSpy).toHaveReceivedEventDetail({ rows: [{ lastname: 'Simpson', firstname: 'Homer' }] });
+    expect(rowSelectionChangeSpy).toHaveReceivedEventDetail({ rows: [{ firstname: 'Homer', lastname: 'Simpson' }] });
   });
 
   it('should have sortable columns', async() => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', isSortable: true, title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
     const sortSpy = await el.spyOnEvent('odsSortChange');
 
@@ -138,7 +138,7 @@ describe('e2e:osds-datagrid', () => {
   it('should have a column formatter', async() => {
     await setup({ attributes: {
       columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await page.$eval('osds-datagrid', (elm: any) => {
@@ -156,7 +156,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
       height,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
     const style = await table?.getComputedStyle();
     expect(style?.height).toBe(height + 'px');
@@ -167,7 +167,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
       rowHeight,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]),
     } });
     const rows = await table?.findAll('.tabulator-row');
     const isAllRowHasHeight = await rows?.every(async(row) => {
@@ -188,7 +188,7 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       hasHideableColumns: false,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
     } });
     const columns = await table?.findAll('.tabulator-col');
     expect(columns).toHaveLength(2);
@@ -200,9 +200,9 @@ describe('e2e:osds-datagrid', () => {
     await setup({ attributes: {
       columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       hasHideableColumns: false,
-      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
+      rows: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
     } });
-    el.setProperty('rows', JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]));
+    el.setProperty('rows', JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }, { firstname: 'Marge', lastname: 'Simpson' }]));
     await page.waitForChanges();
 
     const rows = JSON.parse(await el.getProperty('rows'));

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.e2e.ts
@@ -32,13 +32,13 @@ describe('e2e:osds-datagrid', () => {
 
   it('should render 1 rows & 3 columns', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
     } });
     const columns = await table?.findAll('.tabulator-col');
     expect(columns).toHaveLength(3);
-    expect(columns?.[0].innerText).toContain('Name');
-    expect(columns?.[1].innerText).toContain('Firstname');
+    expect(columns?.[0].innerText).toContain('First name');
+    expect(columns?.[1].innerText).toContain('Last name');
     expect(columns?.[2].innerHTML).toContain('osds-button');
     const rows = await table?.findAll('.tabulator-row');
     expect(rows).toHaveLength(1);
@@ -47,9 +47,9 @@ describe('e2e:osds-datagrid', () => {
 
   it('should have selectable columns', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
     } });
 
     const selectableHeader = await table?.find('.tabulator-header input[type="checkbox"]');
@@ -59,9 +59,9 @@ describe('e2e:osds-datagrid', () => {
 
   it('should deselect all selected columns after toggle isSelectable', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
     } });
     const selectableRow = await table?.find('.tabulator-row input[type="checkbox"]');
     await selectableRow?.click();
@@ -74,9 +74,9 @@ describe('e2e:osds-datagrid', () => {
 
   it('should select all rows', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
 
     const selectableHeader = await table?.find('.tabulator-header input[type="checkbox"]');
@@ -92,9 +92,9 @@ describe('e2e:osds-datagrid', () => {
 
   it('should select 1 rows with header checkbox indeterminate', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       isSelectable: true,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
     const rowSelectionChangeSpy = await el.spyOnEvent('odsRowSelectionChange');
 
@@ -109,44 +109,44 @@ describe('e2e:osds-datagrid', () => {
     }) ?? []);
     expect(isAllSelect.includes(false)).toBe(true);
     expect(await selectableHeader?.getProperty('indeterminate')).toBe(true);
-    expect(rowSelectionChangeSpy).toHaveReceivedEventDetail({ rows: [{ firstname: 'Simpson', name: 'Homer' }] });
+    expect(rowSelectionChangeSpy).toHaveReceivedEventDetail({ rows: [{ lastname: 'Simpson', firstname: 'Homer' }] });
   });
 
-  it('should sortable columns', async() => {
+  it('should have sortable columns', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', isSortable: true, title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      columns: JSON.stringify([{ field: 'firstname', isSortable: true, title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
     const sortSpy = await el.spyOnEvent('odsSortChange');
 
     const sortableHeader = await table?.find('.tabulator-header .tabulator-col-sorter');
     await sortableHeader?.click();
 
-    const rows = await table?.findAll('.tabulator-row [tabulator-field="name"]');
+    const rows = await table?.findAll('.tabulator-row [tabulator-field="firstname"]');
     expect(rows?.[0].innerText).toContain('Homer');
     expect(rows?.[1].innerText).toContain('Marge');
-    expect(sortSpy).toHaveReceivedEventDetail({ dir: 'asc', field: 'name' });
+    expect(sortSpy).toHaveReceivedEventDetail({ dir: 'asc', field: 'firstname' });
 
     await sortableHeader?.click();
-    const newRows = await table?.findAll('.tabulator-row [tabulator-field="name"]');
+    const newRows = await table?.findAll('.tabulator-row [tabulator-field="firstname"]');
     expect(newRows?.[0].innerText).toContain('Marge');
     expect(newRows?.[1].innerText).toContain('Homer');
-    expect(sortSpy).toHaveReceivedEventDetail({ dir: 'desc', field: 'name' });
+    expect(sortSpy).toHaveReceivedEventDetail({ dir: 'desc', field: 'firstname' });
 
   });
 
   it('should have a column formatter', async() => {
     await setup({ attributes: {
-      columns: [{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }],
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await page.$eval('osds-datagrid', (elm: any) => {
-      elm.columns = [{ field: 'name', formatter: (value): string => `<osds-button>Button content</osds-button>${value}`, title: 'Name' }, { field: 'firstname', title: 'Firstname' }];
+      elm.columns = [{ field: 'firstname', formatter: (value): string => `<osds-button>Button content</osds-button>${value}`, title: 'First name' }, { field: 'lastname', title: 'Last name' }];
     });
     await page.waitForChanges();
 
-    const rows = await table?.findAll('.tabulator-row [tabulator-field="name"]');
+    const rows = await table?.findAll('.tabulator-row [tabulator-field="firstname"]');
     expect(rows?.[0].innerHTML).toContain('osds-button');
     expect(rows?.[0].innerHTML).toContain('Homer');
   });
@@ -154,9 +154,9 @@ describe('e2e:osds-datagrid', () => {
   it('should have height', async() => {
     const height = 600;
     await setup({ attributes: {
-      columns: [{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }],
+      columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
       height,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
     const style = await table?.getComputedStyle();
     expect(style?.height).toBe(height + 'px');
@@ -165,9 +165,9 @@ describe('e2e:osds-datagrid', () => {
   it('should have row height', async() => {
     const rowHeight = 60;
     await setup({ attributes: {
-      columns: [{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }],
+      columns: [{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }],
       rowHeight,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]),
     } });
     const rows = await table?.findAll('.tabulator-row');
     const isAllRowHasHeight = await rows?.every(async(row) => {
@@ -186,23 +186,23 @@ describe('e2e:osds-datagrid', () => {
 
   it('should not display hideablecolumns', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       hasHideableColumns: false,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
     } });
     const columns = await table?.findAll('.tabulator-col');
     expect(columns).toHaveLength(2);
-    expect(columns?.[0].innerText).toContain('Name');
-    expect(columns?.[1].innerText).toContain('Firstname');
+    expect(columns?.[0].innerText).toContain('First name');
+    expect(columns?.[1].innerText).toContain('Last name');
   });
 
   it('should update rows', async() => {
     await setup({ attributes: {
-      columns: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+      columns: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
       hasHideableColumns: false,
-      rows: JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }]),
+      rows: JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }]),
     } });
-    el.setProperty('rows', JSON.stringify([{ firstname: 'Simpson', name: 'Homer' }, { firstname: 'Simpson', name: 'Marge' }]));
+    el.setProperty('rows', JSON.stringify([{ lastname: 'Simpson', firstname: 'Homer' }, { lastname: 'Simpson', firstname: 'Marge' }]));
     await page.waitForChanges();
 
     const rows = JSON.parse(await el.getProperty('rows'));

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.scss
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.scss
@@ -82,6 +82,7 @@ $ods-border-datagrid: solid 1px var(--ods-color-blue-200);
             box-sizing: border-box;
             border-top: $ods-border-datagrid;
             border-right: none;
+            overflow: visible;
 
             &:not(.ods-selectable__input-checkbox) {
                 position: initial;

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.spec.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.spec.ts
@@ -45,7 +45,7 @@ describe('spec:osds-datagrid', () => {
       odsUnitTestAttribute<OdsDatagridAttribute, 'columns'>({
         defaultValue: DEFAULT_ATTRIBUTE.columns,
         name: 'columns',
-        newValue: JSON.stringify([{ field: 'name', title: 'Name' }, { field: 'firstname', title: 'Firstname' }]),
+        newValue: JSON.stringify([{ field: 'firstname', title: 'First name' }, { field: 'lastname', title: 'Last name' }]),
         setup: (value) => setup({ attributes: { ['columns']: value } }),
         value: '[]',
         ...config,
@@ -57,7 +57,7 @@ describe('spec:osds-datagrid', () => {
       odsUnitTestAttribute<OdsDatagridAttribute, 'rows'>({
         defaultValue: DEFAULT_ATTRIBUTE.rows,
         name: 'rows',
-        newValue: JSON.stringify([{ firstname: 'Homer', name: 'Simpson' }]),
+        newValue: JSON.stringify([{ lastname: 'Homer', firstname: 'Simpson' }]),
         setup: (value) => setup({ attributes: { ['rows']: value } }),
         value: '[]',
         ...config,
@@ -80,7 +80,7 @@ describe('spec:osds-datagrid', () => {
       odsUnitTestAttribute<OdsDatagridAttribute, 'noResultLabel'>({
         defaultValue: DEFAULT_ATTRIBUTE.noResultLabel,
         name: 'noResultLabel',
-        newValue: 'Aucune données de renseignée',
+        newValue: 'No data.',
         setup: (value) => setup({ attributes: { ['noResultLabel']: value } }),
         value: '',
         ...config,

--- a/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.spec.ts
+++ b/packages/components/datagrid/src/components/osds-datagrid/osds-datagrid.spec.ts
@@ -57,7 +57,7 @@ describe('spec:osds-datagrid', () => {
       odsUnitTestAttribute<OdsDatagridAttribute, 'rows'>({
         defaultValue: DEFAULT_ATTRIBUTE.rows,
         name: 'rows',
-        newValue: JSON.stringify([{ lastname: 'Homer', firstname: 'Simpson' }]),
+        newValue: JSON.stringify([{ firstname: 'Homer', lastname: 'Simpson' }]),
         setup: (value) => setup({ attributes: { ['rows']: value } }),
         value: '[]',
         ...config,

--- a/packages/components/datagrid/src/index.html
+++ b/packages/components/datagrid/src/index.html
@@ -15,15 +15,6 @@
   <script type='module' src='/build/osds-datagrid.esm.js'></script>
   <script nomodule src='/build/osds-datagrid.js'></script>
   <link rel="stylesheet" href="/build/osds-datagrid.css">
-
-  <style>
-    :root {
-      --ods-menu-position: static;
-      --ods-select-position: static;
-      --ods-popover-position: static;
-      --ods-tooltip-position: static;
-    }
-  </style>
 </head>
 <body>
   <osds-datagrid id="datagridFormatter" is-selectable height="400"></osds-datagrid>
@@ -32,16 +23,16 @@
   <h1>With sorted column</h1>
   <osds-datagrid
     id="datagridFormatter"
-    columns='[{"title":"Name", "field":"name", "isSortable": true}, {"title":"Firstname", "field":"firstname", "isSortable": true}, {"title":"Gender", "field":"gender"}]'
-    rows='[{"name":"Homer", "firstname":"Simpson", "gender": "Male"}, {"name":"Marge", "firstname":"Simpson", "gender": "Female"}]'
+    columns='[{"title":"First name", "field":"firstname", "isSortable": true}, {"title":"Last name", "field":"lastname", "isSortable": true}, {"title":"Gender", "field":"gender"}]'
+    rows='[{"firstname":"Homer", "lastname":"Simpson", "gender": "Male"}, {"firstname":"Marge", "lastname":"Simpson", "gender": "Female"}]'
     height="300">
   </osds-datagrid>
 
   <h1>With selectable columns</h1>
   <osds-datagrid
     is-selectable
-    columns='[{"title":"Name", "field":"name"}, {"title":"Firstname", "field":"firstname"}]'
-    rows='[{"name":"Homer", "firstname":"Simpson"}, {"name":"Marge", "firstname":"Simpson"}]'
+    columns='[{"title":"First name", "field":"firstname"}, {"title":"Last name", "field":"lastname"}]'
+    rows='[{"firstname":"Homer", "lastname":"Simpson"}, {"firstname":"Marge", "lastname":"Simpson"}]'
     height="300">
   </osds-datagrid>
 
@@ -50,13 +41,13 @@
     has-hideable-columns="false"
     id="largeDatagrid"
     is-selectable="false"
-    columns='[{"title":"Name", "field":"name"}, {"title":"Firstname", "field":"firstname"}]'
+    columns='[{"title":"First name", "field":"firstname"}, {"title":"Last name", "field":"lastname"}]'
     height="300">
   </osds-datagrid>
 
   <h1>Empty state</h1>
   <osds-datagrid
-    columns='[{"title":"Name", "field":"name", "isSortable": true}, {"title":"Firstname", "field":"firstname"}]'
+    columns='[{"title":"First name", "field":"firstname", "isSortable": true}, {"title":"Last name", "field":"lastname"}]'
     rows='[]'
     no-result-label="Aucune données de renseignée"
     height="100">
@@ -67,10 +58,10 @@
     const button = document.getElementById('buttonDatagrid');
     button.addEventListener('click', () => {
       datagrid.rows = [{
-        firstname: `firstname1`,
+        lastname: `lastname1`,
         name: `name1`,
       }, {
-        firstname: `firstname2`,
+        lastname: `lastname2`,
         name: `name2`,
       }];
     });
@@ -78,7 +69,7 @@
     datagrid.addEventListener('odsRowSelectedChange', (data) => console.log('odsRowSelectedChange', data))
 
     datagrid.columns = [
-      { title: "Name", field: "name", formatter: (cellValue, rowValue) => {
+      { title: "First name", field: "firstname", formatter: (cellValue, rowValue) => {
           return `<osds-menu>
 <osds-button slot="menu-title" color="primary" variant="stroked">
   Action menu
@@ -98,11 +89,26 @@
 </osds-menu>`
         }
       },
-      { title: "Firstname", field: "firstname", isSortable: true },
+      { title: "Test", field: "test", formatter: (cellValue, rowValue) => {
+        return `<osds-menu>
+    <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+    <osds-menu-group>
+      <osds-text>Group/Text 1</osds-text>
+    </osds-menu-group>
+    <osds-menu-item>
+      <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 1</span></osds-button>
+    </osds-menu-item>
+    <osds-menu-item>
+      <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
+    </osds-menu-item>
+    <osds-divider color="text" separator="true"></osds-divider>
+  </osds-menu>`}
+      },
+      { title: "Last name", field: "lastname", isSortable: true },
       { title: "Gender", field: "gender", isSortable: true },
       { title: "Date Of Birth", field: "dob", isSortable: true },
     ];
-    datagrid.rows = Array.from({ length: 5 }).fill({ name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" });
+    datagrid.rows = Array.from({ length: 11 }).fill({ name: "Garnbret", lastname: "Janja", gender: "female", dob: "12/03/1999" });
     // datagrid.hideableColumns = ['name', 'gender'];
 
     const largeDatagrid = document.getElementById('largeDatagrid');
@@ -110,7 +116,7 @@
 
     for (let i = 0; i < 100; i++) {
       rows.push({
-        firstname: `firstname-${i}`,
+        lastname: `lastname-${i}`,
         name: `name${i}`,
       });
     }

--- a/packages/storybook/stories/components/datagrid/4_demo.stories.ts
+++ b/packages/storybook/stories/components/datagrid/4_demo.stories.ts
@@ -1,64 +1,79 @@
-import { html } from 'lit-html';
-import { defineCustomElements } from '@ovhcloud/ods-components/datagrid/loader';
-import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
 // @ts-ignore
 import changelog from '@ovhcloud/ods-components/datagrid/CHANGELOG.md';
+import { defineCustomElements } from '@ovhcloud/ods-components/datagrid/loader';
+import { html } from 'lit-html';
 // @ts-ignore
 import page from './2_usage.stories.mdx';
+import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
 
 defineCustomElements();
 
 /* Default story parameters */
 const defaultStoryParams = {
   columns: {
-    category: 'Général',
+    category: 'General',
     defaultValue: [
-      { title: "Name", field: "name", isSortable: true },
-      { title: "Firstname", field: "firstname" },
-      { title: "Gender", field: "gender" },
-      { title: "Date Of Birth", field: "dob", formatter: (value: string) => {
-        return `<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400">${value}</osds-text>` 
+      { field: 'firstname', title: 'First name' },
+      { field: 'lastname', isSortable: true, title: 'Last name' },
+      { field: 'gender', title: 'Gender' },
+      { field: 'dob', title: 'Date Of Birth', formatter: (value: string) => {
+        return `<osds-icon name="calendar"></osds-icon> <osds-text color="text" size="400">${value}</osds-text>`;
+      } },
+      { field: 'test', title: 'Button', formatter: () => {
+        return `<osds-menu>
+    <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+    <osds-menu-group>
+      <osds-text>Group/Text 1</osds-text>
+    </osds-menu-group>
+    <osds-menu-item>
+      <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 1</span></osds-button>
+    </osds-menu-item>
+    <osds-menu-item>
+      <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
+    </osds-menu-item>
+    <osds-divider color="text" separator="true"></osds-divider>
+  </osds-menu>`;
       } },
     ],
   },
-  rows: {
-    category: 'Général',
-    defaultValue: [
-      { name: "Dupont", firstname: "Antoine", gender: "male", dob: "15/11/1996" },
-      { name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" },
-    ],
+  hasHideableColumns: {
+    category: 'General',
+    defaultValue: true,
+  },
+  height: {
+    category: 'General',
+    defaultValue: 600,
   },
   isSelectable: {
-    category: 'Général',
+    category: 'General',
     defaultValue: false,
   },
   noResultLabel: {
-    category: 'Général',
+    category: 'General',
     defaultValue: 'Aucun résultat',
   },
-  height: {
-    category: 'Général',
-    defaultValue: 600,
-  },
   rowHeight: {
-    category: 'Général',
+    category: 'General',
     defaultValue: 52,
   },
-  hasHideableColumns: {
-    category: 'Général',
-    defaultValue: true,
+  rows: {
+    category: 'General',
+    defaultValue: [
+      { dob: '15/11/1996', firstname: 'Antoine', gender: 'male', lastname: 'Dupont' },
+      { dob: '12/03/1999', firstname: 'Janja', gender: 'female', lastname: 'Garnbret' },
+    ],
   },
 };
 
 const rowsLarge = {
-  category: 'Général',
-  defaultValue: Array.from({ length: 10000 }).fill({ name: "Garnbret", firstname: "Janja", gender: "female", dob: "12/03/1999" }),
+  category: 'General',
+  defaultValue: Array.from({ length: 10000 }).fill({ dob: '12/03/1999', firstname: 'Janja', gender: 'female', lastname: 'Garnbret' }),
 };
 
 export default {
-  title: 'ODS Components/Layout/Datagrid [organism]/Web Component',
+  argTypes: extractArgTypes(defaultStoryParams),
   id: 'datagrid',
-  argTypes: extractArgTypes(defaultStoryParams)
+  title: 'ODS Components/Layout/Datagrid [organism]/Web Component',
 };
 
 const TemplateDefault = (args: Record<string, unknown>) => html`


### PR DESCRIPTION
If the `OsdsDatagrid` contains an overflowing on-interaction element (such as `OsdsMenu`, `OsdsTooltip`, `OsdsSelect` or `OsdsPopover`), the element is either being displayed at the top left corner of the `OsdsDatagrid` _(native)_ or beneath the element, making it `unvisible` _(React)_.

This fix intends to correct this problem in both environments.