### PR TITLE
fix(modal/popover): Overflowing Surfaces

### DIFF
--- a/packages/components/src/modal/src/components/osds-modal/osds-modal.e2e.ts
+++ b/packages/components/src/modal/src/components/osds-modal/osds-modal.e2e.ts
@@ -20,7 +20,7 @@ describe('e2e:osds-modal', () => {
     el = await page.find('osds-modal');
 
     await page.evaluate(() => {
-      const modalElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.wrapper') as HTMLDialogElement;
+      const modalElement = document.querySelector('osds-modal')?.shadowRoot?.querySelector('.popup') as HTMLElement;
       modalElement.style.setProperty('animation', 'none');
     });
   }
@@ -46,7 +46,7 @@ describe('e2e:osds-modal', () => {
       expect(closeIcon).toBeNull();
     });
 
-    it('should set display styling to none when clicked', async() => {
+    it('should set masked to true when clicked', async() => {
       await setup({ attributes: { dismissible: true } });
 
       const closeIcon = await page.find('osds-modal >>> osds-icon[name="close"]');
@@ -54,11 +54,8 @@ describe('e2e:osds-modal', () => {
       await closeIcon.click();
       await page.waitForChanges();
 
-      const display = await page.evaluate(() => {
-        const modal = document.querySelector('osds-modal');
-        return modal ? window.getComputedStyle(modal).display : null;
-      });
-      expect(display).toBe('none');
+      const masked = await el.getProperty('masked');
+      expect(masked).toBe(true);
     });
   });
 

--- a/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
+++ b/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
@@ -22,41 +22,45 @@
 
 :host {
   display: flex;
-  position: fixed;
-  top: 0;
-  left: 0;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
 
-  .backdrop {
-    position: absolute;
-    opacity: 0.75;
-  }
-
-  .wrapper {
-    position: fixed;
-    z-index: 1;
-    outline: none;
-    border: none;
-    overflow: hidden;
-    animation: modal-appear 0.2s ease-in-out;
-
-    .header {
+  .dialog {
+    .wrapper {
       display: flex;
-      align-items: center;
-      justify-content: flex-end;
-      overflow: hidden;
-    }
+      position: fixed;
+      top: 0;
+      left: 0;
+      overflow-y: scroll;
 
-    .content {
-      max-height: 50vh;
-      overflow-y: auto;
+      .backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: -1;
+      }
 
-      .actions {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
+      .popup {
+        overflow: visible;
+        animation: modal-appear 0.2s ease-in-out;
+
+        .header {
+          display: flex;
+          align-items: center;
+          justify-content: flex-end;
+          overflow: hidden;
+        }
+
+        .content {
+          .slot {
+            display: flex;
+            flex-direction: column;
+          }
+
+          .actions {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+          }
+        }
       }
     }
   }

--- a/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
+++ b/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
@@ -29,13 +29,14 @@
       position: fixed;
       top: 0;
       left: 0;
-      overflow-y: scroll;
+      overflow-y: auto;
 
       .backdrop {
         position: fixed;
         top: 0;
         left: 0;
         z-index: -1;
+        pointer-events: none;
       }
 
       .popup {

--- a/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
+++ b/packages/components/src/modal/src/components/osds-modal/osds-modal.scss
@@ -50,11 +50,6 @@
         }
 
         .content {
-          .slot {
-            display: flex;
-            flex-direction: column;
-          }
-
           .actions {
             display: flex;
             align-items: center;

--- a/packages/components/src/modal/src/components/osds-modal/osds-modal.tsx
+++ b/packages/components/src/modal/src/components/osds-modal/osds-modal.tsx
@@ -99,36 +99,42 @@ export class OsdsModal implements OdsModalAttribute, OdsModalMethod, OdsModalEve
 
     return (
       <Host masked={masked}>
-        <div class="backdrop"></div>
-
         <dialog
-          class="wrapper"
+          class="dialog"
+          tabindex={-1}
           ref={(el?: HTMLElement | null): void => {
             this.modal = el as HTMLDialogElement;
           }}>
-          <div class="header">
-            {dismissible && (
-              <osds-button onClick={(): Promise<void> => this.close()} color={color} circle variant={ODS_BUTTON_VARIANT.ghost}>
-                <osds-icon ariaName={ODS_ICON_NAME.CLOSE + ' icon'} name={ODS_ICON_NAME.CLOSE} size={ODS_ICON_SIZE.sm} color={color}></osds-icon>
-              </osds-button>
-            )}
-          </div>
 
-          <div class="content">
-            {headline && headline.length > 0 && (
-              <div class="headline">
-                <osds-text level={ODS_TEXT_LEVEL.heading} size={ODS_THEME_TYPOGRAPHY_SIZE._400} color={ODS_THEME_COLOR_INTENT.primary}>
-                  {headline}
-                </osds-text>
+          <div class="wrapper">
+            <div class="backdrop"></div>
+
+            <div class="popup">
+              <div class="header">
+                {dismissible && (
+                  <osds-button onClick={(): Promise<void> => this.close()} color={color} circle variant={ODS_BUTTON_VARIANT.ghost}>
+                    <osds-icon ariaName={ODS_ICON_NAME.CLOSE + ' icon'} name={ODS_ICON_NAME.CLOSE} size={ODS_ICON_SIZE.sm} color={color}></osds-icon>
+                  </osds-button>
+                )}
               </div>
-            )}
 
-            <div class="slot">
-              <slot></slot>
-            </div>
+              <div class="content" tabindex={-1}>
+                {headline && headline.length > 0 && (
+                  <div class="headline">
+                    <osds-text level={ODS_TEXT_LEVEL.heading} size={ODS_THEME_TYPOGRAPHY_SIZE._400} color={ODS_THEME_COLOR_INTENT.primary}>
+                      {headline}
+                    </osds-text>
+                  </div>
+                )}
 
-            <div class="actions">
-              <slot name="actions"></slot>
+                <div class="slot">
+                  <slot></slot>
+                </div>
+
+                <div class="actions">
+                  <slot name="actions"></slot>
+                </div>
+              </div>
             </div>
           </div>
         </dialog>

--- a/packages/components/src/modal/src/components/osds-modal/styles/osds-modal.color.scss
+++ b/packages/components/src/modal/src/components/osds-modal/styles/osds-modal.color.scss
@@ -7,9 +7,13 @@
     background-color: '100'
   )) using($colors) {
     @include osds-modal-on-selected-host {
-      .wrapper {
-        .header {
-          background-color: map_get($colors, background-color);
+      .dialog {
+        .wrapper {
+          .popup {
+            .header {
+              background-color: map_get($colors, background-color);
+            }
+          }
         }
       }
     }
@@ -22,15 +26,24 @@
   :host {
     border-color: transparent;
 
-    .backdrop {
-      background-color: var(--ods-color-primary-500);
-    }
+    .dialog {
+      border-color: transparent;
+      background: none;
 
-    .wrapper {
-      background: #fff;
+      .wrapper {
+        // Doesn't work with most browsers
+        &::backdrop {
+          background: none;
+        }
 
-      &::backdrop {
-        opacity: 0;
+        .backdrop {
+          opacity: 0.75;
+          background-color: var(--ods-color-primary-500);
+        }
+
+        .popup {
+          background-color: var(--ods-color-default-000);
+        }
       }
     }
   }

--- a/packages/components/src/modal/src/components/osds-modal/styles/osds-modal.size.scss
+++ b/packages/components/src/modal/src/components/osds-modal/styles/osds-modal.size.scss
@@ -3,45 +3,49 @@
 
 // Main CSS mixin for sizes
 @mixin osds-modal-theme-size() {
-  :host {
-    width: 100%;
-    height: 100%;
-
-    * {
-      box-sizing: border-box;
-    }
-
-    .backdrop {
-      width: 100%;
-      height: 100%;
-    }
-
-    .wrapper {
-      border-radius: var(--ods-size-04);
-      padding: 0;
-      width: 100%;
-      max-width: 512px;
-
-      .header {
-        padding: 0 calc(var(--ods-size-04) / 2);
-        width: 100%;
-        height: calc(var(--ods-size-09) + var(--ods-size-05));
-      }
-
-      .content {
-        padding: var(--ods-size-06) var(--ods-size-08) var(--ods-size-08);
-        width: 100%;
-
-        .headline {
-          margin-bottom: var(--ods-size-04);
+    :host {
+        * {
+            box-sizing: border-box;
         }
 
-        .actions {
-          gap: var(--ods-size-04);
-          margin-top: var(--ods-size-07);
-          width: 100%;
+        .dialog {
+            .wrapper {
+                padding: var(--ods-size-09) 0;
+                width: 100%;
+                height: 100%;
+
+                .backdrop {
+                    width: 100%;
+                    height: 100%;
+                }
+
+                .popup {
+                    margin: auto;
+                    border-radius: var(--ods-size-04);
+                    padding: 0;
+                    width: 70%;
+                    min-width: 50%;
+                    max-width: clamp(36rem, 70%, 70%);
+                    height: fit-content;
+
+                    .header {
+                        border-top-left-radius: var(--ods-size-04);
+                        border-top-right-radius: var(--ods-size-04);
+                        padding: 0 calc(var(--ods-size-04) / 2);
+                        width: 100%;
+                        height: calc(var(--ods-size-09) + var(--ods-size-05));
+                    }
+
+                    .content {
+                        padding: var(--ods-size-06) var(--ods-size-08) var(--ods-size-08);
+
+                        .actions {
+                            gap: var(--ods-size-04);
+                            margin-top: var(--ods-size-07);
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/packages/components/src/modal/src/index.html
+++ b/packages/components/src/modal/src/index.html
@@ -69,7 +69,7 @@
   </osds-modal>
   <osds-modal
     id="modal-3"
-    color="success"
+    color="error"
     headline="On Vous Héberge ?"
     dismissible="true"
     masked="true"
@@ -77,7 +77,7 @@
     <osds-text color="text">
       OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
     </osds-text>
-    <osds-select class="w-20" id="select7">
+    <osds-select class="w-20" id="select7" style="margin-top:20px">
       <span slot="placeholder"><i>Select</i> Country</span>
       <osds-select-group>Group title</osds-select-group>
       <osds-select-option value="1">hezh <strong>Value 1</strong></osds-select-option>
@@ -85,7 +85,36 @@
       <osds-select-option value="3">Value 3</osds-select-option>
     </osds-select>
     <osds-button slot="actions" color="default" href="https://www.ovh.com/fr/" target="_blank">En savoir plus</osds-button>
-    <osds-button slot="actions" color="success" href="https://www.ovh.com/fr/" target="_blank">On m'héberge</osds-button>
+    <osds-button slot="actions" color="error" href="https://www.ovh.com/fr/" target="_blank">On m'héberge</osds-button>
+  </osds-modal>
+  <osds-modal
+    id="modal-4"
+    color="warning"
+    headline="On Vous Héberge ?"
+    dismissible="true"
+    masked="true"
+  >
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-text size="800" color="text">OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).</osds-text>
+    <osds-select class="w-20" id="select7" style="margin-top:20px">
+      <span slot="placeholder"><i>Select</i> Country</span>
+      <osds-select-group>Group title</osds-select-group>
+      <osds-select-option value="1">Test <strong>Value 1</strong></osds-select-option>
+      <osds-select-option value="2">A value way toooooooooooooooooooo long for a select</osds-select-option>
+      <osds-select-option value="3">Value 3</osds-select-option>
+    </osds-select>
+    <osds-button slot="actions" color="default" href="https://www.ovh.com/fr/" target="_blank">En savoir plus</osds-button>
+    <osds-button slot="actions" color="warning" href="https://www.ovh.com/fr/" target="_blank">On m'héberge</osds-button>
   </osds-modal>
 </body>
 

--- a/packages/components/src/modal/src/index.html
+++ b/packages/components/src/modal/src/index.html
@@ -21,7 +21,8 @@
   <div>
     <osds-button id="modal-trigger-1" inline slot="actions" color="info">Modal 1</osds-button>
     <osds-button id="modal-trigger-2" inline slot="actions" color="success">Modal 2</osds-button>
-    <osds-button id="modal-trigger-3" inline slot="actions" color="warning">Modal 3</osds-button>
+    <osds-button id="modal-trigger-3" inline slot="actions" color="error">Modal 3</osds-button>
+    <osds-button id="modal-trigger-4" inline slot="actions" color="warning">Modal 4</osds-button>
 
   </div>
   <script>
@@ -33,6 +34,9 @@
     });
     document.querySelector('#modal-trigger-3').addEventListener(('click'), () => {
       document.querySelector('#modal-3').open();
+    });
+    document.querySelector('#modal-trigger-4').addEventListener(('click'), () => {
+      document.querySelector('#modal-4').open();
     });
   </script>
 
@@ -65,38 +69,23 @@
   </osds-modal>
   <osds-modal
     id="modal-3"
-    color="warning"
+    color="success"
     headline="On Vous Héberge ?"
     dismissible="true"
     masked="true"
   >
-    <div style="display: flex; flex-direction: column; gap: 10px;">
-      <osds-text color="text">
-        OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
-      </osds-text>
-      <osds-select class="w-20" id="select7">
-        <span slot="placeholder"><i>Select</i> something</span>
-        <osds-select-group>Group title</osds-select-group>
-        <osds-select-option value="1">This is the <strong>Value 1</strong></osds-select-option>
-        <osds-select-option value="2">A value way toooooooooooooooooooo long for a select</osds-select-option>
-        <osds-select-option value="3">Value 3</osds-select-option>
-      </osds-select>
-      <osds-input inline type="text" value="On Vous Héberge ?" clearable></osds-input>
-      <osds-text color="text">
-        OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
-      </osds-text>
-      <osds-input inline type="text" value="On Vous Héberge ?" clearable></osds-input>
-      <osds-text color="text">
-        OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
-      </osds-text>
-      <osds-input inline type="text" value="On Vous Héberge ?" clearable></osds-input>
-      <osds-text color="text">
-        OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
-      </osds-text>
-      <osds-input inline type="text" value="On Vous Héberge ?" clearable></osds-input>
-    </div>
+    <osds-text color="text">
+      OVHcloud, anciennement OVH, est une entreprise française. Elle pratique initialement de l'hébergement de serveur, et est un fournisseur d'accès à Internet (FAI), puis opérateur de télécommunications pour les entreprises. Elle se développe, à la fin des années 2010, dans le cloud computing (informatique en nuage).
+    </osds-text>
+    <osds-select class="w-20" id="select7">
+      <span slot="placeholder"><i>Select</i> Country</span>
+      <osds-select-group>Group title</osds-select-group>
+      <osds-select-option value="1">hezh <strong>Value 1</strong></osds-select-option>
+      <osds-select-option value="2">A value 2 way toooooooooooooooooooo long for a select but</osds-select-option>
+      <osds-select-option value="3">Value 3</osds-select-option>
+    </osds-select>
     <osds-button slot="actions" color="default" href="https://www.ovh.com/fr/" target="_blank">En savoir plus</osds-button>
-    <osds-button slot="actions" color="warning" href="https://www.ovh.com/fr/" target="_blank">On m'héberge</osds-button>
+    <osds-button slot="actions" color="success" href="https://www.ovh.com/fr/" target="_blank">On m'héberge</osds-button>
   </osds-modal>
 </body>
 

--- a/packages/components/src/popover/src/components/osds-popover/styles/osds-popover.size.scss
+++ b/packages/components/src/popover/src/components/osds-popover/styles/osds-popover.size.scss
@@ -3,8 +3,9 @@
 // Main CSS mixin for sizes
 @mixin osds-popover-theme-size() {
   ocdk-surface {
-    padding: 8px;
+    padding: var(--ods-size-04);
     width: max-content;
     max-width: 300px;
+    overflow: visible;
   }
 }

--- a/packages/components/src/select/src/components/osds-select/osds-select.tsx
+++ b/packages/components/src/select/src/components/osds-select/osds-select.tsx
@@ -112,7 +112,7 @@ export class OsdsSelect implements OdsSelectAttribute, OdsSelectEvent, OdsSelect
   }
 
   handleKeyDown(event: KeyboardEvent): void {
-    event.stopPropagation();
+    event.preventDefault();
     this.controller.handlerKeyDown(event);
   }
 


### PR DESCRIPTION
## Initial issue
If an `OcdkSurface` is contained into a `OsdsPopover` or `OsdsModal` component and is too large for its container, it will be overflowing inside the said container leading to an unpleasant scroll both horizontally and vertically.

## Content
- Fixing the issue on `OsdsPopover` by adding overflow properties.
- Fixing the issue on `OsdsModal` by editing the structure of the component and its SCSS properties.
- Fixing the issue with the `OsdsModal` if you open an `OsdsSelect` inside and close it with the `ESC` key.

## To review
Check if the listed fixes above work on every testable environment you have. Make sure that the Surface will overflow from the `OsdsModal` or the `OsdsPopover` when it should.