### PR TITLE
fix(pagination): Component goes out of bounds

### DIFF
--- a/packages/components/src/pagination/package.json
+++ b/packages/components/src/pagination/package.json
@@ -18,7 +18,7 @@
     "doc:api": "typedoc",
     "generate:licence": "npx generate-license-file --input package.json --output THIRD-PARTY-LICENCES --overwrite",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
-    "FIXME_lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
+    "lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
     "start": "stencil build --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",

--- a/packages/components/src/pagination/src/components/osds-pagination/core/controller.spec.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/core/controller.spec.ts
@@ -1,11 +1,9 @@
 import type { OdsPaginationPageList } from '../interfaces/attributes';
-
+import type { OdsLoggerSpyReferences } from '@ovhcloud/ods-common-testing';
 import { OdsLogger } from '@ovhcloud/ods-common-core';
-import { OdsClearLoggerSpy, OdsInitializeLoggerSpy, OdsLoggerSpyReferences } from '@ovhcloud/ods-common-testing';
-
+import { OdsClearLoggerSpy, OdsInitializeLoggerSpy } from '@ovhcloud/ods-common-testing';
 import { OdsPaginationController } from './controller';
 import { OsdsPagination } from '../osds-pagination';
-
 
 class OdsPaginationMock extends OsdsPagination {
   constructor(attribute: Partial<OsdsPagination>) {
@@ -19,7 +17,7 @@ describe('spec:ods-pagination-controller', () => {
   let component: OsdsPagination;
   let loggerSpyReferences: OdsLoggerSpyReferences;
 
-  function setup(attributes: Partial<OsdsPagination> = {}) {
+  function setup(attributes: Partial<OsdsPagination> = {}): void {
     component = new OdsPaginationMock(attributes);
     controller = new OdsPaginationController(component);
   }
@@ -43,26 +41,26 @@ describe('spec:ods-pagination-controller', () => {
 
       it('should return totalPages if totalItems is not defined', () => {
         const dummyTotalPages = 8;
-        setup({ disabled: false, current: 2, totalPages: dummyTotalPages });
+        setup({ current: 2, disabled: false, totalPages: dummyTotalPages });
 
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(dummyTotalPages);
       });
 
       it('should return the correct amount of pages if totalItems is defined', () => {
-        setup({ disabled: false, current: 2, totalItems: 33, totalPages: 1 });
+        setup({ current: 2, disabled: false, totalItems: 33, totalPages: 1 });
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(4);
 
-        setup({ disabled: false, current: 2, totalItems: 9, totalPages: 1 });
+        setup({ current: 2, disabled: false, totalItems: 9, totalPages: 1 });
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(1);
 
-        setup({ disabled: false, current: 2, totalItems: 9, totalPages: 1 });
+        setup({ current: 2, disabled: false, totalItems: 9, totalPages: 1 });
         expect(controller.computeActualTotalPages(0)).toBe(9);
       });
     });
 
     describe('createPageList', () => {
       it('should generate the correct number of pages', () => {
-        setup({ disabled: false, current: 2, totalPages: 8 });
+        setup({ current: 2, disabled: false, totalPages: 8 });
 
         const pageList = controller.createPageList(component.totalPages, component.current);
 
@@ -70,7 +68,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should generate the correct page list', () => {
-        setup({ disabled: false, current: 2, totalPages: 9 });
+        setup({ current: 2, disabled: false, totalPages: 9 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -78,7 +76,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 5', () => {
-        setup({ disabled: false, current: 5, totalPages: 12 });
+        setup({ current: 5, disabled: false, totalPages: 12 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -98,7 +96,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 2', () => {
-        setup({ disabled: false, current: 2, totalPages: 9 });
+        setup({ current: 2, disabled: false, totalPages: 9 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -115,7 +113,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 3', () => {
-        setup({ disabled: false, current: 3, totalPages: 9 });
+        setup({ current: 3, disabled: false, totalPages: 9 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -132,7 +130,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 4', () => {
-        setup({ disabled: false, current: 4, totalPages: 9 });
+        setup({ current: 4, disabled: false, totalPages: 9 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -149,7 +147,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('all pages should be active if there are 5 pages', () => {
-        setup({ disabled: false, current: 4, totalPages: 5 });
+        setup({ current: 4, disabled: false, totalPages: 5 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -162,7 +160,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the last 5 pages if page 9 on 9 is selected', () => {
-        setup({ disabled: false, current: 9, totalPages: 9 });
+        setup({ current: 9, disabled: false, totalPages: 9 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
 
@@ -179,7 +177,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('set page to 5 with setPageIndex', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
         expect(component.current).toBe(10);
 
         controller.setPageIndex(5);
@@ -187,30 +185,30 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('handlePreviousKeyDown', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
         expect(component.current).toBe(10);
 
-        const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+        const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
         controller.handlePreviousKeyDown(event, component.current);
         expect(component.current).toBe(9);
       });
 
       it('handlePageKeyDown', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
 
         const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
         expect(component.current).toBe(10);
 
-        const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+        const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
         controller.handleNextKeyDown(event, component.current, pageList);
         expect(component.current).toBe(11);
       });
 
       it('handlePageKeyDown on page 5', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
         expect(component.current).toBe(10);
 
-        const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+        const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
 
         controller.handlePageKeyDown(event, 6);
         expect(component.current).toBe(6);
@@ -229,7 +227,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('handlePreviousClick', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
 
         expect(component.current).toBe(10);
         controller.handlePreviousClick(component.current);
@@ -239,7 +237,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('handleNextClick', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
 
         expect(component.current).toBe(10);
         controller.handleNextClick(component.current);
@@ -249,7 +247,7 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('handlePageClick', () => {
-        setup({ disabled: false, current: 10, totalPages: 12 });
+        setup({ current: 10, disabled: false, totalPages: 12 });
 
         expect(component.current).toBe(10);
         controller.handlePageClick(1);

--- a/packages/components/src/pagination/src/components/osds-pagination/core/controller.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/core/controller.ts
@@ -13,7 +13,7 @@ class OdsPaginationController {
    * @param itemPerPage - Number of item per page.
    * @returns The number of pages.
    */
-  computeActualTotalPages(itemPerPage: number) {
+  computeActualTotalPages(itemPerPage: number): number {
     if (!this.component.totalItems) {
       return this.component.totalPages;
     }
@@ -27,7 +27,7 @@ class OdsPaginationController {
     @param pageSelected - Selected page number.
     @returns An array of objects representing pages with an array of the size of the number of pages and 'active' (displayed page) properties.
   */
-  createPageList(totalPages: number, pageSelected: number) {
+  createPageList(totalPages: number, pageSelected: number): OdsPaginationPageList {
     const pageList: OdsPaginationPageList = [];
 
     // Create initial pageList with 'active' property set to false for each page.
@@ -77,37 +77,37 @@ class OdsPaginationController {
 
   // click events
 
-  handlePreviousClick(page: number) {
+  handlePreviousClick(page: number): void {
     this.setPageIndex(page - 1);
   }
 
-  handleNextClick(page: number) {
+  handleNextClick(page: number): void {
     this.setPageIndex(page + 1);
   }
 
-  handlePageClick(page: number) {
+  handlePageClick(page: number): void {
     this.setPageIndex(page);
   }
 
   // key events
 
-  handlePreviousKeyDown(event: KeyboardEvent, page: number) {
+  handlePreviousKeyDown(event: KeyboardEvent, page: number): void {
     if (this.component.current > 1) {
       this.onKeyDown(event, page - 1);
     }
   }
 
-  handleNextKeyDown(event: KeyboardEvent, page: number, pageList: OdsPaginationPageList) {
+  handleNextKeyDown(event: KeyboardEvent, page: number, pageList: OdsPaginationPageList): void {
     if (this.component.current < pageList.length) {
       this.onKeyDown(event, page + 1);
     }
   }
 
-  handlePageKeyDown(event: KeyboardEvent, page: number) {
+  handlePageKeyDown(event: KeyboardEvent, page: number): void {
     this.onKeyDown(event, page);
   }
 
-  onKeyDown(event: KeyboardEvent, page: number) {
+  onKeyDown(event: KeyboardEvent, page: number): void {
     if (event.code === 'Enter' || event.code === 'Space') {
       event.preventDefault(); // to avoid space scrolling the page
       this.setPageIndex(page);
@@ -115,7 +115,7 @@ class OdsPaginationController {
   }
 
   // setPageIndex set the page
-  setPageIndex(current: number) {
+  setPageIndex(current: number): void {
     this.component.current = current;
   }
 }

--- a/packages/components/src/pagination/src/components/osds-pagination/interfaces/attributes.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/interfaces/attributes.ts
@@ -32,7 +32,7 @@ interface OdsPaginationAttribute {
   totalPages: number;
 }
 
-export {
+export type {
   OdsPaginationAttribute,
   OdsPaginationPageList,
 };

--- a/packages/components/src/pagination/src/components/osds-pagination/interfaces/events.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/interfaces/events.ts
@@ -27,7 +27,7 @@ interface OdsPaginationEvent {
   odsPaginationItemPerPageChanged: EventEmitter<OdsPaginationItemPerPageChangedEventDetail>;
 }
 
-export {
+export type {
   OdsPaginationCurrentChangeEvent,
   OdsPaginationChangedEventDetail,
   OdsPaginationEvent,

--- a/packages/components/src/pagination/src/components/osds-pagination/interfaces/methods.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/interfaces/methods.ts
@@ -5,6 +5,6 @@ interface OdsPaginationMethod {
   setPageIndex(value: number): Promise<void>;
 }
 
-export {
+export type {
   OdsPaginationMethod,
 };

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.screenshot.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.screenshot.ts
@@ -1,17 +1,14 @@
 import type { OdsPaginationAttribute } from './interfaces/attributes';
 import type { E2EPage } from '@stencil/core/testing';
-
 import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
 import { newE2EPage } from '@stencil/core/testing';
-
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
-
 
 describe('e2e:osds-pagination', () => {
   const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
   let page: E2EPage;
 
-  async function setup({ attributes = { totalPages: 21, current: 5 }, html = '' }: { attributes?: Partial<OdsPaginationAttribute>; html?: string } = {}) {
+  async function setup({ attributes = { current: 5, totalPages: 21 }, html = '' }: { attributes?: Partial<OdsPaginationAttribute>; html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsPaginationAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
 
     page = await newE2EPage();
@@ -27,11 +24,11 @@ describe('e2e:osds-pagination', () => {
     for (let current = 1; current <= 21; current++) {
       const screenshotActions = [
         {
+          action: (): void => {},
           actionDescription: `page ${current} on 21`,
-          action: () => {},
         },
       ];
-      screenshotActions.forEach(({ actionDescription, action }) => {
+      screenshotActions.forEach(({ action, actionDescription }) => {
         it(actionDescription, async() => {
           await setup({
             attributes: {
@@ -44,9 +41,9 @@ describe('e2e:osds-pagination', () => {
 
           await page.evaluate(() => {
             const element = document.querySelector('osds-pagination') as HTMLElement;
-            return { width: element.clientWidth, height: element.clientHeight };
+            return { height: element.clientHeight, width: element.clientWidth };
           });
-          await page.setViewport({ width: 600, height: 600 });
+          await page.setViewport({ height: 600, width: 600 });
           const results = await page.compareScreenshot('pagination', { fullPage: false, omitBackground: true });
           expect(results).toMatchScreenshot({ allowableMismatchedRatio: 0 });
         });
@@ -58,8 +55,8 @@ describe('e2e:osds-pagination', () => {
     for (let current = 1; current <= 21; current++) {
       const screenshotActions = [
         {
+          action: (): void => {},
           actionDescription: `page ${current} on 21 and disabled`,
-          action: () => {},
         },
       ];
       screenshotActions.forEach(({ actionDescription, action }) => {
@@ -67,8 +64,8 @@ describe('e2e:osds-pagination', () => {
           await setup({
             attributes: {
               current,
-              totalPages: 21,
               disabled: true,
+              totalPages: 21,
             },
           });
           action();
@@ -76,9 +73,9 @@ describe('e2e:osds-pagination', () => {
 
           await page.evaluate(() => {
             const element = document.querySelector('osds-pagination') as HTMLElement;
-            return { width: element.clientWidth, height: element.clientHeight };
+            return { height: element.clientHeight, width: element.clientWidth };
           });
-          await page.setViewport({ width: 600, height: 600 });
+          await page.setViewport({ height: 600, width: 600 });
           const results = await page.compareScreenshot('pagination', { fullPage: false, omitBackground: true });
           expect(results).toMatchScreenshot({ allowableMismatchedRatio: 0 });
         });

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -298,5 +298,41 @@ describe('e2e:osds-pagination', () => {
       pageItemElements = await page.findAll('osds-pagination >>> ul > li:not([class="arrows"])');
       expect(pageItemElements.length).toBe(1);
     });
+
+    it('should not allow to go to next page if the current page is the last one', async() => {
+      await setup({ attributes: { current: 2, totalItems: 30 } });
+
+      const allArrows = await page.findAll('osds-pagination >>> .arrows >>> osds-button');
+
+      allArrows[1].click();
+      await page.waitForChanges();
+
+      let current = Number(el.getAttribute('current'));
+      expect(current).toEqual(3);
+
+      allArrows[1].click();
+      await page.waitForChanges();
+
+      current = Number(el.getAttribute('current'));
+      expect(current).toEqual(3);
+    });
+
+    it('should not allow to go to previous page if the current page is the first one', async() => {
+      await setup({ attributes: { current: 2, totalItems: 30 } });
+
+      const allArrows = await page.findAll('osds-pagination >>> .arrows >>> osds-button');
+
+      allArrows[0].click();
+      await page.waitForChanges();
+
+      let current = Number(el.getAttribute('current'));
+      expect(current).toEqual(1);
+
+      allArrows[0].click();
+      await page.waitForChanges();
+
+      current = Number(el.getAttribute('current'));
+      expect(current).toEqual(1);
+    });
   });
 });

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -308,13 +308,13 @@ describe('e2e:osds-pagination', () => {
       await page.waitForChanges();
 
       let current = Number(el.getAttribute('current'));
-      expect(current).toEqual(3);
+      expect(current).toBe(3);
 
       allArrows[1].click();
       await page.waitForChanges();
 
       current = Number(el.getAttribute('current'));
-      expect(current).toEqual(3);
+      expect(current).toBe(3);
     });
 
     it('should not allow to go to previous page if the current page is the first one', async() => {
@@ -326,13 +326,13 @@ describe('e2e:osds-pagination', () => {
       await page.waitForChanges();
 
       let current = Number(el.getAttribute('current'));
-      expect(current).toEqual(1);
+      expect(current).toBe(1);
 
       allArrows[0].click();
       await page.waitForChanges();
 
       current = Number(el.getAttribute('current'));
-      expect(current).toEqual(1);
+      expect(current).toBe(1);
     });
   });
 });

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -12,7 +12,7 @@ describe('e2e:osds-pagination', () => {
   let el: E2EElement;
   let osdsButtonPaginationPageButtonElement: E2EElement;
 
-  async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsPaginationAttribute>, html?: string } = {}) {
+  async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsPaginationAttribute>, html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsPaginationAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
 
     page = await newE2EPage();
@@ -29,7 +29,7 @@ describe('e2e:osds-pagination', () => {
 
   describe('defaults', () => {
     beforeEach(async() => {
-      await setup({ attributes: { totalPages: 10, current: 4 } });
+      await setup({ attributes: { current: 4, totalPages: 10 } });
     });
 
     it('should render', async() => {
@@ -201,9 +201,9 @@ describe('e2e:osds-pagination', () => {
       await page.waitForChanges();
 
       const expected: OdsPaginationChangedEventDetail = {
-        oldCurrent: 2,
         current: 5,
         itemPerPage: 10,
+        oldCurrent: 2,
       };
 
       expect(odsPaginationChanged).toHaveReceivedEventDetail(expected);

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
@@ -16,7 +16,7 @@ describe('spec:osds-pagination', () => {
     jest.clearAllMocks();
   });
 
-  async function setup({ attributes = {} }: { attributes?: Partial<OdsPaginationAttribute> } = {}) {
+  async function setup({ attributes = {} }: { attributes?: Partial<OdsPaginationAttribute> } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsPaginationAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
 
     // mock setCustomValidity method that does not exist when stencil mock HTMLInputElement
@@ -79,14 +79,14 @@ describe('spec:osds-pagination', () => {
     });
 
     it('should disabled attributes is true', async() => {
-      await setup({ attributes: { disabled: true, current: 2, totalPages: 10 } });
+      await setup({ attributes: { current: 2, disabled: true, totalPages: 10 } });
       expect(page.root?.disabled).toBeDefined();
     });
   });
 
   describe('page list', () => {
     it('should set the correct page number', async() => {
-      await setup({ attributes: { disabled: false, current: 2, totalPages: 8 } });
+      await setup({ attributes: { current: 2, disabled: false, totalPages: 8 } });
 
       await instance.setPageIndex(3);
 
@@ -109,10 +109,10 @@ describe('spec:osds-pagination', () => {
       detail: {},
       preventDefault: jest.fn(),
       stopPropagation: jest.fn(),
-    }
+    };
 
     it('should do nothing if event does not have a value', async() => {
-      await setup({ attributes: { disabled: false, current: 2, totalItems: 200 } });
+      await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
@@ -124,7 +124,7 @@ describe('spec:osds-pagination', () => {
 
     it('should do update item per page value', async() => {
       const dummyValue = 50;
-      await setup({ attributes: { disabled: false, current: 2, totalItems: 200 } });
+      await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
@@ -140,7 +140,7 @@ describe('spec:osds-pagination', () => {
   describe('Watch', () => {
     describe('onItemPerPageChange', () => {
       it('should update page list and reset current to 1', async() => {
-        await setup({ attributes: { disabled: false, current: 2, totalItems: 200 } });
+        await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.itemPerPage = 20;
@@ -150,7 +150,7 @@ describe('spec:osds-pagination', () => {
       });
 
       it('should update page list without changing current if it is already 1', async() => {
-        await setup({ attributes: { disabled: false, current: 1, totalItems: 200 } });
+        await setup({ attributes: { current: 1, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.itemPerPage = 20;
@@ -162,7 +162,7 @@ describe('spec:osds-pagination', () => {
 
     describe('onTotalItemsChange', () => {
       it('should update page list and reset current to 1', async() => {
-        await setup({ attributes: { disabled: false, current: 2, totalItems: 200 } });
+        await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.totalItems = 100;
@@ -172,7 +172,7 @@ describe('spec:osds-pagination', () => {
       });
 
       it('should update page list without changing current if it is already 1', async() => {
-        await setup({ attributes: { disabled: false, current: 1, totalItems: 200 } });
+        await setup({ attributes: { current: 1, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.totalItems = 100;
@@ -193,7 +193,7 @@ describe('spec:osds-pagination', () => {
       });
 
       it('should not update total pages if totalItems is set', async() => {
-        await setup({ attributes: { disabled: false, totalPages: 20, totalItems: 100 } });
+        await setup({ attributes: { disabled: false, totalItems: 100, totalPages: 20 } });
         const initialPageList = [...instance.pageList];
 
         instance.totalPages = 100;
@@ -208,74 +208,74 @@ describe('spec:osds-pagination', () => {
    */
   describe('attributes', () => {
     const config = {
-      instance: () => instance,
-      page: () => page,
-      root: () => page.root,
-      wait: () => page.waitForChanges(),
+      instance: (): OsdsPagination => instance,
+      page: (): SpecPage => page,
+      root: (): HTMLElement | undefined => page.root,
+      wait: (): Promise<void> => page.waitForChanges(),
     };
 
     describe('totalPages 1->100 with odsUnitTestAttribute', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'totalPages'>({
-        name: 'totalPages',
         defaultValue: DEFAULT_ATTRIBUTE.totalPages,
+        name: 'totalPages',
         newValue: 100,
-        value: 1,
         setup: (value) => setup({ attributes: { ['totalPages']: value } }),
+        value: 1,
         ...config,
       });
     });
 
     describe('current 1->100 with odsUnitTestAttribute', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'current'>({
-        name: 'current',
         defaultValue: DEFAULT_ATTRIBUTE.current,
+        name: 'current',
         newValue: 100,
-        value: 1,
         setup: (value) => setup({ attributes: { ['current']: value } }),
+        value: 1,
         ...config,
       });
     });
 
     describe('disabled with odsUnitTestAttribute', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'disabled'>({
-        name: 'disabled',
         defaultValue: DEFAULT_ATTRIBUTE.disabled,
+        name: 'disabled',
         newValue: true,
-        value: false,
         setup: (value) => setup({ attributes: { ['disabled']: value } }),
+        value: false,
         ...config,
       });
     });
 
     describe('totalItems', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'totalItems'>({
-        name: 'totalItems',
         defaultValue: DEFAULT_ATTRIBUTE.totalItems,
+        name: 'totalItems',
         newValue: 100,
-        value: 1,
         setup: (value) => setup({ attributes: { ['totalItems']: value } }),
+        value: 1,
         ...config,
       });
     });
 
     describe('labelTooltipPrevious with odsUnitTestAttribute', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'labelTooltipPrevious'>({
-        name: 'labelTooltipPrevious',
         defaultValue: DEFAULT_ATTRIBUTE.labelTooltipPrevious,
+        name: 'labelTooltipPrevious',
         newValue: 'Previous',
-        value: 'Précédent',
         setup: (value) => setup({ attributes: { ['labelTooltipPrevious']: value } }),
+        value: 'Précédent',
         ...config,
       });
     });
 
     describe('labelTooltipNext with odsUnitTestAttribute', () => {
       odsUnitTestAttribute<OdsPaginationAttribute, 'labelTooltipNext'>({
-        name: 'labelTooltipNext',
         defaultValue: DEFAULT_ATTRIBUTE.labelTooltipNext,
+        name: 'labelTooltipNext',
         newValue: 'Next',
-        value: 'Suivant',
         setup: (value) => setup({ attributes: { ['labelTooltipNext']: value } }),
+        value: 'Suivant',
         ...config,
       });
     });
@@ -289,7 +289,7 @@ describe('spec:osds-pagination', () => {
     await setup({ attributes: { current: 2, totalPages: 10 } });
     expect(instance.handlePreviousKeyDown).toBeTruthy();
 
-    const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+    const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
     instance.handlePreviousKeyDown(event, instance.current);
 
     expect(instance.current).toBe(1);
@@ -317,7 +317,7 @@ describe('spec:osds-pagination', () => {
     await setup({ attributes: { current: 2, totalPages: 10 } });
     expect(instance.handlePageKeyDown).toBeTruthy();
 
-    const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+    const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
     instance.handlePageKeyDown(event, 5);
 
     expect(instance.current).toBe(5);
@@ -345,7 +345,7 @@ describe('spec:osds-pagination', () => {
     await setup({ attributes: { current: 2, totalPages: 10 } });
     expect(instance.handleNextKeyDown).toBeTruthy();
 
-    const event = new KeyboardEvent('keyDown', { code: 'Space', bubbles: true });
+    const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
     instance.handleNextKeyDown(event, instance.current);
 
     expect(instance.current).toBe(3);

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
@@ -2,34 +2,21 @@ import type { OdsPaginationAttribute, OdsPaginationPageList } from './interfaces
 import type { OdsPaginationChangedEventDetail, OdsPaginationEvent, OdsPaginationItemPerPageChangedEventDetail } from './interfaces/events';
 import type { OdsPaginationMethod } from './interfaces/methods';
 import type { OdsSelectOptionClickEventDetail } from '../../../../select/src';
+import type { EventEmitter } from '@stencil/core';
 import type { HTMLStencilElement } from '@stencil/core/internal';
 import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
-import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT } from '../../../../button/src';
-import { ODS_ICON_NAME, ODS_ICON_SIZE } from '../../../../icon/src';
-import { ODS_TEXT_SIZE } from '../../../../text/src';
-import {
-  Component,
-  Element,
-  Event,
-  EventEmitter,
-  Fragment,
-  Host,
-  Listen,
-  Method,
-  Prop,
-  State,
-  Watch,
-  forceUpdate,
-  h,
-} from '@stencil/core';
+import { Component, Element, Event, Fragment, Host, Listen, Method, Prop, State, Watch, forceUpdate, h } from '@stencil/core';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_PAGINATION_PER_PAGE_MIN, ODS_PAGINATION_PER_PAGE_OPTIONS } from './constants/pagination-per-page';
 import { OdsPaginationController } from './core/controller';
+import { ODS_BUTTON_SIZE, ODS_BUTTON_VARIANT } from '../../../../button/src';
+import { ODS_ICON_NAME, ODS_ICON_SIZE } from '../../../../icon/src';
+import { ODS_TEXT_SIZE } from '../../../../text/src';
 
 @Component({
-  tag: 'osds-pagination',
-  styleUrl: 'osds-pagination.scss',
   shadow: true,
+  styleUrl: 'osds-pagination.scss',
+  tag: 'osds-pagination',
 })
 export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEvent, OdsPaginationMethod {
   private actualTotalPages = DEFAULT_ATTRIBUTE.totalPages;
@@ -40,17 +27,17 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
   @State() itemPerPage = ODS_PAGINATION_PER_PAGE_MIN;
   @State() pageList: OdsPaginationPageList = [];
 
-  @Prop({ reflect: true, mutable: true }) current: number = DEFAULT_ATTRIBUTE.current;
+  @Prop({ mutable: true, reflect: true }) current: number = DEFAULT_ATTRIBUTE.current;
   @Prop({ reflect: true }) totalItems?: number;
   @Prop({ reflect: true }) totalPages: number = DEFAULT_ATTRIBUTE.totalPages;
-  @Prop({ reflect: true, mutable: true }) disabled: boolean = DEFAULT_ATTRIBUTE.disabled;
+  @Prop({ mutable: true , reflect: true }) disabled: boolean = DEFAULT_ATTRIBUTE.disabled;
   @Prop({ reflect: true }) labelTooltipPrevious: string = DEFAULT_ATTRIBUTE.labelTooltipPrevious;
   @Prop({ reflect: true }) labelTooltipNext: string = DEFAULT_ATTRIBUTE.labelTooltipNext;
 
   @Event() odsPaginationChanged!: EventEmitter<OdsPaginationChangedEventDetail>;
   @Event() odsPaginationItemPerPageChanged!: EventEmitter<OdsPaginationItemPerPageChangedEventDetail>;
 
-  componentWillLoad() {
+  componentWillLoad(): void {
     if (this.totalItems) {
       this.actualTotalPages = this.controller.computeActualTotalPages(this.itemPerPage);
     } else {
@@ -61,7 +48,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
   }
 
   @Listen('odsValueChange')
-  odsValueChangeHandler(event: CustomEvent<OdsSelectOptionClickEventDetail>) {
+  odsValueChangeHandler(event: CustomEvent<OdsSelectOptionClickEventDetail>): void {
     event.preventDefault();
     event.stopPropagation();
 
@@ -74,18 +61,18 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
 
   @Watch('labelTooltipNext')
   @Watch('labelTooltipPrevious')
-  updateLabelTooltip() {
+  updateLabelTooltip(): void {
     forceUpdate(this.el);
   }
 
   @Watch('current')
-  async onCurrentChange(current: number, oldCurrent?: number) {
+  async onCurrentChange(current: number, oldCurrent?: number): Promise<void> {
     this.updatePageList();
     this.emitChange(current, oldCurrent);
   }
 
   @Watch('totalPages')
-  async onTotalPagesChange() {
+  async onTotalPagesChange(): Promise<void> {
     if (!this.totalItems) {
       this.actualTotalPages = this.totalPages;
     }
@@ -93,7 +80,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
   }
 
   @Watch('itemPerPage')
-  async onItemPerPageChange() {
+  async onItemPerPageChange(): Promise<void> {
     await this.updatePagination();
 
     this.odsPaginationItemPerPageChanged.emit({
@@ -104,7 +91,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
   }
 
   @Watch('totalItems')
-  async onTotalItemsChange() {
+  async onTotalItemsChange(): Promise<void> {
     await this.updatePagination();
   }
 
@@ -113,23 +100,23 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
    * @see OdsPaginationMethods.setPageIndex
    */
   @Method()
-  async setPageIndex(current: number) {
+  async setPageIndex(current: number): Promise<void> {
     this.controller.setPageIndex(current);
   }
 
-  private emitChange(current: number, oldCurrent?: number) {
+  private emitChange(current: number, oldCurrent?: number): void {
     this.odsPaginationChanged.emit({
       current: current,
-      oldCurrent: oldCurrent,
       itemPerPage: this.itemPerPage,
+      oldCurrent: oldCurrent,
     });
   }
 
-  private updatePageList() {
+  private updatePageList(): void {
     this.pageList = this.controller.createPageList(this.actualTotalPages, this.current);
   }
 
-  private async updatePagination() {
+  private async updatePagination(): Promise<void> {
     this.actualTotalPages = this.controller.computeActualTotalPages(this.itemPerPage);
 
     if (this.current === 1) {
@@ -142,33 +129,33 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
 
   // clicks events
 
-  handlePreviousClick(page: number) {
+  handlePreviousClick(page: number): void {
     this.controller.handlePreviousClick(page);
   }
 
-  handleNextClick(page: number) {
+  handleNextClick(page: number): void {
     this.controller.handleNextClick(page);
   }
 
-  handlePageClick(page: number) {
+  handlePageClick(page: number): void {
     this.controller.handlePageClick(page);
   }
 
   // keyDown events
 
-  handlePreviousKeyDown(event: KeyboardEvent, page: number) {
+  handlePreviousKeyDown(event: KeyboardEvent, page: number): void {
     this.controller.handlePreviousKeyDown(event, page);
   }
 
-  handleNextKeyDown(event: KeyboardEvent, page: number) {
+  handleNextKeyDown(event: KeyboardEvent, page: number): void {
     this.controller.handleNextKeyDown(event, page, this.pageList);
   }
 
-  handlePageKeyDown(event: KeyboardEvent, page: number) {
+  handlePageKeyDown(event: KeyboardEvent, page: number): void {
     this.controller.handlePageKeyDown(event, page);
   }
 
-  renderArrows(direction: 'left' | 'right') {
+  renderArrows(direction: 'left' | 'right'): typeof Fragment {
     const { disabled } = this;
     const isLeft = direction === 'left';
     const arrowIcon = isLeft ? ODS_ICON_NAME.CHEVRON_LEFT : ODS_ICON_NAME.CHEVRON_RIGHT;
@@ -188,14 +175,18 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
             variant={ODS_BUTTON_VARIANT.ghost}
             color={ODS_THEME_COLOR_INTENT.primary}
             disabled={disabled || (isLeft && this.current === 1) || (direction === 'right' && this.current >= this.pageList.length)}
-            onKeyDown={(event: KeyboardEvent) => {
+            onKeyDown={(event: KeyboardEvent): void => {
               if (isLeft) {
                 this.handlePreviousKeyDown(event, Number(this.current));
               } else {
                 this.handleNextKeyDown(event, Number(this.current));
               }
             }}
-            onClick={() => {
+            onClick={(): void => {
+              if (disabled || (isLeft && this.current === 1) || (direction === 'right' && this.current >= this.pageList.length)) {
+                return;
+              }
+
               if (isLeft) {
                 this.handlePreviousClick(Number(this.current));
               } else {
@@ -216,7 +207,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
     );
   }
 
-  renderEllipsis() {
+  renderEllipsis(): typeof Fragment {
     return (
       <li>
         <osds-button color={ODS_THEME_COLOR_INTENT.primary}
@@ -232,7 +223,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
     );
   }
 
-  render() {
+  render(): JSX.Element | undefined {
     if (!this.totalItems && this.actualTotalPages < 2) {
       return;
     }
@@ -290,8 +281,8 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
                         inline
                         color={ODS_THEME_COLOR_INTENT.primary}
                         size={ODS_BUTTON_SIZE.sm}
-                        onKeyDown={(event: KeyboardEvent) => this.handlePageKeyDown(event, Number(pageId))}
-                        onClick={() => this.handlePageClick(Number(pageId))}>
+                        onKeyDown={(event: KeyboardEvent): void => this.handlePageKeyDown(event, Number(pageId))}
+                        onClick={(): void => this.handlePageClick(Number(pageId))}>
                         {pageId}
                       </osds-button>
                     </li>


### PR DESCRIPTION
**Bug Description:** Pagination - Goes out of bounds _[Chromium, Safari]_

**Steps to verify:** 
1) Open `OsdsPagination` component on `Chromium` or `Safari`.
2) Click on disabled `previous` arrow or `next` arrow.
3) The component should not go out of bounds anymore.