### PR TITLE
feat(pagination): add odsPaginationItemPerPageChanged on itemPerPage change

### DIFF
--- a/packages/components/src/datagrid/documentation/specifications/spec.md
+++ b/packages/components/src/datagrid/documentation/specifications/spec.md
@@ -9,8 +9,8 @@
 |**`hasHideableColumns`** | _boolean_ |  |  | Can you hide columns|
 |**`height`** | _number_ | ✴️ |  | Height of the datagrid, in pixel|
 |**`hideableColumns`** | string[] |  |  | List of the hide columnsThe key need to be according to the column field|
-|**`isSelectable`** | _boolean_ |  |  | The rows can be selectable|
-|**`noResultLabel`** | _string_ |  |  | Text when the datagrid was no rows|
+|**`isSelectable`** | _boolean_ |  |  | The rows can be selected|
+|**`noResultLabel`** | _string_ |  |  | Text when the datagrid has no rows|
 |**`rowHeight`** | _number_ |  |  | Height for each row, in pixel|
 |**`rows`** | `string` \| `OdsDatagridRow[]` | ✴️ |  | The list of the rowsThe key needs to be according to the column field|
 

--- a/packages/components/src/pagination/documentation/specifications/spec.md
+++ b/packages/components/src/pagination/documentation/specifications/spec.md
@@ -24,6 +24,14 @@
 |Name | Type | Required | Default | Description|
 |---|---|:---:|---|---|
 |**`odsPaginationChanged`** | `EventEmitter<OdsPaginationChangedEventDetail>` | ✴️ |  | Emitted when the value has changed|
+|**`odsPaginationItemPerPageChanged`** | `EventEmitter<OdsPaginationItemPerPageChangedEventDetail>` | ✴️ |  | Emitted when the number of items per page value has changed|
+
+### OdsPaginationItemPerPageChangedEventDetail
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`current`** | _number_ | ✴️ |  | |
+|**`currentPage`** | _number_ | ✴️ |  | |
+|**`totalPages`** | _number_ | ✴️ |  | |
 
 ### OdsPaginationMethod
 |Name | Type | Required | Default | Description|

--- a/packages/components/src/pagination/src/components/osds-pagination/interfaces/events.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/interfaces/events.ts
@@ -8,15 +8,29 @@ interface OdsPaginationChangedEventDetail {
 
 type OdsPaginationCurrentChangeEvent = CustomEvent<OdsPaginationChangedEventDetail>;
 
+interface OdsPaginationItemPerPageChangedEventDetail {
+  current: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+type OdsPaginationItemPerPageChangedEvent = CustomEvent<OdsPaginationItemPerPageChangedEventDetail>;
+
 interface OdsPaginationEvent {
   /**
    * Emitted when the value has changed
    */
   odsPaginationChanged: EventEmitter<OdsPaginationChangedEventDetail>;
+  /**
+   * Emitted when the number of items per page value has changed
+   */
+  odsPaginationItemPerPageChanged: EventEmitter<OdsPaginationItemPerPageChangedEventDetail>;
 }
 
 export {
   OdsPaginationCurrentChangeEvent,
   OdsPaginationChangedEventDetail,
   OdsPaginationEvent,
+  OdsPaginationItemPerPageChangedEvent,
+  OdsPaginationItemPerPageChangedEventDetail,
 };

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -1,14 +1,10 @@
 import type { OdsPaginationAttribute } from './interfaces/attributes';
-import type { OdsPaginationChangedEventDetail } from './interfaces/events';
+import type { OdsPaginationChangedEventDetail, OdsPaginationItemPerPageChangedEventDetail } from './interfaces/events';
 import type { E2EElement, E2EPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { newE2EPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_PAGINATION_PER_PAGE_OPTIONS } from './constants/pagination-per-page';
-
-
 
 describe('e2e:osds-pagination', () => {
   const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
@@ -195,7 +191,7 @@ describe('e2e:osds-pagination', () => {
       expect(current).toEqual(5);
     });
 
-    it('should emit when the attribute changes', async() => {
+    it('should emit when current attribute changes', async() => {
       await setup({ attributes: { current: 2, totalPages: 5 } });
 
       const odsPaginationChanged = await el.spyOnEvent('odsPaginationChanged');
@@ -240,6 +236,26 @@ describe('e2e:osds-pagination', () => {
         .map((el) => el.getAttribute('value'))
         .map((attr) => parseInt(attr, 10));
       expect(selectValues).toEqual(ODS_PAGINATION_PER_PAGE_OPTIONS);
+    });
+
+    it('should emit when the itemPerPage attribute changes', async() => {
+      await setup({ attributes: { current: 2, totalItems: 60 } });
+
+      const odsPaginationItemPerPageChanged = await el.spyOnEvent('odsPaginationItemPerPageChanged');
+
+      perPageSelectElement = await page.find('osds-pagination >>> osds-select');
+      perPageSelectElement.setAttribute('value', 50);
+
+      await page.waitForChanges();
+
+      const expected: OdsPaginationItemPerPageChangedEventDetail = {
+        current: 50,
+        currentPage: 1,
+        totalPages: 2,
+      };
+
+      expect(odsPaginationItemPerPageChanged).toHaveReceivedEventDetail(expected);
+      expect(odsPaginationItemPerPageChanged).toHaveReceivedEventTimes(1);
     });
   });
 

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
@@ -1,13 +1,10 @@
 import type { OdsPaginationAttribute } from './interfaces/attributes';
 import type { SpecPage } from '@stencil/core/testing';
-
 import { OdsMockNativeMethod, odsComponentAttributes2StringAttributes, odsStringAttributes2Str, odsUnitTestAttribute } from '@ovhcloud/ods-common-testing';
 import { newSpecPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_PAGINATION_PER_PAGE_MIN } from './constants/pagination-per-page';
 import { OsdsPagination } from './osds-pagination';
-
 
 describe('spec:osds-pagination', () => {
   const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
@@ -108,12 +105,20 @@ describe('spec:osds-pagination', () => {
   });
 
   describe('odsValueChangeHandler', () => {
+    const mockEvent = {
+      detail: {},
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    }
+
     it('should do nothing if event does not have a value', async() => {
       await setup({ attributes: { disabled: false, current: 2, totalItems: 200 } });
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
-      await instance.odsValueChangeHandler({ detail: {} });
+      await instance.odsValueChangeHandler(mockEvent);
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockEvent.stopPropagation).toHaveBeenCalled();
       expect(instance.itemPerPage).toBe(10);
     });
 
@@ -123,11 +128,11 @@ describe('spec:osds-pagination', () => {
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
-      await instance.odsValueChangeHandler({ detail: { value: dummyValue } });
+      await instance.odsValueChangeHandler({ ...mockEvent, detail: { value: dummyValue } });
       expect(instance.itemPerPage).toBe(dummyValue);
 
       // @ts-ignore for test purpose
-      await instance.odsValueChangeHandler({ detail: { value: dummyValue.toString() } });
+      await instance.odsValueChangeHandler({ ...mockEvent, detail: { value: dummyValue.toString() } });
       expect(instance.itemPerPage).toBe(dummyValue);
     });
   });

--- a/packages/components/src/pagination/src/components/osds-pagination/public-api.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/public-api.ts
@@ -1,5 +1,11 @@
 export type { OdsPaginationAttribute } from './interfaces/attributes';
-export type { OdsPaginationCurrentChangeEvent, OdsPaginationChangedEventDetail, OdsPaginationEvent } from './interfaces/events';
+export type {
+  OdsPaginationCurrentChangeEvent,
+  OdsPaginationChangedEventDetail,
+  OdsPaginationEvent,
+  OdsPaginationItemPerPageChangedEvent,
+  OdsPaginationItemPerPageChangedEventDetail,
+} from './interfaces/events';
 export type { OdsPaginationMethod } from './interfaces/methods';
 export { ODS_PAGINATION_PER_PAGE_MAX, ODS_PAGINATION_PER_PAGE_MIN, ODS_PAGINATION_PER_PAGE_OPTIONS } from './constants/pagination-per-page';
 export { ODS_PAGINATION_SIZE, ODS_PAGINATION_SIZES } from './constants/pagination-size';

--- a/packages/components/src/pagination/src/index.html
+++ b/packages/components/src/pagination/src/index.html
@@ -123,14 +123,13 @@
         console.log('changeLabelTooltip for', p.id);
         p.labelTooltipPrevious = 'Previous';
         p.labelTooltipNext = 'NextNextNextNextNextNextNextNext';
-      }, 5000); 
+      }, 5000);
     }
     const paginationEditLabel = document.querySelector('#paginationEditLabel');
     changeLabelTooltip(paginationEditLabel);
 
     const paginationAddLabel = document.querySelector('#paginationAddLabel');
     changeLabelTooltip(paginationAddLabel);
-   
   </script>
 </body>
 </html>

--- a/packages/components/src/skeleton/documentation/specifications/spec.md
+++ b/packages/components/src/skeleton/documentation/specifications/spec.md
@@ -7,7 +7,7 @@
 |Name | Type | Required | Default | Description|
 |---|---|:---:|---|---|
 |**`inline`** | _boolean_ |  |  | inline or not: see component principles|
-|**`randomized`** | _boolean_ |  |  | wether or not skeleton size is randomized|
+|**`randomized`** | _boolean_ |  |  | whether or not skeleton size is randomized|
 |**`size`** | `ODS_SKELETON_SIZE` |  |  | skeleton size|
 
 ## Types


### PR DESCRIPTION
Trigger a `odsPaginationItemPerPageChanged` event on `itemPerPage` select change, with the following payload:
```
current: 10 // new select value
currentPage: 1 // new page after change
totalPages: 6 // new number of pages after change
```

This replace the ods event triggered by the internal `ods-select` component