### PR TITLE
fix(quantity): fix arrow showing in safari

### DIFF
--- a/packages/components/src/input/src/components/osds-input/osds-input.scss
+++ b/packages/components/src/input/src/components/osds-input/osds-input.scss
@@ -51,12 +51,14 @@ input {
   cursor: not-allowed;
 }
 
-/* Chrome, Safari, Edge, Opera */
-input[type="number"],
+input[type="number"] {
+  appearance: textfield;
+  margin: 0;
+}
+
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
   appearance: none;
-  appearance: textfield;
   margin: 0;
 }
 


### PR DESCRIPTION
Fix input type number showing arrow in Safari and chromium