### PR TITLE
docs(datagrid): update reactFormatter to fit React 18

### DIFF
--- a/packages/components/src/datagrid/documentation/usage-guidelines/usage-react.mdx
+++ b/packages/components/src/datagrid/documentation/usage-guidelines/usage-react.mdx
@@ -1,8 +1,12 @@
 ## Usage React
 
+When implementing the OsdsDatagrid component in React, you will also probably want to implement components inside your cells.
+
+This is made possible by using a reactFormatter inside the columns section, as shown below.
+
 ```jsx
 import React, { useRef } from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { OsdsDatagrid } from '@ovhcloud/ods-components/datagrid/react';
 import { OsdsButton } from '@ovhcloud/ods-components/button/react';
 import { OsdsText } from '@ovhcloud/ods-components/text/react';
@@ -10,63 +14,71 @@ import { OsdsText } from '@ovhcloud/ods-components/text/react';
 import '@ovhcloud/ods-theme-blue-jeans';
 
 const App = () => {
-    function SimpleButton(props) {
-        return <OsdsButton onClick={() => {
-            alert(props.rowData.name)
-        }}>{ props.cellData }</OsdsButton>;
-    }
+  const roots = new Map();
 
-    function SimpleText(props) {
-        return <OsdsText onClick={() => alert(props.rowData.firstname)}>{ props.cellData }</OsdsText>;
-    }
+  const SimpleButton = (props) => (
+    <OsdsButton onClick={() => alert(props.rowData.name)}>
+      {props.cellData}
+    </OsdsButton>
+  );
 
-    function reactFormatter(JSX) {
-        return function customFormatter(cellData, rowData, cell, onRendered) {
-          const renderFn = () => {
-            const cellEl = cell.getElement();
-            if (cellEl) {
-              const formatterCell = cellEl.querySelector('.formatterCell');
-              if (formatterCell) {
-                const CompWithMoreProps = React.cloneElement(JSX, { cellData, rowData });
-                render(CompWithMoreProps, cellEl.querySelector('.formatterCell'));
-              }
-            }
-          };
-      
-          onRendered(renderFn); // initial render only.
-      
-          setTimeout(() => {
-            renderFn(); // render every time cell value changed.
-          }, 0);
-          return '<div class="formatterCell"></div>';
-        };
-    }
+  const SimpleText = (props) => (
+    <OsdsText onClick={() => alert(props.rowData.firstname)}>
+      {props.cellData}
+    </OsdsText>
+  );
 
-    const columns = [
-        { title: 'Name', field: 'name', width: 150 },
-        { title: 'Firstname', field: 'firstname', formatter: reactFormatter(<SimpleText></SimpleText>) },
-        { title: 'Custom', field: 'custom', formatter: reactFormatter(<SimpleButton></SimpleButton>) }
-    ];
+  const reactFormatter = (JSX) => (cellData, rowData, cell, onRendered) => {
+    const renderFn = () => {
+      const cellEl = cell.getElement();
+      if (cellEl) {
+        const formatterCell = cellEl.querySelector('.formatterCell');
+        if (formatterCell) {
+          const CompWithMoreProps = React.cloneElement(JSX, { cellData, rowData });
 
-    const rows = [
-        { name: "Homer", firstname: "Simpson", custom: 'test' }, 
-        { name: "Marge", firstname: "Simpson", custom: 'test' }
-    ];
-   
-    return (
-        <div>
-            <OsdsDatagrid
-                has-hideable-columns="false"
-                id="largeDatagrid"
-                is-selectable="false"
-                columns={columns}
-                rows={rows}
-                height="300">
-            </OsdsDatagrid>
-        </div>
-    )
+          let root = roots.get(formatterCell);
+          if (!root) {
+            root = createRoot(formatterCell);
+            roots.set(formatterCell, root);
+          }
+
+          root.render(CompWithMoreProps);
+        }
+      }
+    };
+
+    onRendered(renderFn);
+
+    setTimeout(() => {
+      renderFn();
+    }, 0);
+    return '<div class="formatterCell"></div>';
+  };
+
+  const columns = [
+    { title: 'Name', field: 'name', width: 150 },
+    { title: 'Firstname', field: 'firstname', formatter: reactFormatter(<SimpleText></SimpleText>) },
+    { title: 'Custom', field: 'custom', formatter: reactFormatter(<SimpleButton></SimpleButton>) }
+  ];
+
+  const rows = [
+    { name: "Homer", firstname: "Simpson", custom: 'test' },
+    { name: "Marge", firstname: "Simpson", custom: 'test' }
+  ];
+
+  return (
+    <div>
+      <OsdsDatagrid
+        has-hideable-columns="false"
+        id="largeDatagrid"
+        is-selectable="false"
+        columns={columns}
+        rows={rows}
+        height="300">
+      </OsdsDatagrid>
+    </div>
+  );
 }
 
-export { App }
-
+export default App;
 ```


### PR DESCRIPTION
- This update intends to fix `ReactDOM.render is no longer supported in React 18` error that was displayed several times while initiating the `OsdsDatagrid` component in React.
- The new documentation for React now uses `createRoot` which is encouraged in React 18.
- Other errors / logs supposedly covered by this branch were due to wrong usage.