### PR TITLE
fix(checkbox-radio-buttons): fix slots display to align smaller texts vertically

### DIFF
--- a/packages/components/src/checkbox-button/src/components/osds-checkbox-button/osds-checkbox-button.scss
+++ b/packages/components/src/checkbox-button/src/components/osds-checkbox-button/osds-checkbox-button.scss
@@ -14,6 +14,10 @@
   cursor: pointer;
   width: fit-content;
 
+  > ::slotted(span) {
+    display: grid;
+  }
+
   .checkbox-button {
     border-style: solid;
     border-radius: var(--ods-size-border-radius-01);
@@ -39,11 +43,6 @@
     opacity: 0.5;
     cursor: not-allowed;
   }
-}
-
-
-slot {
-  display: block;
 }
 
 // apply the theme template for the component

--- a/packages/components/src/radio-button/src/components/osds-radio-button/osds-radio-button.scss
+++ b/packages/components/src/radio-button/src/components/osds-radio-button/osds-radio-button.scss
@@ -13,6 +13,10 @@
   align-items: center;
   width: fit-content;
 
+  > ::slotted(span) {
+    display: grid;
+  }
+
   .radio-button {
     position:relative;
     border-style: solid;
@@ -42,10 +46,6 @@
   @include osds-radio-button-on-main-element {
     cursor: not-allowed;
   }
-}
-
-slot {
-  display: block;
 }
 
 // apply the theme template for the component


### PR DESCRIPTION
Added `display: grid;` to first level slots of radio-button and checkbox-button components.

<img width="200" alt="Capture d’écran 2024-01-04 à 19 11 37" src="https://github.com/ovh/design-system/assets/6471771/c39409c4-2807-4362-9069-6e6703411c2a">

*Example already working as expected with slot containing text component in `font-size: 16px`*

<img width="199" alt="Capture d’écran 2024-01-04 à 19 13 58" src="https://github.com/ovh/design-system/assets/6471771/31157b48-0e49-4cdd-be62-709c93692d05">

*Example with slot containing text component in `font-size: 12px` **before** fix*


<img width="176" alt="Capture d’écran 2024-01-04 à 19 10 42" src="https://github.com/ovh/design-system/assets/6471771/5701dbfa-a901-4562-8be2-588c0ee63839">

*Example with slot containing text component in `font-size: 12px` **after** fix*

Manually tested on Chromium, Firefox, Safari, in Storybook.
