### PR TITLE
fix(link): multiple active states on Safari

### DIFF
--- a/packages/components/src/link/src/components/osds-link/osds-link.scss
+++ b/packages/components/src/link/src/components/osds-link/osds-link.scss
@@ -44,7 +44,7 @@
 
 :not([disabled]) {
   :host(&:hover),
-  :host(&:focus) {
+  :host(&:focus-within) {
     @include osds-link-on-text-content {
       transition: background-size .2s ease-out;
       background-size: 100% var(--ods-size-02);


### PR DESCRIPTION
This fixes an abnormal behavior initially identified on Safari with the `OsdsBreadcrumb` where multiple breadcrumb items could stay underlined after clicking on them.

### To review:
---
Check if you are able to click on multiple items on the `OsdsBreadcrumb` component without having multiple items with a focused visual.
