### PR TITLE
fix(menu): force min height in style instead of CDK

### DIFF
--- a/packages/components/src/menu/src/components/osds-menu/styles/osds-menu.size.scss
+++ b/packages/components/src/menu/src/components/osds-menu/styles/osds-menu.size.scss
@@ -7,6 +7,7 @@
     padding: 0;
     width: auto;
     max-width: 25rem;
+    min-height: 36px !important;
     overflow: hidden;
   }
 }

--- a/packages/components/src/menu/src/components/osds-menu/styles/osds-menu.size.scss
+++ b/packages/components/src/menu/src/components/osds-menu/styles/osds-menu.size.scss
@@ -7,7 +7,7 @@
     padding: 0;
     width: auto;
     max-width: 25rem;
-    min-height: 36px !important;
+    min-height: 36px !important; /* important is necessary to override the min-height inline rule setted by CDK */
     overflow: hidden;
   }
 }


### PR DESCRIPTION
Fix bottom margin when there is one element by setting min height in menu style instead of automatically setted by CDK