### PR TITLE
fix(core): config version

### DIFF
--- a/packages/common/core/src/version.ts
+++ b/packages/common/core/src/version.ts
@@ -1,2 +1,2 @@
 // replaced on built file
-export const VERSION = '9.0.3';
+export const VERSION = '{{{VERSION}}}';


### PR DESCRIPTION
Now in the navigator `window.ods.version` is the current version
The script `yarn build:prod` also run `./scripts/generate-ods-version.js` and this script update the version in the dist files `/version`