### PR TITLE
fix(doc): rm useless slotting in menu usage

### DIFF
--- a/packages/components/src/menu/documentation/usage-guidelines/usage.mdx
+++ b/packages/components/src/menu/documentation/usage-guidelines/usage.mdx
@@ -12,29 +12,29 @@ import GenericStyle from '@ovhcloud/ods-common-core/docs/generic-style.mdx';
 ```
 
 <osds-menu>
-  <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+  <osds-button slot='menu-title' color='primary' variant='stroked'>Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
   <osds-menu-group>
     <osds-text>Group Text</osds-text>
   </osds-menu-group>
   <osds-menu-item>
-    <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 1</span></osds-button>
+    <osds-button color='primary' size='sm' variant='ghost' text-align='start' flex><span>Action 1</span></osds-button>
   </osds-menu-item>
   <osds-menu-item>
-    <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
+    <osds-button color='primary' size='sm' variant='ghost' text-align='start' flex><span>Action 2</span></osds-button>
   </osds-menu-item>
 </osds-menu>
 
 ```html
 <osds-menu>
-  <osds-button slot="menu-title" color="primary" variant="stroked">Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+  <osds-button slot='menu-title' color='primary' variant='stroked'>Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
   <osds-menu-group>
     <osds-text>Group Text</osds-text>
   </osds-menu-group>
   <osds-menu-item>
-    <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 1</span></osds-button>
+    <osds-button color='primary' size='sm' variant='ghost' text-align='start' flex><span>Action 1</span></osds-button>
   </osds-menu-item>
   <osds-menu-item>
-    <osds-button color="primary" size='sm' variant='ghost' flex><span slot="start">Action 2</span></osds-button>
+    <osds-button color='primary' size='sm' variant='ghost' text-align='start' flex><span>Action 2</span></osds-button>
   </osds-menu-item>
 </osds-menu>
 ```

--- a/packages/storybook/stories/components/menu/3_demo.stories.ts
+++ b/packages/storybook/stories/components/menu/3_demo.stories.ts
@@ -15,7 +15,7 @@ export default {
 /* Default */
 const TemplateDemo = () => html`
   <osds-menu>
-    <osds-button slot='menu-title' color='primary' variant='stroked'>Action menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
+    <osds-button slot='menu-title' color='primary' variant='stroked'>Menu <osds-icon name='home' size='xs'></osds-icon></osds-button>
     <osds-menu-group>
       <osds-text>Group/Text 1</osds-text>
     </osds-menu-group>


### PR DESCRIPTION
Updated Usage Guidelines for Menu (items content should not be in start & end slots)