### PR TITLE
feat(pagination): add defaultCurrentPage attribute, remove current & update tests

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1044,7 +1044,7 @@ export namespace Components {
         /**
           * Its corresponding current page.
          */
-        "current": number;
+        "defaultCurrentPage": number;
         /**
           * Default items per page.
          */
@@ -1053,6 +1053,7 @@ export namespace Components {
           * indicates if the pagination is entirely disabled. it means no interactions (hover, click, focus, etc)
          */
         "disabled": boolean;
+        "getCurrentPage": () => Promise<number>;
         /**
           * The label of the tooltip on the arrow next
          */
@@ -3732,7 +3733,7 @@ declare namespace LocalJSX {
         /**
           * Its corresponding current page.
          */
-        "current"?: number;
+        "defaultCurrentPage"?: number;
         /**
           * Default items per page.
          */

--- a/packages/components/src/pagination/documentation/specifications/spec.md
+++ b/packages/components/src/pagination/documentation/specifications/spec.md
@@ -6,7 +6,7 @@
 ### OdsPaginationAttribute
 |Name | Type | Required | Default | Description|
 |---|---|:---:|---|---|
-|**`current`** | _number_ | ✴️ |  | Its corresponding current page.|
+|**`defaultCurrentPage`** | _number_ | ✴️ |  | Its corresponding current page.|
 |**`defaultItemsPerPage`** | `ODS_PAGINATION_PER_PAGE` | ✴️ |  | Default items per page.|
 |**`disabled`** | _boolean_ | ✴️ |  | indicates if the pagination is entirely disabled.it means no interactions (hover, click, focus, etc)|
 |**`labelTooltipNext`** | _string_ | ✴️ |  | The label of the tooltip on the arrow next|

--- a/packages/components/src/pagination/src/components/osds-pagination/constants/default-attributes.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/constants/default-attributes.ts
@@ -2,7 +2,7 @@ import type { OdsPaginationAttribute } from '../interfaces/attributes';
 import { ODS_PAGINATION_PER_PAGE_MIN } from './pagination-per-page';
 
 const DEFAULT_ATTRIBUTE: OdsPaginationAttribute = Object.freeze({
-  current: 1,
+  defaultCurrentPage: 1,
   defaultItemsPerPage: ODS_PAGINATION_PER_PAGE_MIN,
   disabled: false,
   labelTooltipNext: '',

--- a/packages/components/src/pagination/src/components/osds-pagination/core/controller.spec.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/core/controller.spec.ts
@@ -41,44 +41,44 @@ describe('spec:ods-pagination-controller', () => {
 
       it('should return totalPages if totalItems is not defined', () => {
         const dummyTotalPages = 8;
-        setup({ current: 2, disabled: false, totalPages: dummyTotalPages });
+        setup({ defaultCurrentPage: 2, disabled: false, totalPages: dummyTotalPages });
 
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(dummyTotalPages);
       });
 
       it('should return the correct amount of pages if totalItems is defined', () => {
-        setup({ current: 2, disabled: false, totalItems: 33, totalPages: 1 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalItems: 33, totalPages: 1 });
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(4);
 
-        setup({ current: 2, disabled: false, totalItems: 9, totalPages: 1 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalItems: 9, totalPages: 1 });
         expect(controller.computeActualTotalPages(dummyItemPerPage)).toBe(1);
 
-        setup({ current: 2, disabled: false, totalItems: 9, totalPages: 1 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalItems: 9, totalPages: 1 });
         expect(controller.computeActualTotalPages(0)).toBe(9);
       });
     });
 
     describe('createPageList', () => {
       it('should generate the correct number of pages', () => {
-        setup({ current: 2, disabled: false, totalPages: 8 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalPages: 8 });
 
-        const pageList = controller.createPageList(component.totalPages, component.current);
+        const pageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(8);
       });
 
       it('should generate the correct page list', () => {
-        setup({ current: 2, disabled: false, totalPages: 9 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalPages: 9 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(9);
       });
 
       it('should display the correct page list following to the current page 5', () => {
-        setup({ current: 5, disabled: false, totalPages: 12 });
+        setup({ defaultCurrentPage: 5, disabled: false, totalPages: 12 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(12);
         expect(pageList[0].active).toBe(true);
@@ -96,9 +96,9 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 2', () => {
-        setup({ current: 2, disabled: false, totalPages: 9 });
+        setup({ defaultCurrentPage: 2, disabled: false, totalPages: 9 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(9);
         expect(pageList[0].active).toBe(true);
@@ -113,9 +113,9 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 3', () => {
-        setup({ current: 3, disabled: false, totalPages: 9 });
+        setup({ defaultCurrentPage: 3, disabled: false, totalPages: 9 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(9);
         expect(pageList[0].active).toBe(true);
@@ -130,9 +130,9 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the correct page list following to the current page 4', () => {
-        setup({ current: 4, disabled: false, totalPages: 9 });
+        setup({ defaultCurrentPage: 4, disabled: false, totalPages: 9 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(9);
         expect(pageList[0].active).toBe(true);
@@ -147,9 +147,9 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('all pages should be active if there are 5 pages', () => {
-        setup({ current: 4, disabled: false, totalPages: 5 });
+        setup({ defaultCurrentPage: 4, disabled: false, totalPages: 5 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(5);
         expect(pageList[0].active).toBe(true);
@@ -160,9 +160,9 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('should display the last 5 pages if page 9 on 9 is selected', () => {
-        setup({ current: 9, disabled: false, totalPages: 9 });
+        setup({ defaultCurrentPage: 9, disabled: false, totalPages: 9 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
 
         expect(pageList).toHaveLength(9);
         expect(pageList[0].active).toBe(true);
@@ -177,36 +177,37 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('set page to 5 with setPageIndex', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
-        expect(component.current).toBe(10);
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
+        expect(component.defaultCurrentPage).toBe(10);
 
         controller.setPageIndex(5);
         expect(component.current).toBe(5);
       });
 
       it('handlePreviousKeyDown', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
-        expect(component.current).toBe(10);
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
+        expect(component.defaultCurrentPage).toBe(10);
 
         const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
-        controller.handlePreviousKeyDown(event, component.current);
+        controller.onKeyDown(event, component.defaultCurrentPage);
+        controller.handlePreviousKeyDown(event, component.defaultCurrentPage);
         expect(component.current).toBe(9);
       });
 
       it('handlePageKeyDown', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
 
-        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.current);
-        expect(component.current).toBe(10);
+        const pageList: OdsPaginationPageList = controller.createPageList(component.totalPages, component.defaultCurrentPage);
+        expect(component.defaultCurrentPage).toBe(10);
 
         const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
-        controller.handleNextKeyDown(event, component.current, pageList);
+        controller.handleNextKeyDown(event, component.defaultCurrentPage, pageList);
         expect(component.current).toBe(11);
       });
 
       it('handlePageKeyDown on page 5', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
-        expect(component.current).toBe(10);
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
+        expect(component.defaultCurrentPage).toBe(10);
 
         const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
 
@@ -227,31 +228,33 @@ describe('spec:ods-pagination-controller', () => {
       });
 
       it('handlePreviousClick', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
 
-        expect(component.current).toBe(10);
-        controller.handlePreviousClick(component.current);
+        expect(component.defaultCurrentPage).toBe(10);
+        controller.handlePreviousClick(component.defaultCurrentPage);
         expect(component.current).toBe(9);
         controller.handlePreviousClick(component.current);
         expect(component.current).toBe(8);
       });
 
       it('handleNextClick', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
 
-        expect(component.current).toBe(10);
-        controller.handleNextClick(component.current);
+        expect(component.defaultCurrentPage).toBe(10);
+        controller.handleNextClick(component.defaultCurrentPage);
         expect(component.current).toBe(11);
         controller.handleNextClick(component.current);
         expect(component.current).toBe(12);
       });
 
-      it('handlePageClick', () => {
-        setup({ current: 10, disabled: false, totalPages: 12 });
+      it('handlePageClick', async() => {
+        setup({ defaultCurrentPage: 10, disabled: false, totalPages: 12 });
 
-        expect(component.current).toBe(10);
+        expect(component.defaultCurrentPage).toBe(10);
+
         controller.handlePageClick(1);
         expect(component.current).toBe(1);
+
         controller.handlePageClick(3);
         expect(component.current).toBe(3);
       });

--- a/packages/components/src/pagination/src/components/osds-pagination/interfaces/attributes.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/interfaces/attributes.ts
@@ -10,7 +10,7 @@ interface OdsPaginationAttribute {
   /**
    * Its corresponding current page.
    */
-  current: number;
+  defaultCurrentPage: number;
   /**
    * Default items per page.
    */

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.screenshot.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.screenshot.ts
@@ -5,10 +5,10 @@ import { newE2EPage } from '@stencil/core/testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 describe('e2e:osds-pagination', () => {
-  const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
+  const baseAttribute = { defaultCurrentPage: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
   let page: E2EPage;
 
-  async function setup({ attributes = { current: 5, totalPages: 21 }, html = '' }: { attributes?: Partial<OdsPaginationAttribute>; html?: string } = {}): Promise<void> {
+  async function setup({ attributes = { defaultCurrentPage: 5, totalPages: 21 }, html = '' }: { attributes?: Partial<OdsPaginationAttribute>; html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsPaginationAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
 
     page = await newE2EPage();
@@ -21,18 +21,18 @@ describe('e2e:osds-pagination', () => {
   }
 
   describe('screenshots of totalPages of 21', () => {
-    for (let current = 1; current <= 21; current++) {
+    for (let defaultCurrentPage = 1; defaultCurrentPage <= 21; defaultCurrentPage++) {
       const screenshotActions = [
         {
           action: (): void => {},
-          actionDescription: `page ${current} on 21`,
+          actionDescription: `page ${defaultCurrentPage} on 21`,
         },
       ];
       screenshotActions.forEach(({ action, actionDescription }) => {
         it(actionDescription, async() => {
           await setup({
             attributes: {
-              current,
+              defaultCurrentPage,
               totalPages: 21,
             },
           });
@@ -52,18 +52,18 @@ describe('e2e:osds-pagination', () => {
   });
 
   describe('screenshots of totalPages of 21 and disabled', () => {
-    for (let current = 1; current <= 21; current++) {
+    for (let defaultCurrentPage = 1; defaultCurrentPage <= 21; defaultCurrentPage++) {
       const screenshotActions = [
         {
           action: (): void => {},
-          actionDescription: `page ${current} on 21 and disabled`,
+          actionDescription: `page ${defaultCurrentPage} on 21 and disabled`,
         },
       ];
       screenshotActions.forEach(({ actionDescription, action }) => {
         it(actionDescription, async() => {
           await setup({
             attributes: {
-              current,
+              defaultCurrentPage,
               disabled: true,
               totalPages: 21,
             },
@@ -85,14 +85,14 @@ describe('e2e:osds-pagination', () => {
 
   describe('screenshots with total items', () => {
     it('should not display the per-page select if less than 10 items', async() => {
-      await setup({ attributes: { current: 1, totalItems: 5 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 5 } });
 
       const results = await page.compareScreenshot('pagination', { fullPage: false, omitBackground: true });
       expect(results).toMatchScreenshot({ allowableMismatchedRatio: 0 });
     });
 
     it('should render the per-page select if more than 10 items', async() => {
-      await setup({ attributes: { current: 1, totalItems: 25 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 25 } });
 
       const results = await page.compareScreenshot('pagination', { fullPage: false, omitBackground: true });
       expect(results).toMatchScreenshot({ allowableMismatchedRatio: 0 });

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -7,7 +7,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { ODS_PAGINATION_PER_PAGE_OPTIONS } from './constants/pagination-per-page';
 
 describe('e2e:osds-pagination', () => {
-  const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
+  const baseAttribute = { defaultCurrentPage: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
   let page: E2EPage;
   let el: E2EElement;
   let osdsButtonPaginationPageButtonElement: E2EElement;
@@ -29,7 +29,7 @@ describe('e2e:osds-pagination', () => {
 
   describe('defaults', () => {
     beforeEach(async() => {
-      await setup({ attributes: { current: 4, totalPages: 10 } });
+      await setup({ attributes: { defaultCurrentPage: 4, totalPages: 10 } });
     });
 
     it('should render', async() => {
@@ -58,68 +58,68 @@ describe('e2e:osds-pagination', () => {
 
   describe('check the pagination structure', () => {
     it('should not render if total pages is less than 2', async() => {
-      await setup({ attributes: { current: 1, totalPages: 1 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 1 } });
       expect(el.shadowRoot.innerHTML).toBe('');
     });
 
     it('< 1 2 > should have 4 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 2 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 2 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(4);
     });
 
     it('< 1 2 3 > should have 5 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 3 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 3 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(5);
     });
 
     it('< 1 2 3 4 > should have 6 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 4 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 4 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(6);
     });
 
     it('< 1 2 3 4 5 > should have 7 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 5 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 5 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(7);
     });
 
     it('< 1 2 3 4 5 6 > should have 8 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 6 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 6 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(8);
     });
 
     it('< 1 2 3 4 5 … 7 > should have 9 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 7 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 7 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(9);
     });
 
     it('< 1 2 3 4 5 … 8 > should have 9 osds-button', async() => {
-      await setup({ attributes: { current: 1, totalPages: 8 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalPages: 8 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(9);
     });
 
     it('< 1 … 4 5 6 … 21 > should have 9 osds-button', async() => {
-      await setup({ attributes: { current: 5, totalPages: 21 } });
+      await setup({ attributes: { defaultCurrentPage: 5, totalPages: 21 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(9);
     });
 
     it('< 1 … 4 5 6 … 9000 > should have 9 osds-button', async() => {
-      await setup({ attributes: { current: 5, totalPages: 9000 } });
+      await setup({ attributes: { defaultCurrentPage: 5, totalPages: 9000 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(9);
@@ -127,76 +127,78 @@ describe('e2e:osds-pagination', () => {
   });
 
   describe('should change page if we click', () => {
-    it('current from 2 to 1 by button click', async() => {
-      await setup({ attributes: { current: 2, totalPages: 5 } });
+    it('switch current page from 2 to 1 by button click', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 5 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
 
-      const indexBeforeClick = Number(el.getAttribute('current'));
+      const indexBeforeClick = await el.callMethod('getCurrentPage');
       expect(indexBeforeClick).toEqual(2);
 
       await buttonList[1].click();
 
       await page.waitForChanges();
 
-      const current = Number(el.getAttribute('current'));
+      const current = await el.callMethod('getCurrentPage');
       expect(current).toEqual(1);
     });
 
-    it('current from 2 to 3 by button click', async() => {
-      await setup({ attributes: { current: 2, totalPages: 5 } });
+    it('switch current page from 2 to 3 by button click', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 5 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
 
-      const indexBeforeClick = Number(el.getAttribute('current'));
+      const indexBeforeClick = await el.callMethod('getCurrentPage');
       expect(indexBeforeClick).toEqual(2);
 
       await buttonList[3].click();
 
       await page.waitForChanges();
 
-      const current = Number(el.getAttribute('current'));
+      const current = await el.callMethod('getCurrentPage');
       expect(current).toEqual(3);
     });
 
-    it('current from 2 to 4 by button click', async() => {
-      await setup({ attributes: { current: 2, totalPages: 5 } });
+    it('switch current page from 2 to 4 by button click', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 5 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
 
-      const indexBeforeClick = Number(el.getAttribute('current'));
+      const indexBeforeClick = await el.callMethod('getCurrentPage');
       expect(indexBeforeClick).toEqual(2);
 
       await buttonList[4].click();
 
       await page.waitForChanges();
 
-      const current = Number(el.getAttribute('current'));
+      const current = await el.callMethod('getCurrentPage');
       expect(current).toEqual(4);
     });
 
-    it('current from 2 to 5 by button click', async() => {
-      await setup({ attributes: { current: 2, totalPages: 5 } });
+    it('switch current page from 2 to 5 by button click', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 5 } });
 
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
 
-      const indexBeforeClick = Number(el.getAttribute('current'));
+      const indexBeforeClick = await el.callMethod('getCurrentPage');
       expect(indexBeforeClick).toEqual(2);
 
       await buttonList[5].click();
 
       await page.waitForChanges();
 
-      const current = Number(el.getAttribute('current'));
+      const current = await el.callMethod('getCurrentPage');
       expect(current).toEqual(5);
     });
 
-    it('should emit when current attribute changes', async() => {
-      await setup({ attributes: { current: 2, totalPages: 5 } });
+    it('should emit when current page changes', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 5 } });
+
+      const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
 
       const odsPaginationChanged = await el.spyOnEvent('odsPaginationChanged');
 
-      el.setAttribute('current', 5);
+      await buttonList[5].click();
 
       await page.waitForChanges();
 
@@ -215,7 +217,7 @@ describe('e2e:osds-pagination', () => {
     let perPageSelectElement: E2EElement;
 
     it('should not show the select if the totalItems < 10', async() => {
-      await setup({ attributes: { current: 1, totalItems: 5 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 5 } });
 
       perPageSelectElement = await page.find('osds-pagination >>> osds-select');
 
@@ -223,7 +225,7 @@ describe('e2e:osds-pagination', () => {
     });
 
     it('should show all the default step', async() => {
-      await setup({ attributes: { current: 1, totalItems: 500 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 500 } });
 
       perPageSelectElement = await page.find('osds-pagination >>> osds-select');
       expect(perPageSelectElement).toBeDefined();
@@ -239,7 +241,7 @@ describe('e2e:osds-pagination', () => {
     });
 
     it('should emit when the itemPerPage attribute changes', async() => {
-      await setup({ attributes: { current: 2, totalItems: 60 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalItems: 60 } });
 
       const odsPaginationItemPerPageChanged = await el.spyOnEvent('odsPaginationItemPerPageChanged');
 
@@ -266,7 +268,7 @@ describe('e2e:osds-pagination', () => {
 
     it('should show both slots and the totalItems number', async() => {
       await setup({
-        attributes: { current: 1, totalItems: dummyTotalItems },
+        attributes: { defaultCurrentPage: 1, totalItems: dummyTotalItems },
         html: `
           <span slot="before-total-items">of&nbsp;</span>
           <span slot="after-total-items">&nbsp;results</span>
@@ -286,21 +288,21 @@ describe('e2e:osds-pagination', () => {
     let pageItemElements: E2EElement[];
 
     it('should have a default step of 10', async() => {
-      await setup({ attributes: { current: 1, totalItems: 20 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 20 } });
 
       pageItemElements = await page.findAll('osds-pagination >>> ul > li:not([class="arrows"])');
       expect(pageItemElements.length).toBe(2);
     });
 
     it('should adapt to default step of 25 if defaultItemsPerPage', async() => {
-      await setup({ attributes: { current: 1, defaultItemsPerPage: 25 , totalItems: 20 } });
+      await setup({ attributes: { defaultCurrentPage: 1, defaultItemsPerPage: 25 , totalItems: 20 } });
 
       pageItemElements = await page.findAll('osds-pagination >>> ul > li:not([class="arrows"])');
       expect(pageItemElements.length).toBe(1);
     });
 
     it('should change the totalPages according to the selected step', async() => {
-      await setup({ attributes: { current: 1, totalItems: 20 } });
+      await setup({ attributes: { defaultCurrentPage: 1, totalItems: 20 } });
 
       pageItemElements = await page.findAll('osds-pagination >>> ul > li:not([class="arrows"])');
       expect(pageItemElements.length).toBe(2);
@@ -314,38 +316,42 @@ describe('e2e:osds-pagination', () => {
     });
 
     it('should not allow to go to next page if the current page is the last one', async() => {
-      await setup({ attributes: { current: 2, totalItems: 30 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalItems: 30 } });
 
       const allArrows = await page.findAll('osds-pagination >>> .arrows >>> osds-button');
 
       allArrows[1].click();
       await page.waitForChanges();
 
-      let current = Number(el.getAttribute('current'));
+      let current = await el.callMethod('getCurrentPage');
       expect(current).toBe(3);
 
       allArrows[1].click();
       await page.waitForChanges();
 
-      current = Number(el.getAttribute('current'));
+      current = await el.callMethod('getCurrentPage');
       expect(current).toBe(3);
     });
 
     it('should not allow to go to previous page if the current page is the first one', async() => {
-      await setup({ attributes: { current: 2, totalItems: 30 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalItems: 30 } });
+
+      await page.waitForChanges();
 
       const allArrows = await page.findAll('osds-pagination >>> .arrows >>> osds-button');
 
       allArrows[0].click();
       await page.waitForChanges();
 
-      let current = Number(el.getAttribute('current'));
+      let current = await el.callMethod('getCurrentPage');
+      await page.waitForChanges();
       expect(current).toBe(1);
 
       allArrows[0].click();
       await page.waitForChanges();
 
-      current = Number(el.getAttribute('current'));
+      current = await el.callMethod('getCurrentPage');
+      await page.waitForChanges();
       expect(current).toBe(1);
     });
   });

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.e2e.ts
@@ -124,6 +124,20 @@ describe('e2e:osds-pagination', () => {
       const buttonList = await page.findAll('osds-pagination >>> li >>> osds-button');
       expect(buttonList.length).toBe(9);
     });
+
+    it('should not allow for a defaultCurrentPage lower than 1', async() => {
+      await setup({ attributes: { defaultCurrentPage: -5, totalPages: 5 } });
+
+      const current = await el.callMethod('getCurrentPage');
+      expect(current).toEqual(1);
+    });
+
+    it('should not allow for a defaultCurrentPage higher than total number of pages', async() => {
+      await setup({ attributes: { defaultCurrentPage: 10, totalPages: 5 } });
+
+      const current = await el.callMethod('getCurrentPage');
+      expect(current).toEqual(5);
+    });
   });
 
   describe('should change page if we click', () => {

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.spec.ts
@@ -7,7 +7,7 @@ import { ODS_PAGINATION_PER_PAGE_MIN } from './constants/pagination-per-page';
 import { OsdsPagination } from './osds-pagination';
 
 describe('spec:osds-pagination', () => {
-  const baseAttribute = { current: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
+  const baseAttribute = { defaultCurrentPage: 0, disabled: false, labelTooltipNext: '', labelTooltipPrevious: '', totalPages: 0 };
   let page: SpecPage;
   let instance: OsdsPagination;
   let htmlPagination: HTMLElement | null | undefined;
@@ -40,53 +40,63 @@ describe('spec:osds-pagination', () => {
   });
 
   describe('attributes', () => {
-    it('if the current of the pagination is 6, then page index should be 6', async() => {
-      await setup({ attributes: { current: 6, totalPages: 10 } });
+    it('if the defaultCurrentPage of the pagination is 6, then page index should be 6', async() => {
+      await setup({ attributes: { defaultCurrentPage: 6, totalPages: 10 } });
 
-      expect(instance.current).toBe(6);
+      expect(instance.defaultCurrentPage).toBe(6);
       expect(instance.itemPerPage).toBe(ODS_PAGINATION_PER_PAGE_MIN);
     });
 
-    it('if the current of the pagination is 2, then page index should be 2', async() => {
-      await setup({ attributes: { current: 2, totalPages: 10 } });
+    it('if the defaultCurrentPage of the pagination is 2, then page index should be 2', async() => {
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
 
-      expect(instance.current).toBe(2);
+      expect(instance.defaultCurrentPage).toBe(2);
       expect(instance.itemPerPage).toBe(ODS_PAGINATION_PER_PAGE_MIN);
     });
 
     it('if the totalItems is defined itemPerPage should be also', async() => {
-      await setup({ attributes: { current: 2, totalItems: 20 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalItems: 20 } });
 
-      expect(instance?.current).toBe(2);
+      expect(instance?.defaultCurrentPage).toBe(2);
       expect(instance.itemPerPage).toBe(ODS_PAGINATION_PER_PAGE_MIN);
     });
   });
 
   describe('methods', () => {
     it('should call setPageIndex function and the page index should be set to 4', async() => {
-      await setup({ attributes: { current: 2, totalPages: 10 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
       expect(instance).toBeTruthy();
 
       await instance.setPageIndex(4);
       expect(instance.current).toBe(4);
     });
+
+    describe('getCurrentPage', () => {
+      it('should return the current page index', async() => {
+        await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
+
+        await instance.setPageIndex(4);
+        const current = await instance.getCurrentPage();
+        expect(current).toBe(4);
+      });
+    });
   });
 
   describe('disabled', () => {
     it('should disabled attributes is false by default', async() => {
-      await setup({ attributes: { current: 2, totalPages: 10 } });
+      await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
       expect(page.root?.disabled).toBe(false);
     });
 
     it('should disabled attributes is true', async() => {
-      await setup({ attributes: { current: 2, disabled: true, totalPages: 10 } });
+      await setup({ attributes: { defaultCurrentPage: 2, disabled: true, totalPages: 10 } });
       expect(page.root?.disabled).toBeDefined();
     });
   });
 
   describe('page list', () => {
     it('should set the correct page number', async() => {
-      await setup({ attributes: { current: 2, disabled: false, totalPages: 8 } });
+      await setup({ attributes: { defaultCurrentPage: 2, disabled: false, totalPages: 8 } });
 
       await instance.setPageIndex(3);
 
@@ -95,7 +105,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('onCurrentChange', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
 
     const componentDidUpdateSpy = jest.spyOn(instance, 'onCurrentChange');
 
@@ -112,7 +122,7 @@ describe('spec:osds-pagination', () => {
     };
 
     it('should do nothing if event does not have a value', async() => {
-      await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
+      await setup({ attributes: { defaultCurrentPage: 2, disabled: false, totalItems: 200 } });
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
@@ -124,7 +134,7 @@ describe('spec:osds-pagination', () => {
 
     it('should do update item per page value', async() => {
       const dummyValue = 50;
-      await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
+      await setup({ attributes: { defaultCurrentPage: 2, disabled: false, totalItems: 200 } });
       expect(instance.itemPerPage).toBe(10);
 
       // @ts-ignore for test purpose
@@ -139,8 +149,8 @@ describe('spec:osds-pagination', () => {
 
   describe('Watch', () => {
     describe('onItemPerPageChange', () => {
-      it('should update page list and reset current to 1', async() => {
-        await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
+      it('should update page list and reset defaultCurrentPage to 1', async() => {
+        await setup({ attributes: { defaultCurrentPage: 2, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.itemPerPage = 20;
@@ -149,8 +159,8 @@ describe('spec:osds-pagination', () => {
         expect(instance.pageList).not.toEqual(initialPageList);
       });
 
-      it('should update page list without changing current if it is already 1', async() => {
-        await setup({ attributes: { current: 1, disabled: false, totalItems: 200 } });
+      it('should update page list without changing defaultCurrentPage if it is already 1', async() => {
+        await setup({ attributes: { defaultCurrentPage: 1, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.itemPerPage = 20;
@@ -161,8 +171,8 @@ describe('spec:osds-pagination', () => {
     });
 
     describe('onTotalItemsChange', () => {
-      it('should update page list and reset current to 1', async() => {
-        await setup({ attributes: { current: 2, disabled: false, totalItems: 200 } });
+      it('should update page list and reset defaultCurrentPage to 1', async() => {
+        await setup({ attributes: { defaultCurrentPage: 2, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.totalItems = 100;
@@ -171,8 +181,8 @@ describe('spec:osds-pagination', () => {
         expect(instance.pageList).not.toEqual(initialPageList);
       });
 
-      it('should update page list without changing current if it is already 1', async() => {
-        await setup({ attributes: { current: 1, disabled: false, totalItems: 200 } });
+      it('should update page list without changing defaultCurrentPage if it is already 1', async() => {
+        await setup({ attributes: { defaultCurrentPage: 1, disabled: false, totalItems: 200 } });
         const initialPageList = [...instance.pageList];
 
         instance.totalItems = 100;
@@ -225,12 +235,12 @@ describe('spec:osds-pagination', () => {
       });
     });
 
-    describe('current 1->100 with odsUnitTestAttribute', () => {
-      odsUnitTestAttribute<OdsPaginationAttribute, 'current'>({
-        defaultValue: DEFAULT_ATTRIBUTE.current,
-        name: 'current',
+    describe('defaultCurrentPage 1->100 with odsUnitTestAttribute', () => {
+      odsUnitTestAttribute<OdsPaginationAttribute, 'defaultCurrentPage'>({
+        defaultValue: DEFAULT_ATTRIBUTE.defaultCurrentPage,
+        name: 'defaultCurrentPage',
         newValue: 100,
-        setup: (value) => setup({ attributes: { ['current']: value } }),
+        setup: (value) => setup({ attributes: { ['defaultCurrentPage']: value } }),
         value: 1,
         ...config,
       });
@@ -297,17 +307,17 @@ describe('spec:osds-pagination', () => {
    */
 
   it('handlePreviousKeyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handlePreviousKeyDown).toBeTruthy();
 
     const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
-    instance.handlePreviousKeyDown(event, instance.current);
+    instance.handlePreviousKeyDown(event, instance.defaultCurrentPage);
 
     expect(instance.current).toBe(1);
   });
 
   it('handlePreviousKeyDown controller', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     instance.controller.handlePreviousKeyDown = jest.fn();
 
     instance.handlePreviousKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }), instance.current);
@@ -317,15 +327,15 @@ describe('spec:osds-pagination', () => {
   });
 
   it('handlePreviousClick', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handlePreviousClick).toBeTruthy();
 
-    instance.handlePreviousClick(instance.current);
+    instance.handlePreviousClick(instance.defaultCurrentPage);
     expect(instance.current).toBe(1);
   });
 
   it('handlePageKeyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handlePageKeyDown).toBeTruthy();
 
     const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
@@ -335,7 +345,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('handlePageKeyDown controller', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
 
     instance.controller.handlePageKeyDown = jest.fn();
     instance.handlePageKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }), 5);
@@ -345,7 +355,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('handlePageClick', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handlePageClick).toBeTruthy();
 
     instance.handlePageClick(5);
@@ -353,17 +363,17 @@ describe('spec:osds-pagination', () => {
   });
 
   it('handleNextKeyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handleNextKeyDown).toBeTruthy();
 
     const event = new KeyboardEvent('keyDown', { bubbles: true, code: 'Space' });
-    instance.handleNextKeyDown(event, instance.current);
+    instance.handleNextKeyDown(event, instance.defaultCurrentPage);
 
     expect(instance.current).toBe(3);
   });
 
   it('handleNextKeyDown controller', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
 
     instance.controller.handleNextKeyDown = jest.fn();
     instance.handleNextKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }), instance.current);
@@ -373,16 +383,18 @@ describe('spec:osds-pagination', () => {
   });
 
   it('handleNextClick', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     expect(instance.handleNextClick).toBeTruthy();
 
-    instance.handleNextClick(instance.current);
+    instance.handleNextClick(instance.defaultCurrentPage);
     expect(instance.current).toBe(3);
   });
 
   it('left arrow click', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
+
+    expect(instance.current).toBe(2);
 
     expect(buttons?.[0]).toBeDefined();
 
@@ -393,7 +405,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('left arrow keyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
 
     expect(buttons?.[0]).toBeDefined();
@@ -411,7 +423,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('right arrow click', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
 
     expect(buttons?.[8]).toBeDefined();
@@ -423,7 +435,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('right arrow keyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
 
     expect(buttons?.[8]).toBeDefined();
@@ -441,7 +453,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('page click on 10', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
 
     expect(buttons?.[7]).toBeDefined();
@@ -453,7 +465,7 @@ describe('spec:osds-pagination', () => {
   });
 
   it('page keyDown', async() => {
-    await setup({ attributes: { current: 2, totalPages: 10 } });
+    await setup({ attributes: { defaultCurrentPage: 2, totalPages: 10 } });
     const buttons = htmlPagination?.shadowRoot?.querySelectorAll('osds-button');
 
     expect(buttons?.[7]).toBeDefined();

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
@@ -44,12 +44,19 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
 
   componentWillLoad(): void {
     this.itemPerPage = ODS_PAGINATION_PER_PAGE_OPTIONS.includes(this.defaultItemsPerPage) && this.defaultItemsPerPage || ODS_PAGINATION_PER_PAGE_MIN;
-    this.current = this.defaultCurrentPage || this.current;
 
     if (this.totalItems) {
       this.actualTotalPages = this.controller.computeActualTotalPages(this.itemPerPage);
     } else {
       this.actualTotalPages = this.totalPages;
+    }
+
+    if (this.defaultCurrentPage > this.actualTotalPages) {
+      this.current = this.actualTotalPages;
+    } else if (this.defaultCurrentPage < 1) {
+      this.current = 1;
+    } else {
+      this.current = this.defaultCurrentPage || this.current;
     }
 
     this.updatePageList();

--- a/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
+++ b/packages/components/src/pagination/src/components/osds-pagination/osds-pagination.tsx
@@ -27,10 +27,11 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
 
   @State() itemPerPage = ODS_PAGINATION_PER_PAGE_MIN;
   @State() pageList: OdsPaginationPageList = [];
+  @State() current: number = 1;
 
   private isFirstLoad: boolean = true;
 
-  @Prop({ mutable: true, reflect: true }) current: number = DEFAULT_ATTRIBUTE.current;
+  @Prop({ reflect: true }) defaultCurrentPage: number = DEFAULT_ATTRIBUTE.defaultCurrentPage;
   @Prop({ reflect: true }) totalItems?: number;
   @Prop({ reflect: true }) defaultItemsPerPage: ODS_PAGINATION_PER_PAGE = DEFAULT_ATTRIBUTE.defaultItemsPerPage;
   @Prop({ reflect: true }) totalPages: number = DEFAULT_ATTRIBUTE.totalPages;
@@ -43,6 +44,7 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
 
   componentWillLoad(): void {
     this.itemPerPage = ODS_PAGINATION_PER_PAGE_OPTIONS.includes(this.defaultItemsPerPage) && this.defaultItemsPerPage || ODS_PAGINATION_PER_PAGE_MIN;
+    this.current = this.defaultCurrentPage || this.current;
 
     if (this.totalItems) {
       this.actualTotalPages = this.controller.computeActualTotalPages(this.itemPerPage);
@@ -111,6 +113,11 @@ export class OsdsPagination implements OdsPaginationAttribute, OdsPaginationEven
   @Method()
   async setPageIndex(current: number): Promise<void> {
     this.controller.setPageIndex(current);
+  }
+
+  @Method()
+  async getCurrentPage(): Promise<number> {
+    return this.current;
   }
 
   private emitChange(current: number, oldCurrent?: number): void {

--- a/packages/components/src/pagination/src/index.html
+++ b/packages/components/src/pagination/src/index.html
@@ -31,58 +31,58 @@
 <body>
   <h3>3rd page and previous</h3>
   <div class="row">
-    <osds-pagination current=3 total-pages=21></osds-pagination>
-    <p class="description">21 pages to display, current page 3</p>
+    <osds-pagination default-current-page=3 total-pages=21></osds-pagination>
+    <p class="description">21 pages to display, default current page 3</p>
   </div>
 
   <h3>Between 3rd and antepenultimate page</h3>
   <div class="row">
-    <osds-pagination current=2 total-pages=4></osds-pagination>
-    <p class="description">4 pages to display, current page 1</p>
+    <osds-pagination default-current-page=2 total-pages=4></osds-pagination>
+    <p class="description">4 pages to display, default current page 1</p>
     </div>
 
   <div class="row">
-    <osds-pagination current=5 total-pages=5></osds-pagination>
-    <p class="description">5 pages to display, current page 5</p>
+    <osds-pagination default-current-page=5 total-pages=5></osds-pagination>
+    <p class="description">5 pages to display, default current page 5</p>
   </div>
 
   <h3>Antepenultimate page and after</h3>
   <div class="row">
-    <osds-pagination current=5 total-pages=6></osds-pagination>
-    <p class="description">6 pages to display, current page 5</p>
+    <osds-pagination default-current-page=5 total-pages=6></osds-pagination>
+    <p class="description">6 pages to display, default current page 5</p>
   </div>
 
   <div class="row">
-    <osds-pagination current=5 total-pages=7></osds-pagination>
-    <p class="description">7 pages to display, current page 5</p>
+    <osds-pagination default-current-page=5 total-pages=7></osds-pagination>
+    <p class="description">7 pages to display, default current page 5</p>
   </div>
 
   <div class="row">
-    <osds-pagination current=5 total-pages=9></osds-pagination>
-    <p class="description">9 pages to display, current page 5</p>
+    <osds-pagination default-current-page=5 total-pages=9></osds-pagination>
+    <p class="description">9 pages to display, default current page 5</p>
   </div>
 
   <h3>disabled</h3>
   <div class="row">
-    <osds-pagination current=1 total-pages=6 disabled></osds-pagination>
+    <osds-pagination default-current-page=1 total-pages=6 disabled></osds-pagination>
     <p class="description"></p>
   </div>
 
   <h3>With background with over 9000 pages</h3>
   <div class="row">
-    <osds-pagination current=1 total-pages=9001 ></osds-pagination>
+    <osds-pagination default-current-page=1 total-pages=9001 ></osds-pagination>
     <p class="description">It's over 9000</p>
   </div>
 
   <h3>Less than two pages</h3>
   <div class="row">
-    <osds-pagination current=1 total-pages=1></osds-pagination>
+    <osds-pagination default-current-page=1 total-pages=1></osds-pagination>
     <p class="description">Pagination should not appear</p>
   </div>
 
   <h3>Total items < 10</h3>
   <div class="row">
-    <osds-pagination current=1 total-items=5>
+    <osds-pagination default-current-page=1 total-items=5>
       <span slot="after-total-items">&nbsp;results</span>
     </osds-pagination>
     <p class="description">Select should not appear</p>
@@ -90,7 +90,7 @@
 
   <h3>Total items between 10 and 300</h3>
   <div class="row">
-    <osds-pagination current=2 total-items=60  default-items-per-page=77>
+    <osds-pagination default-current-page=2 total-items=60  default-items-per-page=77>
       <span slot="before-total-items">of&nbsp;</span>
       <span slot="after-total-items">&nbsp;results</span>
     </osds-pagination>
@@ -99,7 +99,7 @@
 
   <h3>Total items above 300</h3>
   <div class="row">
-    <osds-pagination id="paginationAddLabel" current=2 total-items=500 default-items-per-page=50>
+    <osds-pagination id="paginationAddLabel" default-current-page=10 total-items=500 default-items-per-page=50>
       <span slot="before-total-items">of&nbsp;</span>
       <span slot="after-total-items">&nbsp;results</span>
     </osds-pagination>
@@ -108,13 +108,13 @@
 
   <h3>Total items disabled</h3>
   <div class="row">
-    <osds-pagination current=3 total-items=60 disabled></osds-pagination>
+    <osds-pagination default-current-page=3 total-items=60 disabled></osds-pagination>
     <p class="description">All disabled</p>
   </div>
 
   <h3>Change label tooltip</h3>
   <div class="row">
-    <osds-pagination id="paginationEditLabel" current=3 total-pages=21 label-tooltip-previous="Précédent" label-tooltip-next="Suivant"></osds-pagination>
+    <osds-pagination id="paginationEditLabel" default-current-page=3 total-pages=21 label-tooltip-previous="Précédent" label-tooltip-next="Suivant"></osds-pagination>
     <p class="description">labelTooltipPrevious & labelTooltipNext will change after 5 secondes</p>
   </div>
   <script>

--- a/packages/components/src/pagination/src/index.html
+++ b/packages/components/src/pagination/src/index.html
@@ -99,7 +99,7 @@
 
   <h3>Total items above 300</h3>
   <div class="row">
-    <osds-pagination id="paginationAddLabel" default-current-page=10 total-items=500 default-items-per-page=50>
+    <osds-pagination id="paginationAddLabel" default-current-page=8 total-items=500 default-items-per-page=50>
       <span slot="before-total-items">of&nbsp;</span>
       <span slot="after-total-items">&nbsp;results</span>
     </osds-pagination>

--- a/packages/storybook/stories/components/pagination/3_demo.stories.ts
+++ b/packages/storybook/stories/components/pagination/3_demo.stories.ts
@@ -7,9 +7,9 @@ import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../
 defineCustomElement();
 
 const storyParams = {
-  current: {
+  defaultCurrentPage: {
     category: 'General',
-    defaultValue: 5,
+    defaultValue: 4,
   },
   disabled: {
     category: 'Misc',


### PR DESCRIPTION
This new feature will allow the users to set a default page in the `OsdsPagination` component with the new `defaultCurrentPage` attribute.

### Content:
---
- Added new attribute `defaultCurrentPage` to `OsdsPagination`.
- Added new method `getCurrentPage()`.
- Removed old attribute `current`.
- Updated documentation
- Updated spec, e2e & screenshot tests
- Updated Storybook

### To review:
---
Check if you can set a `defaultCurrentPage` attribute to the `OsdsPagination` component and if it is well displayed and still allows for interaction with the component.

