### PR TITLE
feat(autocomplete): create component

### DIFF
--- a/packages/components/src/autocomplete/.gitignore
+++ b/packages/components/src/autocomplete/.gitignore
@@ -1,0 +1,35 @@
+#--- Project related ---#
+.stencil/
+coverage/
+dist/
+docs-api/
+screenshot/
+www/
+src/components.d.ts
+
+# Local Stencil command generates external ods component build at the root of the project
+# Excluding them is a temporary solution to avoid pushing generated files
+# But the issue may cause main build (ods-component package) to fails, as it detects multiples occurences
+# of the same component and thus you have to delete all those generated dir manually
+*/src/
+
+#--- Misc ---#
+*~
+*.sw[mnpcod]
+*.log
+*.lock
+*.tmp
+*.tmp.*
+log.txt
+*.sublime-project
+*.sublime-workspace
+.idea/
+.vscode/
+.sass-cache/
+.versions/
+node_modules/
+$RECYCLE.BIN/
+.DS_Store
+Thumbs.db
+UserInterfaceState.xcuserstate
+.env

--- a/packages/components/src/autocomplete/documentation/specifications/spec.md
+++ b/packages/components/src/autocomplete/documentation/specifications/spec.md
@@ -1,0 +1,48 @@
+* [**Interfaces**](#interfaces)
+
+## Interfaces
+
+### OdsAutocompleteAttribute
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`ariaLabel`** | `undefined` \| `string` | ✴️ |  | The corresponding aria-label describing its content|
+|**`ariaLabelledby`** | _string_ | ✴️ |  | The ID to an external description|
+|**`clearable`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be clearable or not (displays a clear button)|
+|**`defaultValue`** | _string_ | ✴️ |  | Default value of the Autocomplete|
+|**`disabled`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)|
+|**`error`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should display an error state|
+|**`icon`** | `ODS_ICON_NAME` |  |  | Defines if the Autocomplete should display an icon in the input field|
+|**`inline`** | _boolean_ | ✴️ |  | Indicates if the Autocomplete is full width or not: see component principles|
+|**`isLoading`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should display a loading spinner in the dropdown|
+|**`minimumNumberOfCharacters`** | _number_ | ✴️ |  | Defines the Autocomplete's minimum number of characters to open the dropdown|
+|**`name`** | _string_ |  |  | Name of the Autocomplete field|
+|**`opened`** | _boolean_ | ✴️ |  | Defines if the Autocomplete dropdown is opened or not|
+|**`placeholder`** | _string_ |  |  | Defines if the Autocomplete should display a placeholder message|
+|**`required`** | _boolean_ | ✴️ |  | Defines if a value has to be selected or not|
+|**`value`** | _string_ | ✴️ |  | Defines the Autocomplete's value|
+
+### OdsAutocompleteEvent
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`odsBlur`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's blur|
+|**`odsFocus`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's focus|
+|**`odsValueChange`** | `EventEmitter<OdsAutocompleteValueChangeEventDetail>` | ✴️ |  | Event emitted on value change|
+
+### OdsAutocompleteMethod
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`clear`** | `Promise<void>` | ✴️ |  | Erase the current selection|
+|**`getValidity`** | `Promise<OdsValidityState>` | ✴️ |  | Get the validity state|
+|**`reset`** | `Promise<void>` | ✴️ |  | Reset the value to the initial one (default value)|
+|**`setFocus`** | `Promise<void>` | ✴️ |  | Focus the element|
+|**`setInputTabindex`** | `Promise<void>` | ✴️ |  | Set tab index on the component|
+|**`validate`** | `Promise<OdsValidityState>` | ✴️ |  | check if the Autocomplete is valid.In case of required field, the validation will check the entered valueand set the field in error if it is not fulfilled|
+
+### OdsAutocompleteValueChangeEventDetail
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`name`** | _string_ |  |  | |
+|**`oldValue`** | `OdsInputValue` |  |  | |
+|**`selection`** | `undefined` \| `OsdsSelectOption` | ✴️ |  | |
+|**`validity`** | `OdsValidityState` | ✴️ |  | |
+|**`value`** | `OdsInputValue` | ✴️ |  | |

--- a/packages/components/src/autocomplete/documentation/specifications/specifications-autocomplete.mdx
+++ b/packages/components/src/autocomplete/documentation/specifications/specifications-autocomplete.mdx
@@ -1,0 +1,47 @@
+* [**Interfaces**](#interfaces)
+
+## Interfaces
+
+### OdsAutocompleteAttribute
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`ariaLabel`** | `undefined` \| `string` | ✴️ |  | The corresponding aria-label describing its content|
+|**`ariaLabelledby`** | _string_ | ✴️ |  | The ID to an external description|
+|**`clearable`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be clearable or not (displays a clear button)|
+|**`defaultValue`** | _string_ | ✴️ |  | Default value of the Autocomplete|
+|**`disabled`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)|
+|**`error`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should display an error state|
+|**`icon`** | `ODS_ICON_NAME` |  |  | Defines if the Autocomplete should display an icon in the input field|
+|**`inline`** | _boolean_ | ✴️ |  | Indicates if the Autocomplete is full width or not: see component principles|
+|**`minimumNumberOfCharacters`** | _number_ | ✴️ |  | Defines the Autocomplete's minimum number of characters to open the dropdown|
+|**`name`** | _string_ |  |  | Name of the Autocomplete field|
+|**`opened`** | _boolean_ | ✴️ |  | Defines if the Autocomplete dropdown is opened or not|
+|**`placeholder`** | _string_ |  |  | Defines if the Autocomplete should display a placeholder message|
+|**`required`** | _boolean_ | ✴️ |  | Defines if a value has to be selected or not|
+|**`value`** | _string_ | ✴️ |  | Defines the Autocomplete's value|
+
+### OdsAutocompleteEvent
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`odsBlur`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's blur|
+|**`odsFocus`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's focus|
+|**`odsValueChange`** | `EventEmitter<OdsAutocompleteValueChangeEventDetail>` | ✴️ |  | Event emitted on value change|
+
+### OdsAutocompleteMethod
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`clear`** | `Promise<void>` | ✴️ |  | erase the current selection|
+|**`getValidity`** | `Promise<OdsValidityState>` | ✴️ |  | get the validity state|
+|**`reset`** | `Promise<void>` | ✴️ |  | reset the value to the initial one (default value)|
+|**`setFocus`** | `Promise<void>` | ✴️ |  | focus the element|
+|**`setInputTabindex`** | `Promise<void>` | ✴️ |  | set tab index on the component|
+|**`validate`** | `Promise<OdsValidityState>` | ✴️ |  | check that the select is valid or not.In case of required field, the validation will check the entered valueand set the field in error if it is not fulfilled|
+
+### OdsAutocompleteValueChangeEventDetail
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`name`** | _string_ |  |  | |
+|**`oldValue`** | `OdsInputValue` |  |  | |
+|**`selection`** | `undefined` \| `OsdsSelectOption` | ✴️ |  | |
+|**`validity`** | `OdsValidityState` | ✴️ |  | |
+|**`value`** | `OdsInputValue` | ✴️ |  | |

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/logic/WithLogicComponent.ts
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/logic/WithLogicComponent.ts
@@ -1,0 +1,56 @@
+import type { OsdsAutocomplete } from '@ovhcloud/ods-components';
+import React, { useEffect } from 'react';
+
+type DatabaseEntry = {
+  value: string;
+  text: string;
+};
+
+const WithLogicComponent: React.FC = () => {
+  useEffect(() => {
+    const autocomplete = document.querySelector('#logic') as (HTMLElement & OsdsAutocomplete) | null;
+
+    const database: DatabaseEntry[] = [
+      { value: 'Hello', text: 'Hello World' },
+      { value: 'How', text: 'How are you today?' },
+      { value: 'Bonjour', text: 'Bonjour tout le monde' },
+      { value: 'Hola', text: 'Hola Mundo' },
+      { value: 'Fizz', text: 'Buzz' },
+      { value: 'Auto', text: 'Autocomplete' },
+    ];
+
+    const updateOptions = (value: string): void => {
+      while (autocomplete && autocomplete.firstChild) {
+        autocomplete.removeChild(autocomplete.firstChild);
+      }
+
+      const regex = new RegExp(value, 'i');
+      database.forEach((entry) => {
+        if (regex.test(entry.text)) {
+          const optionElement = document.createElement('osds-select-option');
+          optionElement.value = entry.value;
+          optionElement.tabIndex = 1;
+
+          const textElem = document.createElement('osds-text');
+          textElem.innerHTML = entry.text.replace(regex, '<b>$&</b>');
+          optionElement.appendChild(textElem);
+
+          autocomplete?.appendChild(optionElement);
+        }
+      });
+    };
+
+    if (autocomplete) {
+      autocomplete.addEventListener('odsValueChange', (event: Event) => {
+        const detail = (event as CustomEvent<{ value: string }>).detail;
+        updateOptions(detail.value);
+      });
+
+      updateOptions('');
+    }
+  }, []);
+
+  return null;
+};
+
+export default WithLogicComponent;

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/logic/WithLogicComponent.ts
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/logic/WithLogicComponent.ts
@@ -1,4 +1,4 @@
-import type { OsdsAutocomplete } from '@ovhcloud/ods-components';
+import type { OsdsAutocomplete } from '../../../src/components/osds-autocomplete/public-api';
 import React, { useEffect } from 'react';
 
 type DatabaseEntry = {

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.clearable.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.clearable.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline clearable>
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline clearable>
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.disabled.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.disabled.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline disabled>
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline disabled>
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.error.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.error.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline error>
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline error>
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.icon.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.icon.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline icon="home">
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline icon="home">
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.inline.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.inline.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline>
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline>
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.logic.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.logic.mdx
@@ -1,0 +1,68 @@
+import WithLogicComponent from '../logic/WithLogicComponent.ts';
+import { Canvas } from '@storybook/addon-docs';
+
+The `osds-autocomplete` component is a versatile visual tool designed to enhance user experience by providing a dynamic and responsive option selection mechanism. It allows users to quickly find and select from a list of options, reducing the need for extensive navigation and search.
+
+Please keep in mind that the `osds-autocomplete` does not integrate any sorting logic by itself.
+
+#### Implementing Dynamic Option Updating
+
+We provide you here with an example of how options can be dynamically updated based on user input. This example serves an informative purpose, and is only one way of how you could implement this logic on the `osds-autocomplete`.
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete id="logic" clearable="true" placeholder="Bonjour">
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+<WithLogicComponent />
+
+```html
+<osds-autocomplete id="logic" clearable="true" placeholder="Bonjour">
+  [... -> Leave it empty to edit the slot]
+</osds-autocomplete>
+```
+
+```javascript
+<script>
+  const autocomplete = document.querySelector('#logic');
+
+  const database = [
+    { value: 'Hello', text: 'Hello World' },
+    { value: 'How', text: 'How are you today?' },
+    { value: 'Bonjour', text: 'Bonjour tout le monde' },
+    { value: 'Hola', text: 'Hola Mundo' },
+    { value: 'Fizz', text: 'Buzz' },
+    { value: 'Auto', text: 'Autocomplete' },
+  ];
+
+  const updateOptions = (value) => {
+    while (autocomplete && autocomplete.firstChild) {
+      autocomplete.removeChild(autocomplete.firstChild);
+    }
+    const regex = new RegExp(value, 'i');
+
+    database.forEach((entry) => {
+      if (regex.test(entry.text)) {
+        const optionElement = document.createElement('osds-select-option');
+        optionElement.value = entry.value;
+        optionElement.tabIndex = 1;
+        const textElem = document.createElement('osds-text');
+        textElem.innerHTML = entry.text.replace(regex, '<b>$&</b>');
+        optionElement.appendChild(textElem);
+        autocomplete?.appendChild(optionElement);
+      }
+    });
+  };
+
+  if (autocomplete) {
+    autocomplete.addEventListener('odsValueChange', (event) => {
+      const detail = event.detail;
+      updateOptions(detail.value);
+    });
+
+    updateOptions('');
+  }
+</script>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.minimumNumberOfCharacters.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.minimumNumberOfCharacters.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline minimum-number-of-characters="2">
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline minimum-number-of-characters="2">
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.placeholder.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/properties/usage.placeholder.mdx
@@ -1,0 +1,17 @@
+import { Canvas } from '@storybook/addon-docs';
+
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete inline placeholder="My custom placeholder...">
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas>
+
+```html
+<osds-autocomplete inline placeholder="My custom placeholder...">
+  [... -> your Select Options]
+</osds-autocomplete>
+```

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/usage.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/usage.mdx
@@ -1,3 +1,4 @@
+import WithLogic from './properties/usage.logic.mdx';
 import ClearableProperty from './properties/usage.clearable.mdx';
 import DisabledProperty from './properties/usage.disabled.mdx';
 import ErrorProperty from './properties/usage.error.mdx';
@@ -30,6 +31,9 @@ import { Canvas } from '@storybook/addon-docs';
     <osds-select-option value="EN">Hello</osds-select-option>
 </osds-autocomplete>
 ```
+
+### Autocompletion Logic
+<WithLogic />
 
 ### Clearable
 <ClearableProperty />

--- a/packages/components/src/autocomplete/documentation/usage-guidelines/usage.mdx
+++ b/packages/components/src/autocomplete/documentation/usage-guidelines/usage.mdx
@@ -1,0 +1,56 @@
+import ClearableProperty from './properties/usage.clearable.mdx';
+import DisabledProperty from './properties/usage.disabled.mdx';
+import ErrorProperty from './properties/usage.error.mdx';
+import IconProperty from './properties/usage.icon.mdx';
+import InlineProperty from './properties/usage.inline.mdx';
+import MinimumNumberOfCharactersProperty from './properties/usage.minimumNumberOfCharacters.mdx';
+import PlaceholderProperty from './properties/usage.placeholder.mdx';
+import GenericStyle from '@ovhcloud/ods-common-core/docs/generic-style.mdx';
+import { Canvas } from '@storybook/addon-docs';
+
+<GenericStyle />
+
+## Usage
+
+### Default
+<Canvas withSource="none">
+  <div style={{ height: '300px' }}>
+    <osds-autocomplete>
+      <osds-select-option value="FR">Bonjour</osds-select-option>
+      <osds-select-option value="IT">Bongiorno</osds-select-option>
+      <osds-select-option value="EN">Hello</osds-select-option>
+    </osds-autocomplete>
+  </div>
+</Canvas >
+
+```html
+<osds-autocomplete>
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+</osds-autocomplete>
+```
+
+### Clearable
+<ClearableProperty />
+
+### Disabled
+<DisabledProperty />
+
+### Error
+<ErrorProperty />
+
+### Icon
+<IconProperty />
+
+### Inline
+<InlineProperty />
+
+### Inline
+<InlineProperty />
+
+### MinimumNumberOfCharacters
+<MinimumNumberOfCharactersProperty />
+
+### Placeholder
+<PlaceholderProperty />

--- a/packages/components/src/autocomplete/jest.config.ts
+++ b/packages/components/src/autocomplete/jest.config.ts
@@ -1,0 +1,7 @@
+import { getStencilJestConfig } from '@ovhcloud/ods-common-testing';
+
+const config = getStencilJestConfig({
+  args: process.argv.slice(2),
+});
+
+export default config;

--- a/packages/components/src/autocomplete/package.json
+++ b/packages/components/src/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovhcloud/ods-component-autocomplete",
-  "version": "17.1.0",
+  "version": "17.2.1",
   "private": true,
   "description": "ODS Autocomplete Component",
   "license": "Apache-2.0",
@@ -28,13 +28,13 @@
     "FIXME_test:e2e:ci:screenshot:update": "stencil test --config stencil.config.ts --e2e --ci --screenshot --update-screenshot --passWithNoTests"
   },
   "dependencies": {
-    "@ovhcloud/ods-cdk": "17.1.0",
-    "@ovhcloud/ods-common-core": "17.1.0",
-    "@ovhcloud/ods-common-stencil": "17.1.0",
-    "@ovhcloud/ods-common-theming": "17.1.0"
+    "@ovhcloud/ods-cdk": "17.2.1",
+    "@ovhcloud/ods-common-core": "17.2.1",
+    "@ovhcloud/ods-common-stencil": "17.2.1",
+    "@ovhcloud/ods-common-theming": "17.2.1"
   },
   "devDependencies": {
-    "@ovhcloud/ods-common-testing": "17.1.0",
-    "@ovhcloud/ods-stencil-dev": "17.1.0"
+    "@ovhcloud/ods-common-testing": "17.2.1",
+    "@ovhcloud/ods-stencil-dev": "17.2.1"
   }
 }

--- a/packages/components/src/autocomplete/package.json
+++ b/packages/components/src/autocomplete/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ovhcloud/ods-component-autocomplete",
+  "version": "17.1.0",
+  "private": true,
+  "description": "ODS Autocomplete Component",
+  "license": "Apache-2.0",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.js",
+  "es2015": "dist/esm/index.js",
+  "es2017": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "collection": "dist/collection/collection-manifest.json",
+  "collection:main": "dist/collection/index.js",
+  "scripts": {
+    "clean": "rimraf .stencil coverage custom-elements custom-elements-bundle dist docs-api loader screenshot www",
+    "doc": "typedoc --json ./docs-api/typedoc.json --pretty && node ../../../../scripts/generate-typedoc-md.js",
+    "doc:api": "typedoc",
+    "lint:scss": "stylelint 'src/components/**/*.scss'",
+    "lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
+    "start": "stencil build --dev --watch --serve",
+    "test:e2e": "stencil test --e2e --config stencil.config.ts",
+    "test:e2e:ci": "stencil test --config stencil.config.ts --e2e --ci",
+    "test:e2e:screenshot": "stencil test --e2e --screenshot --config stencil.config.ts --passWithNoTests",
+    "test:e2e:screenshot:update": "stencil test --e2e --screenshot --config stencil.config.ts --update-screenshot --passWithNoTests",
+    "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
+    "test:spec:ci": "stencil test --config stencil.config.ts  --spec --ci --coverage",
+    "FIXME_test:e2e:ci:screenshot": "stencil test --config stencil.config.ts --e2e --ci --screenshot --passWithNoTests",
+    "FIXME_test:e2e:ci:screenshot:update": "stencil test --config stencil.config.ts --e2e --ci --screenshot --update-screenshot --passWithNoTests"
+  },
+  "dependencies": {
+    "@ovhcloud/ods-cdk": "17.1.0",
+    "@ovhcloud/ods-common-core": "17.1.0",
+    "@ovhcloud/ods-common-stencil": "17.1.0",
+    "@ovhcloud/ods-common-theming": "17.1.0"
+  },
+  "devDependencies": {
+    "@ovhcloud/ods-common-testing": "17.1.0",
+    "@ovhcloud/ods-stencil-dev": "17.1.0"
+  }
+}

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
@@ -9,6 +9,7 @@ const DEFAULT_ATTRIBUTE: OdsAutocompleteAttribute = Object.freeze({
   error: false,
   icon: undefined,
   inline: false,
+  isLoading: false,
   minimumNumberOfCharacters: 0,
   name: undefined,
   opened: false,

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
@@ -1,0 +1,22 @@
+import type { OdsAutocompleteAttribute } from '../interfaces/attributes';
+
+const DEFAULT_ATTRIBUTE: OdsAutocompleteAttribute = Object.freeze({
+  ariaLabel: null,
+  ariaLabelledby: '',
+  clearable: false,
+  defaultValue: '',
+  disabled: false,
+  error: false,
+  icon: undefined,
+  inline: false,
+  minimumNumberOfCharacters: 0,
+  name: undefined,
+  opened: false,
+  placeholder: '',
+  required: false,
+  value: '',
+});
+
+export {
+  DEFAULT_ATTRIBUTE,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-validity-state.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-validity-state.ts
@@ -1,0 +1,14 @@
+import type { OdsValidityState } from '@ovhcloud/ods-common-core';
+
+const DEFAULT_VALIDITY_STATE: OdsValidityState = Object.freeze({
+  customError: false,
+  forbiddenValue: false,
+  invalid: false,
+  stepMismatch: false,
+  valid: true,
+  valueMissing: false,
+});
+
+export {
+  DEFAULT_VALIDITY_STATE,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/core/controller.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/core/controller.ts
@@ -1,0 +1,157 @@
+import type { OdsSelectOptionClickEventDetail, OsdsSelectOption } from '../../../../../select/src/components/osds-select-option/public-api';
+import type { OsdsAutocomplete } from '../osds-autocomplete';
+import type { OdsValidityState } from '@ovhcloud/ods-common-core';
+
+class OdsAutocompleteController {
+  private component: OsdsAutocomplete;
+  private _selectOptions: (HTMLElement & OsdsSelectOption)[] = [];
+
+  public get selectOptions(): (HTMLElement & OsdsSelectOption)[] {
+    return this._selectOptions;
+  }
+
+  public set selectOptions(value: (HTMLElement & OsdsSelectOption)[]) {
+    this._selectOptions = value;
+  }
+
+  constructor(component: OsdsAutocomplete) {
+    this.component = component;
+  }
+
+  beforeInit(): void {
+    if (this.component.value === '' && this.component.defaultValue !== undefined) {
+      this.component.value = this.component.defaultValue;
+    }
+    this.component.internals.setFormValue(this.component.value?.toString() ?? '');
+    this.component.openedChanged(this.component.opened);
+    this.component.selectedLabelSlot = this.component.el.querySelector('[slot="selectedLabel"]');
+  }
+
+  changeValue(value: string): void {
+    this.component.value = value;
+    this.component.internals.setFormValue(value?.toString() ?? '');
+  }
+
+  getValidity(): OdsValidityState {
+    const requiredError = this.hasRequiredError();
+    return {
+      customError: false,
+      forbiddenValue: false,
+      invalid: requiredError,
+      stepMismatch: false,
+      valid: !requiredError,
+      valueMissing: requiredError,
+    };
+  }
+
+  syncReferences(): void {
+    if (this.component.surface && this.component.anchor) {
+      this.component.surface.setAnchorElement(this.component.anchor);
+      this.component.surface.setAnchorMargin({ bottom: 0, top: 0 });
+    }
+  }
+
+  closeSurface(): void {
+    if (this.component.surface?.opened) {
+      this.component.surface.close();
+      this.component.opened = false;
+    }
+  }
+
+  openSurface(): void {
+    if (this.component.surface) {
+      this.component.surface.open();
+      this.component.opened = true;
+    }
+  }
+
+  hasRequiredError(): boolean {
+    if (this.component.required) {
+      return !this.component.value;
+    }
+    return false;
+  }
+
+  handlerKeyDown(event: KeyboardEvent): void {
+    const selectedSelectOptionIndex = this.selectOptions.findIndex((select) => select.getAttribute('selected') !== null || document.activeElement === select);
+    switch (event.code) {
+      case 'Escape': {
+        this.selectOptions.forEach((s) => s.removeAttribute('selected'));
+        this.selectOptions.find((s) => s.value === this.component.value)?.setAttribute('selected', '');
+        return this.closeSurface();
+      }
+      case 'ArrowUp':
+      case 'ArrowDown':
+      case 'Tab':
+        return this.handlerKeyArrow(event, selectedSelectOptionIndex);
+      case 'Enter':
+      case 'NumpadEnter':
+        return this.handlerKeyEnter(this.selectOptions[selectedSelectOptionIndex]);
+      default:
+        break;
+    }
+  }
+
+  private handlerKeyArrow(event: KeyboardEvent, selectedSelectOptionIndex: number): void {
+    if (!this.component.opened) {
+      return;
+    }
+    const focusSelectOption = (index: number): void => {
+      this.selectOptions[index].focus();
+      this.selectOptions[index].setAttribute('selected', '');
+      event.preventDefault();
+    };
+    const hasSelectedOption = selectedSelectOptionIndex !== -1;
+    if (hasSelectedOption) {
+      this.selectOptions[selectedSelectOptionIndex].removeAttribute('selected');
+      this.selectOptions[selectedSelectOptionIndex].blur();
+    }
+    if (event.code === 'ArrowUp' || (event.code === 'Tab' && event.shiftKey)) {
+      const index = hasSelectedOption ? selectedSelectOptionIndex - 1 : 0;
+      if (!hasSelectedOption && (event.code === 'Tab' && event.shiftKey)) {
+        return;
+      }
+      if (index < 0 && (event.code === 'Tab' && event.shiftKey)) {
+        event.preventDefault();
+        this.component.anchor.focus();
+        return;
+      }
+      if (index < 0) {
+        return focusSelectOption(this.selectOptions.length - 1);
+      }
+      return focusSelectOption(index);
+    }
+    if (event.code === 'ArrowDown' || event.code === 'Tab') {
+      const index = hasSelectedOption ? selectedSelectOptionIndex + 1 : 0;
+      if (index >= this.selectOptions.length && event.code === 'Tab') {
+        this.selectOptions.forEach((s) => s.removeAttribute('selected'));
+        this.selectOptions.find((s) => s.value === this.component.value)?.setAttribute('selected', '');
+        return this.closeSurface();
+      } else if (index >= this.selectOptions.length) {
+        return focusSelectOption(0);
+      }
+      return focusSelectOption(index);
+    }
+  }
+
+  private handlerKeyEnter(selectOption?: OsdsSelectOption): void {
+    if (!this.component.opened || !selectOption) {
+      return this.component.handleAutocompleteClick();
+    }
+    this.component.handleValueChange(new CustomEvent<OdsSelectOptionClickEventDetail>('odsSelectOptionClick', {
+      detail: {
+        value: selectOption.value,
+      },
+    }));
+    this.component.setFocus();
+  }
+
+  onValueChange(value: string, oldValue?: string): void {
+    this.component.internals.setFormValue(value?.toString() ?? '');
+    this.component.emitChange(value, oldValue);
+  }
+}
+
+export {
+  OdsAutocompleteController,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/core/controller.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/core/controller.ts
@@ -4,15 +4,7 @@ import type { OdsValidityState } from '@ovhcloud/ods-common-core';
 
 class OdsAutocompleteController {
   private component: OsdsAutocomplete;
-  private _selectOptions: (HTMLElement & OsdsSelectOption)[] = [];
-
-  public get selectOptions(): (HTMLElement & OsdsSelectOption)[] {
-    return this._selectOptions;
-  }
-
-  public set selectOptions(value: (HTMLElement & OsdsSelectOption)[]) {
-    this._selectOptions = value;
-  }
+  public selectOptions: (HTMLElement & OsdsSelectOption)[] = [];
 
   constructor(component: OsdsAutocomplete) {
     this.component = component;
@@ -47,7 +39,7 @@ class OdsAutocompleteController {
   syncReferences(): void {
     if (this.component.surface && this.component.anchor) {
       this.component.surface.setAnchorElement(this.component.anchor);
-      this.component.surface.setAnchorMargin({ bottom: 0, top: 0 });
+      this.component.surface.setAnchorMargin({ bottom: 0, left: 0, right: 0, top: 0 });
     }
   }
 

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
@@ -34,6 +34,10 @@ interface OdsAutocompleteAttribute {
    */
   inline: boolean;
   /**
+   * Defines if the Autocomplete should display a loading spinner in the dropdown
+   */
+  isLoading: boolean;
+  /**
    * Defines the Autocomplete's minimum number of characters to open the dropdown
    */
   minimumNumberOfCharacters: number;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
@@ -1,0 +1,64 @@
+import type { ODS_ICON_NAME } from '../../../../../icon/src';
+
+interface OdsAutocompleteAttribute {
+  /**
+   * The corresponding aria-label describing its content
+   */
+  ariaLabel: HTMLElement['ariaLabel'];
+  /**
+   * The ID to an external description
+   */
+  ariaLabelledby: string;
+  /**
+   * Defines if the Autocomplete should be clearable or not (displays a clear button)
+   */
+  clearable: boolean;
+  /**
+   * Default value of the Autocomplete
+   */
+  defaultValue: string;
+  /**
+   * Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)
+   */
+  disabled: boolean;
+  /**
+   * Defines if the Autocomplete should display an error state
+   */
+  error: boolean;
+  /**
+   * Defines if the Autocomplete should display an icon in the input field
+   */
+  icon?: ODS_ICON_NAME;
+  /**
+   * Indicates if the Autocomplete is full width or not: see component principles
+   */
+  inline: boolean;
+  /**
+   * Defines the Autocomplete's minimum number of characters to open the dropdown
+   */
+  minimumNumberOfCharacters: number;
+  /**
+   * Name of the Autocomplete field
+   */
+  name?: string;
+  /**
+   * Defines if the Autocomplete dropdown is opened or not
+   */
+  opened: boolean;
+  /**
+   * Defines if the Autocomplete should display a placeholder message
+   */
+  placeholder?: string;
+  /**
+   * Defines if a value has to be selected or not
+   */
+  required: boolean;
+  /**
+   * Defines the Autocomplete's value
+   */
+  value: string;
+}
+
+export type {
+  OdsAutocompleteAttribute,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/events.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/events.ts
@@ -1,0 +1,34 @@
+import type { OsdsSelectOption } from '../../../../../select/src/components/osds-select-option/osds-select-option';
+import type { OdsInputValue, OdsValidityState } from '@ovhcloud/ods-common-core';
+import type { EventEmitter } from '@stencil/core';
+
+interface OdsAutocompleteValueChangeEventDetail {
+  name?: string,
+  oldValue?: OdsInputValue,
+  selection: OsdsSelectOption | null,
+  validity: OdsValidityState,
+  value: OdsInputValue,
+}
+
+type OdsAutocompleteValueChangeEvent = CustomEvent<OdsAutocompleteValueChangeEventDetail>;
+
+interface OdsAutocompleteEvent {
+  /**
+   * Event triggered on Autocomplete's blur
+   */
+  odsBlur: EventEmitter<void>;
+  /**
+   * Event triggered on Autocomplete's focus
+   */
+  odsFocus: EventEmitter<void>;
+  /**
+   * Event emitted on value change
+   */
+  odsValueChange: EventEmitter<OdsAutocompleteValueChangeEventDetail>;
+}
+
+export type {
+  OdsAutocompleteEvent,
+  OdsAutocompleteValueChangeEvent,
+  OdsAutocompleteValueChangeEventDetail,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/methods.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/methods.ts
@@ -1,0 +1,39 @@
+import type { OdsValidityState } from '@ovhcloud/ods-common-core';
+
+interface OdsAutocompleteMethod {
+  /**
+   * Erase the current selection
+   */
+  clear(): Promise<void>;
+
+  /**
+   * Get the validity state
+   */
+  getValidity(): Promise<OdsValidityState>;
+
+  /**
+   * Reset the value to the initial one (default value)
+   */
+  reset(): Promise<void>;
+
+  /**
+   * Focus the element
+   */
+  setFocus(): Promise<void>;
+
+  /**
+   * Set tab index on the component
+   */
+  setInputTabindex(value: number): Promise<void>;
+
+  /**
+   * check if the Autocomplete is valid.
+   * In case of required field, the validation will check the entered value
+   * and set the field in error if it is not fulfilled
+   */
+  validate(): Promise<OdsValidityState>;
+}
+
+export type {
+  OdsAutocompleteMethod,
+};

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
@@ -7,7 +7,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 describe('e2e:osds-autocomplete', () => {
   let page: E2EPage;
   let el: E2EElement;
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
 
   async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
@@ -1,0 +1,62 @@
+import type { OdsAutocompleteAttribute } from './interfaces/attributes';
+import type { E2EElement, E2EPage } from '@stencil/core/testing';
+import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
+import { newE2EPage } from '@stencil/core/testing';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+
+describe('e2e:osds-autocomplete', () => {
+  let page: E2EPage;
+  let el: E2EElement;
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+
+  async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string } = {}): Promise<void> {
+    const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
+
+    page = await newE2EPage();
+
+    await page.setContent(`
+      <osds-autocomplete ${odsStringAttributes2Str(stringAttributes)}>${html}</osds-autocomplete>
+    `);
+    el = await page.find('osds-autocomplete');
+    await page.evaluate(() => document.body.style.setProperty('margin', '0'));
+  }
+
+  const screenshotActions = [
+    {
+      action: (): void => {/* no action */},
+      actionDescription: 'no action',
+    },
+    {
+      action: (): Promise<void> => el.click(),
+      actionDescription: 'surface visible',
+    },
+    {
+      action: (): void => el.setProperty('disabled', true),
+      actionDescription: 'disabled',
+    },
+  ];
+
+  describe('screenshots', () => {
+    screenshotActions.forEach(({ actionDescription, action }) => {
+      it(actionDescription, async() => {
+        await setup({
+          html: `
+            <osds-select-option value="FR">Bonjour</osds-select-option>
+            <osds-select-option value="IT">Bongiorno</osds-select-option>
+            <osds-select-option value="EN">Hello</osds-select-option>
+          `,
+        });
+        action();
+        await page.waitForChanges();
+
+        await page.evaluate(() => {
+          const element = document.querySelector('osds-autocomplete') as HTMLElement;
+          return { height: element.clientHeight, width: element.clientWidth };
+        });
+        await page.setViewport({ height:600, width: 600 });
+        const results = await page.compareScreenshot('autocomplete', { fullPage: false, omitBackground: true });
+        expect(results).toMatchScreenshot({ allowableMismatchedRatio: 0 });
+      });
+    });
+  });
+});

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
@@ -6,7 +6,7 @@ import { newE2EPage } from '@stencil/core/testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 describe('e2e:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: E2EPage;
   let el: E2EElement;
   let inputElement: E2EElement;
@@ -203,6 +203,14 @@ describe('e2e:osds-autocomplete', () => {
       await page.click('body');
       await page.waitForChanges();
       expect(await el.getProperty('opened')).toBe(false);
+    });
+  });
+
+  describe('isLoading', () => {
+    it('should display a loading spinner', async() => {
+      await setup({ attributes: { isLoading: true } });
+      const spinner = await page.find('osds-autocomplete >>> osds-spinner');
+      expect(spinner).not.toBeNull();
     });
   });
 

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
@@ -1,0 +1,247 @@
+import type { OdsAutocompleteAttribute } from './interfaces/attributes';
+import type { OdsAutocompleteValueChangeEventDetail } from './interfaces/events';
+import type { E2EElement, E2EPage } from '@stencil/core/testing';
+import { odsComponentAttributes2StringAttributes, odsStringAttributes2Str } from '@ovhcloud/ods-common-testing';
+import { newE2EPage } from '@stencil/core/testing';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+
+describe('e2e:osds-autocomplete', () => {
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  let page: E2EPage;
+  let el: E2EElement;
+  let inputElement: E2EElement;
+  let optionElement: E2EElement;
+
+  async function setup({ attributes = {}, html, onPage }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string, onPage?: ({ page }: { page: E2EPage }) => void } = {}): Promise<void> {
+    const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
+
+    page = await newE2EPage();
+    onPage && onPage({ page });
+
+    await page.setContent(`
+      <osds-autocomplete ${odsStringAttributes2Str(stringAttributes)}>
+        ${html ?? ''}
+        <osds-select-option value="FR">Bonjour</osds-select-option>
+        <osds-select-option value="IT">Bongiorno</osds-select-option>
+        <osds-select-option value="EN">Hello</osds-select-option>
+      </osds-autocomplete>
+    `);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    el = await page.find('osds-autocomplete');
+    inputElement = await page.find('osds-autocomplete >>> osds-input');
+    optionElement = await page.find('osds-autocomplete > osds-select-option');
+    await page.waitForChanges();
+  }
+
+  describe('defaults', () => {
+    beforeEach(async() => {
+      await setup({ });
+    });
+
+    it('should render', async() => {
+      expect(el).not.toBeNull();
+      expect(el).toHaveClass('hydrated');
+
+      expect(optionElement).not.toBeNull();
+      expect(optionElement).toHaveClass('hydrated');
+    });
+
+    it('should display a new option', async() => {
+      await setup({ attributes: { }, html: '<osds-select-option value="DE">Guten tag</osds-select-option>' });
+
+      const selectedLabel = await page.find('osds-select-option[value="DE"]');
+
+      expect(selectedLabel).toBeDefined();
+    });
+  });
+
+  it('should render & display the correct value', async() => {
+    await setup({ attributes: { value: 'my-value' } });
+    const value = await el.getProperty('value');
+    expect(value).toBe('my-value');
+    const inputValue = await inputElement.getProperty('value');
+    expect(inputValue).toBe('my-value');
+  });
+
+  it('should open the surface on click', async() => {
+    await setup({ });
+    await el.click();
+    await page.waitForChanges();
+    expect(await el.getProperty('opened')).toBe(true);
+  });
+
+  describe('minimumNumberOfCharacters', () => {
+    it('should not open the surface if input value is smaller than minimumNumberOfCharacters', async() => {
+      await setup({ attributes: { minimumNumberOfCharacters: 3 } });
+
+      await inputElement.setProperty('value', 'my');
+      await el.click();
+      await page.waitForChanges();
+      expect(await el.getProperty('opened')).toBe(false);
+    });
+
+    it('should not open the surface if input value is smaller than minimumNumberOfCharacters', async() => {
+      await setup({ attributes: { minimumNumberOfCharacters: 3 } });
+      await inputElement.setProperty('value', 'my-value');
+      await el.click();
+      await page.waitForChanges();
+      expect(await el.getProperty('opened')).toBe(true);
+    });
+
+    it('should hide the surface if, while typing, input value length goes under minimumNumberOfCharacters', async() => {
+      await setup({ attributes: { minimumNumberOfCharacters: 5 } });
+      await inputElement.setProperty('value', 'my-value');
+      await el.click();
+      await page.waitForChanges();
+      expect(await el.getProperty('opened')).toBe(true);
+      await inputElement.setProperty('value', 'my');
+      await page.waitForChanges();
+      expect(await el.getProperty('opened')).toBe(false);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should close the surface on Escape', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('Escape');
+      expect(await el.getProperty('opened')).toBe(false);
+    });
+
+    it('should focus on the options when navigating with Tab', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('Tab');
+      await page.waitForChanges();
+      expect(await optionElement.getProperty('selected')).toBe(true);
+      await page.keyboard.press('Tab');
+      await page.waitForChanges();
+      expect(await optionElement.getProperty('selected')).toBe(false);
+    });
+
+    it('should focus on the options when navigating with the arrows', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+      expect(await optionElement.getProperty('selected')).toBe(true);
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+      expect(await optionElement.getProperty('selected')).toBe(false);
+    });
+
+    it('should select a focused option when pressing Enter', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+      await page.keyboard.press('Enter');
+      await page.waitForChanges();
+      expect(await el.getProperty('value')).toBe('FR');
+    });
+
+    it('should keep keyboard navigation on selected option even if opened and closed', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+      await page.keyboard.press('Enter');
+      await page.waitForChanges();
+      expect(await el.getProperty('value')).toBe('IT');
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+      await page.keyboard.press('Enter');
+      await page.waitForChanges();
+      expect(await el.getProperty('value')).toBe('EN');
+    });
+
+    it('should select last option if pressing ArrowUp on first option', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowUp');
+      await page.waitForChanges();
+      await page.keyboard.press('Enter');
+      await page.waitForChanges();
+      expect(await el.getProperty('value')).toBe('EN');
+    });
+  });
+
+  describe('setInputTabindex', () => {
+    it('should set inputTabindex to -1', async() => {
+      await setup({ attributes: { } });
+      await el.callMethod('setInputTabindex', '-1');
+      await page.waitForChanges();
+      const value = el.getAttribute('tabindex');
+      expect(value).toBe('-1');
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear the value', async() => {
+      await setup({ attributes: { value: 'my-value' } });
+      await el.callMethod('clear');
+      await page.waitForChanges();
+      const value = await el.getProperty('value');
+      expect(value).toBe('');
+    });
+  });
+
+  describe('checkForClickOutside', () => {
+    it('should close the surface if click outside', async() => {
+      await setup({ });
+      await el.click();
+      await page.waitForChanges();
+      await page.click('body');
+      await page.waitForChanges();
+      expect(await el.getProperty('opened')).toBe(false);
+    });
+  });
+
+  describe('odsValueChange', () => {
+
+    let OdsAutocompleteValueChangeEventDetail: OdsAutocompleteValueChangeEventDetail;
+
+    beforeEach(() => {
+      OdsAutocompleteValueChangeEventDetail = {
+        oldValue: '',
+        selection: null,
+        validity: {
+          customError: false,
+          forbiddenValue: false,
+          invalid: false,
+          stepMismatch: false,
+          valid: true,
+          valueMissing: false,
+        },
+        value: '',
+      };
+    });
+
+    it('should emit when component value property change', async() => {
+      const newValue = 'my-new-value';
+      await setup({ });
+      const odsValueChange = await el.spyOnEvent('odsValueChange');
+
+      el.setProperty('value', `${newValue}`);
+      await page.waitForChanges();
+
+      const expected: OdsAutocompleteValueChangeEventDetail = {
+        ...OdsAutocompleteValueChangeEventDetail,
+        oldValue: '',
+        value: `${newValue}`,
+      };
+
+      expect(odsValueChange).toHaveReceivedEventDetail(expected);
+      expect(odsValueChange).toHaveReceivedEventTimes(1);
+    });
+  });
+});

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -13,10 +13,11 @@
   flex-direction: column;
 }
 
-.autocomplete {
-  display: flex;
-  flex-direction: column;
+:host([inline]) {
+  width: fit-content;
+}
 
+.autocomplete {
   &__anchor {
     position: relative;
     padding: 0;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -11,22 +11,21 @@
 :host(.autocomplete) {
   display: flex;
   flex-direction: column;
-  width: 100%;
 }
 
 .autocomplete {
   display: flex;
   flex-direction: column;
-  width: 100%;
-
-  &--inline {
-    width: fit-content;
-  }
 
   &__anchor {
+    width: 100%;
     position: relative;
     padding: 0;
     text-align: initial;
+
+    &--inline {
+      width: fit-content;
+    }
   }
 
   &__input {
@@ -37,6 +36,7 @@
   }
 
   &__surface {
+    width: 100%;
     box-sizing: border-box;
     display: none;
     flex-direction: column;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -1,0 +1,55 @@
+@keyframes appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+:host(.ods-autocomplete) {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+:host(.ods-autocomplete) .anchor {
+  position: relative;
+  padding: 0;
+  width: 100%;
+  height: 0;
+  text-align: initial;
+}
+
+:host(.ods-autocomplete) .anchor .overlay {
+  box-sizing: border-box;
+  display: none;
+  top: 0 !important; // To be changed
+  flex-direction: column;
+  border-top: none;
+  border-width: var(--ods-size-01);
+  border-style: solid;
+  border-bottom-left-radius: var(--ods-size-03);
+  border-bottom-right-radius: var(--ods-size-03);
+  border-color: var(--ods-color-primary-200);
+  background: var(--ods-color-gray-000);
+  max-height: calc(var(--ods-size-stack-11) * 7.5);
+  overflow: auto;
+  animation: appear 0.2s ease-in-out;
+}
+
+:host(.ods-autocomplete[opened]) {
+  .anchor .overlay {
+    display: flex;
+  }
+
+  osds-input {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+:host(.ods-autocomplete[inline]) {
+  width: fit-content;
+}

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -18,9 +18,9 @@
   flex-direction: column;
 
   &__anchor {
-    width: 100%;
     position: relative;
     padding: 0;
+    width: 100%;
     text-align: initial;
 
     &--inline {
@@ -36,7 +36,6 @@
   }
 
   &__surface {
-    width: 100%;
     box-sizing: border-box;
     display: none;
     flex-direction: column;
@@ -46,6 +45,7 @@
     border-radius: 0 0 var(--ods-size-03) var(--ods-size-03);
     border-color: var(--ods-color-primary-200);
     background: var(--ods-color-gray-000);
+    width: 100%;
     max-height: calc(var(--ods-size-stack-11) * 7.5);
     overflow: auto;
     animation: appear 0.2s ease-in-out;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -53,5 +53,13 @@
     &--opened {
       display: flex;
     }
+
+    &__loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--ods-size-03);
+      height: var(--ods-size-09);
+    }
   }
 }

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -8,48 +8,50 @@
   }
 }
 
-:host(.ods-autocomplete) {
+:host(.autocomplete) {
   display: flex;
   flex-direction: column;
   width: 100%;
 }
 
-:host(.ods-autocomplete) .anchor {
-  position: relative;
-  padding: 0;
-  width: 100%;
-  height: 0;
-  text-align: initial;
-}
-
-:host(.ods-autocomplete) .anchor .overlay {
-  box-sizing: border-box;
-  display: none;
-  top: 0 !important; // To be changed
+.autocomplete {
+  display: flex;
   flex-direction: column;
-  border-top: none;
-  border-width: var(--ods-size-01);
-  border-style: solid;
-  border-bottom-left-radius: var(--ods-size-03);
-  border-bottom-right-radius: var(--ods-size-03);
-  border-color: var(--ods-color-primary-200);
-  background: var(--ods-color-gray-000);
-  max-height: calc(var(--ods-size-stack-11) * 7.5);
-  overflow: auto;
-  animation: appear 0.2s ease-in-out;
-}
+  width: 100%;
 
-:host(.ods-autocomplete[opened]) {
-  .anchor .overlay {
-    display: flex;
+  &--inline {
+    width: fit-content;
   }
 
-  osds-input {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+  &__anchor {
+    position: relative;
+    padding: 0;
+    text-align: initial;
   }
-}
 
-:host(.ods-autocomplete[inline]) {
-  width: fit-content;
+  &__input {
+    &--opened {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  &__surface {
+    box-sizing: border-box;
+    display: none;
+    flex-direction: column;
+    border-width: var(--ods-size-01);
+    border-top-width: 0;
+    border-style: solid;
+    border-radius: 0 0 var(--ods-size-03) var(--ods-size-03);
+    border-color: var(--ods-color-primary-200);
+    background: var(--ods-color-gray-000);
+    max-height: calc(var(--ods-size-stack-11) * 7.5);
+    overflow: auto;
+    animation: appear 0.2s ease-in-out;
+
+    &--opened {
+      display: flex;
+    }
+  }
 }

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
@@ -22,7 +22,7 @@ global.MutationObserver = mutationObserverMock;
 OdsMockPropertyDescriptor(HTMLInputElement.prototype, 'validity', () => DEFAULT_VALIDITY_STATE);
 
 describe('spec:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: SpecPage;
   let instance: OsdsAutocomplete;
 
@@ -138,6 +138,17 @@ describe('spec:osds-autocomplete', () => {
         name: 'inline',
         newValue: true,
         setup: (value) => setup({ attributes: { ['inline']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('isLoading', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'isLoading'>({
+        defaultValue: DEFAULT_ATTRIBUTE.isLoading,
+        name: 'isLoading',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['isLoading']: value } }),
         value: false,
         ...config,
       });

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
@@ -1,0 +1,315 @@
+jest.mock('./core/controller'); // keep jest.mock before any
+
+import type { OdsAutocompleteAttribute } from './interfaces/attributes';
+import type { SpecPage } from '@stencil/core/testing';
+import { OdsMockNativeMethod, OdsMockPropertyDescriptor, odsComponentAttributes2StringAttributes, odsStringAttributes2Str, odsUnitTestAttribute } from '@ovhcloud/ods-common-testing';
+import { newSpecPage } from '@stencil/core/testing';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { DEFAULT_VALIDITY_STATE } from './constants/default-validity-state';
+import { OsdsAutocomplete } from './osds-autocomplete';
+
+const mutationObserverMock = jest.fn(function MutationObserver(callback) {
+  this.observe = jest.fn();
+  this.disconnect = jest.fn();
+  this.trigger = (mockedMutationsList): void => {
+    callback(mockedMutationsList, this);
+  };
+});
+
+// @ts-ignore Not possible to mock MutationObserver in a better way
+global.MutationObserver = mutationObserverMock;
+
+OdsMockPropertyDescriptor(HTMLInputElement.prototype, 'validity', () => DEFAULT_VALIDITY_STATE);
+
+describe('spec:osds-autocomplete', () => {
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  let page: SpecPage;
+  let instance: OsdsAutocomplete;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string }): Promise<void> {
+    const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);
+
+    OdsMockNativeMethod(HTMLInputElement.prototype, 'setCustomValidity', jest.fn());
+
+    page = await newSpecPage({
+      components: [OsdsAutocomplete],
+      html: `<osds-autocomplete ${odsStringAttributes2Str(stringAttributes)}>${html}</osds-autocomplete>`,
+    });
+
+    instance = page.rootInstance;
+  }
+
+  it('should render', async() => {
+    await setup({});
+    expect(page.root?.shadowRoot).toBeTruthy();
+    expect(instance).toBeTruthy();
+  });
+
+  describe('Life cycle', () => {
+    it('should call setSelectOptions', async() => {
+      await setup({ attributes: { } });
+      const spySetSelectOptions = jest.spyOn(instance, 'setSelectOptions');
+      await instance.componentDidLoad();
+      expect(spySetSelectOptions).toHaveBeenCalled();
+    });
+  });
+
+  describe('attributes', () => {
+    const config = {
+      instance: (): OsdsAutocomplete => instance,
+      page: (): SpecPage => page,
+      root: (): HTMLElement | undefined => page.root,
+      wait: (): Promise<void> => page.waitForChanges(),
+    };
+
+    describe('ariaLabel', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'ariaLabel'>({
+        defaultValue: DEFAULT_ATTRIBUTE.ariaLabel,
+        name: 'ariaLabel',
+        newValue: 'my-label',
+        setup: (value) => setup({ attributes: { ['ariaLabel']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+
+    describe('ariaLabelledby', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'ariaLabelledby'>({
+        defaultValue: DEFAULT_ATTRIBUTE.ariaLabelledby,
+        name: 'ariaLabelledby',
+        newValue: 'my-ariaLabelledby',
+        setup: (value) => setup({ attributes: { ['ariaLabelledby']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+
+    describe('clearable', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'clearable'>({
+        defaultValue: DEFAULT_ATTRIBUTE.clearable,
+        name: 'clearable',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['clearable']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('defaultValue', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'defaultValue'>({
+        defaultValue: DEFAULT_ATTRIBUTE.defaultValue,
+        name: 'defaultValue',
+        newValue: 'my-defaultValue',
+        setup: (value) => setup({ attributes: { ['defaultValue']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+
+    describe('disabled', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'disabled'>({
+        defaultValue: DEFAULT_ATTRIBUTE.disabled,
+        name: 'disabled',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['disabled']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('error', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'error'>({
+        defaultValue: DEFAULT_ATTRIBUTE.error,
+        name: 'error',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['error']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('inline', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'inline'>({
+        defaultValue: DEFAULT_ATTRIBUTE.inline,
+        name: 'inline',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['inline']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('minimumNumberOfCharacters', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'minimumNumberOfCharacters'>({
+        defaultValue: DEFAULT_ATTRIBUTE.minimumNumberOfCharacters,
+        name: 'minimumNumberOfCharacters',
+        newValue: 4,
+        setup: (value) => setup({ attributes: { ['minimumNumberOfCharacters']: value } }),
+        value: 2,
+        ...config,
+      });
+    });
+
+    describe('name', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'name'>({
+        defaultValue: DEFAULT_ATTRIBUTE.name,
+        name: 'name',
+        newValue: 'my-name',
+        setup: (value) => setup({ attributes: { ['name']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+
+    describe('opened', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'opened'>({
+        defaultValue: DEFAULT_ATTRIBUTE.opened,
+        name: 'opened',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['opened']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('placeholder', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'placeholder'>({
+        defaultValue: DEFAULT_ATTRIBUTE.placeholder,
+        name: 'placeholder',
+        newValue: 'my-placeholder',
+        setup: (value) => setup({ attributes: { ['placeholder']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+
+    describe('required', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'required'>({
+        defaultValue: DEFAULT_ATTRIBUTE.required,
+        name: 'required',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['required']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('value', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'value'>({
+        defaultValue: DEFAULT_ATTRIBUTE.value,
+        name: 'value',
+        newValue: 'my-value',
+        setup: (value) => setup({ attributes: { ['value']: value } }),
+        value: '',
+        ...config,
+      });
+    });
+  });
+
+  describe('methods', () => {
+    it('should call reset function and set value to defaultValue', async() => {
+      const defaultValue = 'my-default-value';
+      await setup({ attributes: { defaultValue, value: 'my-new-value' } });
+      expect(instance).toBeTruthy();
+      await instance.reset();
+      expect(instance?.value).toBe(`${defaultValue}`);
+    });
+
+    it('should call reset function and set value to empty string if defaultValue is unset', async() => {
+      await setup({ attributes: { value: 'my-value' } });
+      expect(instance).toBeTruthy();
+      await instance.reset();
+      expect(instance?.value).toBe('');
+    });
+
+    it('should call clear function and set value to an empty string', async() => {
+      await setup({ attributes: { value: 'my-value' } });
+      expect(instance).toBeTruthy();
+      await instance.clear();
+      expect(instance?.value).toBe('');
+    });
+
+    it('should call setInputTabindex function and inputTabindex should be set to 4', async() => {
+      await setup({ attributes: { value: 'my-value' } });
+      expect(instance).toBeTruthy();
+      await instance.setInputTabindex(4);
+      expect(instance?.tabindex).toBe(4);
+    });
+
+    it('should call getValidity function and get an OdsValidityState.invalid to true', async() => {
+      await setup({ attributes: { value: 'my-value' } });
+      expect(instance).toBeTruthy();
+      jest.spyOn(instance, 'getValidity');
+      const validity = await instance.getValidity();
+      expect(instance.getValidity).toHaveBeenCalledTimes(1);
+      expect(validity?.invalid).toBe(false);
+    });
+
+    it('should handle slot change', async() => {
+      await setup({ attributes: { } });
+      const spySetSelectOptions = jest.spyOn(instance, 'setSelectOptions');
+      instance.handleSlotChange();
+      expect(spySetSelectOptions).toHaveBeenCalled();
+    });
+
+    it('should handle validity', async() => {
+      await setup({ attributes: { } });
+      const spyValidate = jest.spyOn(instance, 'validate');
+      await instance.validate();
+      expect(spyValidate).toHaveBeenCalled();
+    });
+
+    it('should set focus', async() => {
+      await setup({ attributes: { } });
+      const spySetFocus = jest.spyOn(instance, 'setFocus');
+      await instance.setFocus();
+      expect(spySetFocus).toHaveBeenCalled();
+    });
+
+    it('should emit value change', async() => {
+      await setup({ attributes: { } });
+      const spyEmitChange = jest.spyOn(instance, 'emitChange');
+      instance.emitChange('my-value');
+      expect(spyEmitChange).toHaveBeenCalled();
+    });
+
+    describe('handleAutocompleteClick', () => {
+      it('should call handleAutocompleteClick', async() => {
+        await setup({ attributes: { } });
+        const spyHandleAutocompleteClick = jest.spyOn(instance, 'handleAutocompleteClick');
+        instance.handleAutocompleteClick();
+        expect(spyHandleAutocompleteClick).toHaveBeenCalled();
+      });
+    });
+
+    describe('renderLabel', () => {
+      it('should render label', async() => {
+        await setup({ attributes: { } });
+        const spyRenderLabel = jest.spyOn(instance, 'renderLabel');
+        instance.renderLabel();
+        expect(spyRenderLabel).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('events', () => {
+    it('odsValueChange', async() => {
+      await setup({ attributes: { } });
+      expect(instance.odsValueChange).toBeTruthy();
+    });
+
+    it('odsBlur', async() => {
+      await setup({ attributes: { } });
+      expect(instance.odsBlur).toBeTruthy();
+    });
+
+    it('odsFocus', async() => {
+      await setup({ attributes: { } });
+      expect(instance.odsFocus).toBeTruthy();
+    });
+  });
+});

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -344,9 +344,9 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
         tabindex: disabled ? -1 : this.tabindex,
       }}>
         <div class={{
-            'autocomplete__anchor': true,
-            'autocomplete__anchor--inline': inline,
-          }}>
+          'autocomplete__anchor': true,
+          'autocomplete__anchor--inline': inline,
+        }}>
           <osds-input
             class={{
               'autocomplete__input': true,

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -343,7 +343,10 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
         },
         tabindex: disabled ? -1 : this.tabindex,
       }}>
-        <div class='autocomplete__anchor'>
+        <div class={{
+            'autocomplete__anchor': true,
+            'autocomplete__anchor--inline': inline,
+          }}>
           <osds-input
             class={{
               'autocomplete__input': true,
@@ -372,7 +375,7 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
               }
             }}>
             {this.isLoading
-              ? <div class="loading">
+              ? <div class='autocomplete__surface__loading'>
                 <osds-spinner inline size='sm'/>
               </div>
               : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -71,6 +71,9 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
   /** @see OdsAutocompleteAttribute.inline */
   @Prop({ reflect: true }) inline: boolean = DEFAULT_ATTRIBUTE.inline;
 
+  /** @see OdsAutocompleteAttribute.isLoading */
+  @Prop({ mutable: true, reflect: true }) isLoading: boolean = DEFAULT_ATTRIBUTE.isLoading;
+
   /** @see OdsAutocompleteAttribute.minimumNumberOfCharacters */
   @Prop({ reflect: true }) minimumNumberOfCharacters: number = DEFAULT_ATTRIBUTE.minimumNumberOfCharacters;
 
@@ -368,7 +371,12 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
                 this.syncReferences();
               }
             }}>
-            <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            {this.isLoading
+              ? <div class="loading">
+                <osds-spinner inline size='sm'/>
+              </div>
+              : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            }
           </ocdk-surface>
         </div>
       </Host>

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -1,0 +1,364 @@
+import type { OdsAutocompleteAttribute } from './interfaces/attributes';
+import type { OdsAutocompleteEvent, OdsAutocompleteValueChangeEventDetail } from './interfaces/events';
+import type { OdsAutocompleteMethod } from './interfaces/methods';
+import type { ODS_ICON_NAME } from '../../../../icon/src';
+import type { OdsInputValueChangeEventDetail } from '../../../../input/src';
+import type { OdsSelectOptionClickEventDetail } from '../../../../select/src/components/osds-select-option/interfaces/events';
+import type { OsdsSelectOption } from '../../../../select/src/components/osds-select-option/osds-select-option';
+import type { OcdkSurface } from '@ovhcloud/ods-cdk';
+import type { OdsValidityState } from '@ovhcloud/ods-common-core';
+import type { EventEmitter, FunctionalComponent } from '@stencil/core';
+import type { HTMLStencilElement } from '@stencil/core/internal';
+import { ocdkAssertEventTargetIsNode, ocdkDefineCustomElements, ocdkIsSurface } from '@ovhcloud/ods-cdk';
+import { ODS_THEME_COLOR_INTENT } from '@ovhcloud/ods-common-theming';
+import { AttachInternals, Component, Element, Event, Host, Listen, Method, Prop, State, Watch, h } from '@stencil/core';
+import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
+import { DEFAULT_VALIDITY_STATE } from './constants/default-validity-state';
+import { OdsAutocompleteController } from './core/controller';
+import { ODS_INPUT_TYPE } from '../../../../input/src';
+
+ocdkDefineCustomElements();
+
+@Component({
+  formAssociated: true,
+  shadow: true,
+  styleUrl: 'osds-autocomplete.scss',
+  tag: 'osds-autocomplete',
+})
+export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocompleteEvent, OdsAutocompleteMethod {
+  anchor!: HTMLElement;
+  controller: OdsAutocompleteController = new OdsAutocompleteController(this);
+  dirty = false;
+  observer?: MutationObserver;
+  optionSelected: OsdsSelectOption | null = null;
+  selectedLabelSlot: HTMLElement | null = null;
+  surface: OcdkSurface | undefined = undefined;
+
+  @Element() el!: HTMLStencilElement;
+
+  @AttachInternals() internals!: ElementInternals;
+
+  @State() inputValue = '';
+  @State() selectedOptionLabel = '';
+  @State() tabindex = 0;
+  @State() validityState: OdsValidityState = DEFAULT_VALIDITY_STATE;
+
+  /**
+   * Attributes
+   */
+
+  /** @see OdsAutocompleteAttribute.ariaLabel */
+  @Prop({ reflect: true }) ariaLabel: HTMLElement['ariaLabel'] = DEFAULT_ATTRIBUTE.ariaLabel;
+
+  /** @see OdsAutocompleteAttribute.ariaLabelledby */
+  @Prop() ariaLabelledby: string = DEFAULT_ATTRIBUTE.ariaLabelledby;
+
+  /** @see OdsAutocompleteAttribute.clearable */
+  @Prop({ reflect: true }) clearable: boolean = DEFAULT_ATTRIBUTE.disabled;
+
+  /** @see OdsAutocompleteAttribute.defaultValue */
+  @Prop({ reflect: true }) defaultValue: string = DEFAULT_ATTRIBUTE.defaultValue;
+
+  /** @see OdsAutocompleteAttribute.disabled */
+  @Prop({ mutable: true, reflect: true }) disabled: boolean = DEFAULT_ATTRIBUTE.disabled;
+
+  /** @see OdsAutocompleteAttribute.error */
+  @Prop({ reflect: true }) error: boolean = DEFAULT_ATTRIBUTE.error;
+
+  /** @see OdsAutocompleteAttribute.icon */
+  @Prop({ reflect: true }) icon?: ODS_ICON_NAME = DEFAULT_ATTRIBUTE.icon;
+
+  /** @see OdsAutocompleteAttribute.inline */
+  @Prop({ reflect: true }) inline: boolean = DEFAULT_ATTRIBUTE.inline;
+
+  /** @see OdsAutocompleteAttribute.minimumNumberOfCharacters */
+  @Prop({ reflect: true }) minimumNumberOfCharacters: number = DEFAULT_ATTRIBUTE.minimumNumberOfCharacters;
+
+  /** @see OdsAutocompleteAttribute.name */
+  @Prop({ reflect: true }) name?: string = DEFAULT_ATTRIBUTE.name;
+
+  /** @see OdsAutocompleteAttribute.opened */
+  @Prop({ mutable: true, reflect: true }) opened: boolean = DEFAULT_ATTRIBUTE.opened;
+
+  /** @see OdsAutocompleteAttribute.placeholder */
+  @Prop({ reflect: true }) placeholder?: string = DEFAULT_ATTRIBUTE.placeholder;
+
+  /** @see OdsAutocompleteAttribute.required */
+  @Prop({ mutable: true, reflect: true }) required: boolean = DEFAULT_ATTRIBUTE.required;
+
+  /** @see OdsAutocompleteAttribute.value */
+  @Prop({ mutable: true, reflect: true }) value: string = DEFAULT_ATTRIBUTE.value;
+
+  /**
+   * Events
+   */
+
+  @Event() odsValueChange!: EventEmitter<OdsAutocompleteValueChangeEventDetail>;
+  @Event() odsFocus!: EventEmitter<void>;
+  @Event() odsBlur!: EventEmitter<void>;
+
+  private onFocus(): void {
+    this.odsFocus.emit();
+  }
+
+  onBlur(): void {
+    this.odsBlur.emit();
+  }
+
+  componentWillLoad(): void {
+    this.controller.beforeInit();
+    this.inputValue = this.value;
+  }
+
+  disconnectedCallback(): void {
+    this.observer?.disconnect();
+  }
+
+  formResetCallback(): void {
+    this.value = this.defaultValue;
+  }
+
+  /**
+   * once the component did load, update the state depending the children,
+   * in order to synchronize the already set value with the placeholder
+   */
+  async componentDidLoad(): Promise<void> {
+    this.observer = new MutationObserver(async() => this.selectedOptionLabel = await this.optionSelected?.getLabel() || '');
+    this.setSelectOptions();
+    await this.updateSelectOptionStates(this.value);
+  }
+
+  @Watch('opened')
+  openedChanged(opened: boolean): void {
+    if (this.surface) {
+      this.surface.opened = opened;
+    }
+  }
+
+  @Watch('value')
+  async onValueChange(value: string, oldValue?: string): Promise<void> {
+    this.controller.onValueChange(value, oldValue);
+    await this.updateSelectOptionStates(value);
+    this.inputValue = this.selectedOptionLabel;
+  }
+
+  emitChange(value: string, oldValue?: string): void {
+    this.odsValueChange.emit({
+      name: this.name,
+      oldValue: oldValue,
+      selection: this.optionSelected,
+      validity: this.validityState,
+      value: value,
+    });
+  }
+
+  handleKeyDown(event: KeyboardEvent): void {
+    event.stopPropagation();
+    this.controller.handlerKeyDown(event);
+  }
+
+  @Method()
+  async clear(): Promise<void> {
+    this.optionSelected = null;
+    this.validityState = DEFAULT_VALIDITY_STATE;
+    this.value = '';
+    this.inputValue = '';
+  }
+
+  @Method()
+  async getValidity(): Promise<OdsValidityState> {
+    return this.validityState;
+  }
+
+  @Method()
+  async reset(): Promise<void> {
+    this.optionSelected = null;
+    this.value = this.defaultValue || '';
+    this.validityState = DEFAULT_VALIDITY_STATE;
+  }
+
+  @Method()
+  async setFocus(): Promise<void> {
+    this.el.focus();
+  }
+
+  @Method()
+  async setInputTabindex(value: number): Promise<void> {
+    this.tabindex = value;
+  }
+
+  @Method()
+  async validate(): Promise<OdsValidityState> {
+    this.validityState = this.controller.getValidity();
+    return this.validityState;
+  }
+
+  private async updateSelectOptionStates(value?: string): Promise<void> {
+    let nbSelected = 0;
+    for (const selectOption of this.controller.selectOptions) {
+      selectOption.selected = (value === selectOption.value) && !nbSelected ;
+      if (selectOption.selected) {
+        this.optionSelected = selectOption;
+        nbSelected++;
+        // eslint-disable-next-line no-await-in-loop
+        this.selectedOptionLabel = await selectOption.getLabel();
+      }
+    }
+  }
+
+  // Toggle overlay when we click on the Autocomplete.
+  handleAutocompleteClick(): void {
+    if (this.disabled || (this.value.length < this.minimumNumberOfCharacters && this.inputValue.length < this.minimumNumberOfCharacters)) {
+      return;
+    }
+    this.dirty = true;
+    if (this.opened) {
+      this.controller.closeSurface();
+    } else {
+      this.controller.openSurface();
+    }
+  }
+
+  handleInputValueChange(event: CustomEvent<OdsInputValueChangeEventDetail>): void {
+    if (this.disabled) {
+      return;
+    }
+
+    if (!event.detail.value) {
+      this.clear();
+      return;
+    }
+
+    this.dirty = true;
+    this.inputValue = event.detail.value;
+    if (this.inputValue !== this.value && this.inputValue !== this.selectedOptionLabel) {
+      this.clear();
+    }
+
+    if (!this.opened && event.detail.value.length >= this.minimumNumberOfCharacters) {
+      this.controller.openSurface();
+    } else if (this.opened && event.detail.value.length < this.minimumNumberOfCharacters) {
+      this.controller.closeSurface();
+    }
+  }
+
+  // Hide overlay when we click anywhere else in the window.
+  @Listen('click', { target: 'window' })
+  checkForClickOutside(ev: Event): void {
+    ocdkAssertEventTargetIsNode(ev.target);
+    if (!this.dirty || this.surface?.isClickOutsideSurface(ev)) {
+      return;
+    }
+    this.controller.closeSurface();
+
+    this.controller.selectOptions.forEach((option) => {
+      if (this.value && option.getAttribute('value') === this.value) {
+        option.setAttribute('selected', 'true');
+      } else {
+        option.removeAttribute('selected');
+      }
+    });
+
+    if (this.dirty) {
+      this.validityState = this.controller.getValidity();
+    }
+  }
+
+  @Listen('odsSelectOptionClick')
+  handleValueChange(event: CustomEvent<OdsSelectOptionClickEventDetail>): void {
+    event.detail.value
+      ? this.controller.changeValue(event.detail.value.toString())
+      : this.controller.changeValue('');
+    this.controller.closeSurface();
+  }
+
+  @Watch('disabled')
+  closeWhenDisabled(disabled?: boolean): void {
+    if (disabled) {
+      this.controller.closeSurface();
+    }
+  }
+
+  syncReferences(): void {
+    this.controller.syncReferences();
+  }
+
+  async handleSlotChange(): Promise<void> {
+    this.setSelectOptions();
+    await this.updateSelectOptionStates();
+  }
+
+  setSelectOptions(): void {
+    this.controller.selectOptions = this.getSelectOptionList();
+    this.controller.selectOptions.forEach((option) => this.observer?.observe(option, { attributes: true, childList: true, subtree: true }));
+  }
+
+  getSelectOptionList(): (HTMLElement & OsdsSelectOption)[] {
+    return Array.from(this.el.querySelectorAll<OsdsSelectOption & HTMLElement>('osds-select-option'));
+  }
+
+  renderLabel(): string {
+    if (!this.value) {
+      return '';
+    }
+    return this.selectedOptionLabel;
+  }
+
+  render(): FunctionalComponent {
+    const {
+      ariaLabel,
+      ariaLabelledby,
+      clearable,
+      disabled,
+      error,
+      icon,
+      inline,
+      opened,
+      placeholder,
+    } = this;
+
+    return (
+      <Host {...{
+        'aria-labelledby': ariaLabelledby,
+        ariaLabel,
+        class: 'ods-autocomplete',
+        inline,
+        onBlur: this.onBlur.bind(this),
+        onClick: this.handleAutocompleteClick.bind(this),
+        onFocus: this.onFocus.bind(this),
+        onKeyDown: this.handleKeyDown.bind(this),
+        opened,
+        ref: (el?: HTMLElement | null): void => {
+          this.anchor = el as HTMLElement;
+          this.syncReferences();
+        },
+        tabindex: this.disabled ? -1 : this.tabindex,
+      }}>
+        <osds-input
+          clearable={clearable}
+          color={ODS_THEME_COLOR_INTENT.primary}
+          disabled={disabled}
+          error={error}
+          icon={icon}
+          inline={inline}
+          onOdsValueChange={this.handleInputValueChange.bind(this)}
+          placeholder={placeholder}
+          type={ODS_INPUT_TYPE.text}
+          value={this.inputValue}
+        />
+        <div class="anchor">
+          <ocdk-surface
+            class="overlay"
+            ref={(el: HTMLElement): void => {
+              if (ocdkIsSurface(el)) {
+                this.surface = el as OcdkSurface;
+                this.syncReferences();
+              }
+            }}>
+            <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+          </ocdk-surface>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -206,7 +206,7 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
     }
   }
 
-  // Toggle overlay when we click on the Autocomplete.
+  // Toggle surface when we click on the Autocomplete.
   handleAutocompleteClick(): void {
     if (this.disabled || (this.value.length < this.minimumNumberOfCharacters && this.inputValue.length < this.minimumNumberOfCharacters)) {
       return;
@@ -242,7 +242,7 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
     }
   }
 
-  // Hide overlay when we click anywhere else in the window.
+  // Hide surface when we click anywhere else in the window.
   @Listen('click', { target: 'window' })
   checkForClickOutside(ev: Event): void {
     ocdkAssertEventTargetIsNode(ev.target);
@@ -321,7 +321,13 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
       <Host {...{
         'aria-labelledby': ariaLabelledby,
         ariaLabel,
-        class: 'ods-autocomplete',
+        class: {
+          'autocomplete': true,
+          'autocomplete--disabled': disabled,
+          'autocomplete--error': error,
+          'autocomplete--inline': inline,
+          'autocomplete--opened': opened,
+        },
         inline,
         onBlur: this.onBlur.bind(this),
         onClick: this.handleAutocompleteClick.bind(this),
@@ -332,23 +338,30 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
           this.anchor = el as HTMLElement;
           this.syncReferences();
         },
-        tabindex: this.disabled ? -1 : this.tabindex,
+        tabindex: disabled ? -1 : this.tabindex,
       }}>
-        <osds-input
-          clearable={clearable}
-          color={ODS_THEME_COLOR_INTENT.primary}
-          disabled={disabled}
-          error={error}
-          icon={icon}
-          inline={inline}
-          onOdsValueChange={this.handleInputValueChange.bind(this)}
-          placeholder={placeholder}
-          type={ODS_INPUT_TYPE.text}
-          value={this.inputValue}
-        />
-        <div class="anchor">
+        <div class='autocomplete__anchor'>
+          <osds-input
+            class={{
+              'autocomplete__input': true,
+              'autocomplete__input--opened': opened,
+            }}
+            clearable={clearable}
+            color={ODS_THEME_COLOR_INTENT.primary}
+            disabled={disabled}
+            error={error}
+            icon={icon}
+            inline={inline}
+            onOdsValueChange={this.handleInputValueChange.bind(this)}
+            placeholder={placeholder}
+            type={ODS_INPUT_TYPE.text}
+            value={this.inputValue}
+          />
           <ocdk-surface
-            class="overlay"
+            class={{
+              'autocomplete__surface': true,
+              'autocomplete__surface--opened': opened,
+            }}
             ref={(el: HTMLElement): void => {
               if (ocdkIsSurface(el)) {
                 this.surface = el as OcdkSurface;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 import { DEFAULT_VALIDITY_STATE } from './constants/default-validity-state';
 import { OdsAutocompleteController } from './core/controller';
 import { ODS_INPUT_TYPE } from '../../../../input/src';
+import { ODS_SPINNER_SIZE } from '../../../../spinner/src';
 
 ocdkDefineCustomElements();
 
@@ -376,7 +377,10 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
             }}>
             {this.isLoading
               ? <div class='autocomplete__surface__loading'>
-                <osds-spinner inline size='sm'/>
+                <osds-spinner
+                  inline
+                  size={ODS_SPINNER_SIZE.sm}
+                />
               </div>
               : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
             }

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/public-api.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/public-api.ts
@@ -1,0 +1,4 @@
+export type { OdsAutocompleteAttribute } from './interfaces/attributes';
+export type { OdsAutocompleteEvent, OdsAutocompleteValueChangeEvent, OdsAutocompleteValueChangeEventDetail } from './interfaces/events';
+export type { OdsAutocompleteMethod } from './interfaces/methods';
+export { OsdsAutocomplete } from './osds-autocomplete';

--- a/packages/components/src/autocomplete/src/globals.ts
+++ b/packages/components/src/autocomplete/src/globals.ts
@@ -1,0 +1,12 @@
+/**
+ * Import here all the external ODS component that you need to run the current component
+ * when running dev server (yarn start) or e2e tests
+ *
+ * ex:
+ *   import '../../text/src';
+ */
+import '../../content-addon/src';
+import '../../icon/src';
+import '../../text/src';
+import '../../select/src';
+import '../../input/src';

--- a/packages/components/src/autocomplete/src/globals.ts
+++ b/packages/components/src/autocomplete/src/globals.ts
@@ -5,7 +5,6 @@
  * ex:
  *   import '../../text/src';
  */
-import '../../content-addon/src';
 import '../../icon/src';
 import '../../input/src';
 import '../../select/src';

--- a/packages/components/src/autocomplete/src/globals.ts
+++ b/packages/components/src/autocomplete/src/globals.ts
@@ -7,6 +7,7 @@
  */
 import '../../content-addon/src';
 import '../../icon/src';
-import '../../text/src';
-import '../../select/src';
 import '../../input/src';
+import '../../select/src';
+import '../../spinner/src';
+import '../../text/src';

--- a/packages/components/src/autocomplete/src/index.html
+++ b/packages/components/src/autocomplete/src/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html dir='ltr' lang='en'>
+<head>
+  <meta charset='utf-8'/>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0'/>
+  <title>Dev osds-autocomplete</title>
+
+  <script type="module">
+    !window.ods && (window.ods = {config: {logging: {active: true}}});
+  </script>
+
+  <script type='module' src='/build/osds-autocomplete.esm.js'></script>
+  <script nomodule src='/build/osds-autocomplete.js'></script>
+  <link rel="stylesheet" href="/build/osds-autocomplete.css">
+</head>
+<body>
+
+  <osds-text>Autocomplete 1</osds-text>
+
+  <osds-autocomplete id="autocomplete" clearable="true" inline icon="ovh" value="Hello">
+  </osds-autocomplete>
+
+  <osds-text>Autocomplete 2</osds-text>
+
+  <osds-autocomplete id="autocomplete2" clearable="true" placeholder="Bonjour">
+  </osds-autocomplete>
+
+  <osds-text>Autocomplete 3</osds-text>
+
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language...">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+
+  <osds-text>Autocomplete 4 (Minimum number of characters: 2)</osds-text>
+
+  <osds-autocomplete id="autocomplete4" clearable="true" minimum-number-of-characters="2" placeholder="Select a server...">
+    <osds-select-option value="RS">Rise</osds-select-option>
+    <osds-select-option value="AV">Advance</osds-select-option>
+    <osds-select-option value="GM">Game</osds-select-option>
+    <osds-select-option value="ST">Storage</osds-select-option>
+    <osds-select-option value="SC">Scale</osds-select-option>
+    <osds-select-option value="HG">High Grade</osds-select-option>
+  </osds-autocomplete>
+
+  <script>
+    const database = [
+      { value: 'Hello', text: 'Hello World' },
+      { value: 'How', text: 'How are you today?' },
+      { value: 'Bonjour', text: 'Bonjour tout le monde' },
+      { value: 'Hola', text: 'Hola Mundo' },
+      { value: 'Fizz', text: 'Buzz' },
+      { value: 'Auto', text: 'Autocomplete' },
+    ];
+
+    const autocompleteElement = document.querySelector('#autocomplete');
+    const autocompleteElement2 = document.querySelector('#autocomplete2');
+
+    const updateOptions = (value, element) => {
+      while (element.firstChild) {
+        element.removeChild(element.firstChild);
+      }
+
+      const regex = new RegExp(value, 'i');
+
+      database.forEach(entry => {
+        if (regex.test(entry.text)) {
+          const optionElement = document.createElement('osds-select-option');
+          optionElement.value = entry.value;
+          optionElement.tabIndex = 1;
+
+          const textElem = document.createElement('osds-text');
+          textElem.innerHTML = entry.text.replace(regex, '<b>$&</b>');
+          optionElement.appendChild(textElem);
+
+          element.appendChild(optionElement);
+        }
+      });
+    };
+
+    autocompleteElement.addEventListener('odsValueChange', (event) => {
+      updateOptions(event.detail.value, autocompleteElement);
+    });
+    autocompleteElement2.addEventListener('odsValueChange', (event) => {
+      updateOptions(event.detail.value, autocompleteElement2);
+    });
+    updateOptions('');
+  </script>
+  </body>
+  </html>

--- a/packages/components/src/autocomplete/src/index.html
+++ b/packages/components/src/autocomplete/src/index.html
@@ -44,6 +44,19 @@
     <osds-select-option value="HG">High Grade</osds-select-option>
   </osds-autocomplete>
 
+  <div style="width: 100%; height: 55vh;"></div>
+
+  <osds-text>Autocomplete 5 (At the bottom of the page)</osds-text>
+
+  <osds-autocomplete id="autocomplete5" clearable="true" placeholder="Select a server...">
+    <osds-select-option value="RS">Rise</osds-select-option>
+    <osds-select-option value="AV">Advance</osds-select-option>
+    <osds-select-option value="GM">Game</osds-select-option>
+    <osds-select-option value="ST">Storage</osds-select-option>
+    <osds-select-option value="SC">Scale</osds-select-option>
+    <osds-select-option value="HG">High Grade</osds-select-option>
+  </osds-autocomplete>
+
   <script>
     const database = [
       { value: 'Hello', text: 'Hello World' },

--- a/packages/components/src/autocomplete/src/index.html
+++ b/packages/components/src/autocomplete/src/index.html
@@ -44,11 +44,27 @@
     <osds-select-option value="HG">High Grade</osds-select-option>
   </osds-autocomplete>
 
-  <div style="width: 100%; height: 55vh;"></div>
+  <osds-text>Autocomplete 5 (isLoading)</osds-text>
 
-  <osds-text>Autocomplete 5 (At the bottom of the page)</osds-text>
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
 
-  <osds-autocomplete id="autocomplete5" clearable="true" placeholder="Select a server...">
+  <osds-text>Autocomplete 6 (isLoading)</osds-text>
+
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." inline is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+
+  <div style="width: 100%; height: 45vh;"></div>
+
+  <osds-text>Autocomplete 7 (At the bottom of the page)</osds-text>
+
+  <osds-autocomplete id="autocomplete7" clearable="true" placeholder="Select a server...">
     <osds-select-option value="RS">Rise</osds-select-option>
     <osds-select-option value="AV">Advance</osds-select-option>
     <osds-select-option value="GM">Game</osds-select-option>

--- a/packages/components/src/autocomplete/src/index.ts
+++ b/packages/components/src/autocomplete/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/osds-autocomplete/public-api';

--- a/packages/components/src/autocomplete/stencil.config.ts
+++ b/packages/components/src/autocomplete/stencil.config.ts
@@ -1,0 +1,10 @@
+import { getStencilConfig } from '@ovhcloud/ods-common-stencil';
+
+import jestConfig from './jest.config';
+
+export const config = getStencilConfig({
+  args: process.argv.slice(2),
+  componentCorePackage: '@ovhcloud/ods-component-autocomplete',
+  jestConfig,
+  namespace: 'osds-autocomplete',
+});

--- a/packages/components/src/autocomplete/tsconfig.json
+++ b/packages/components/src/autocomplete/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ]
+}

--- a/packages/components/src/autocomplete/tsconfig.test.json
+++ b/packages/components/src/autocomplete/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.test.json",
+  "include": [
+    "src"
+  ]
+}

--- a/packages/components/src/autocomplete/typedoc.json
+++ b/packages/components/src/autocomplete/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs-api/",
+  "tsconfig":"tsconfig.json",
+  "plugin": ["none"],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "hideGenerator": true
+}

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -227,6 +227,11 @@ export namespace Components {
          */
         "inline": boolean;
         /**
+          * Defines if the Autocomplete should display a loading spinner in the dropdown
+          * @see OdsAutocompleteAttribute.isLoading
+         */
+        "isLoading": boolean;
+        /**
           * Defines the Autocomplete's minimum number of characters to open the dropdown
           * @see OdsAutocompleteAttribute.minimumNumberOfCharacters
          */
@@ -3038,6 +3043,11 @@ declare namespace LocalJSX {
           * @see OdsAutocompleteAttribute.inline
          */
         "inline"?: boolean;
+        /**
+          * Defines if the Autocomplete should display a loading spinner in the dropdown
+          * @see OdsAutocompleteAttribute.isLoading
+         */
+        "isLoading"?: boolean;
         /**
           * Defines the Autocomplete's minimum number of characters to open the dropdown
           * @see OdsAutocompleteAttribute.minimumNumberOfCharacters

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -8,10 +8,11 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ODS_THEME_COLOR_INTENT } from "@ovhcloud/ods-common-theming";
 import { ODS_ACCORDION_SIZE } from "./accordion/src/components/osds-accordion/constants/accordion-size";
 import { OsdsAccordion } from "./accordion/src/components/osds-accordion/osds-accordion";
-import { OdsBreadcrumbAttributeItem } from "./breadcrumb/src/components/osds-breadcrumb/interfaces/attributes";
 import { ODS_ICON_NAME } from "./icon/src";
-import { ODS_LINK_REFERRER_POLICY } from "./link/src";
+import { OdsAutocompleteValueChangeEventDetail } from "./autocomplete/src/components/osds-autocomplete/interfaces/events";
 import { ODS_COUNTRY_ISO_CODE, ODS_LOCALE, ODS_PERIOD_ISO_CODE, OdsErrorStateControl, OdsFormControl, OdsFormForbiddenValues, OdsHTMLAnchorElementRel, OdsHTMLAnchorElementTarget, OdsI18nHook, OdsInputValue, OdsTextAreaValidityState, OdsValidityState } from "@ovhcloud/ods-common-core";
+import { OdsBreadcrumbAttributeItem } from "./breadcrumb/src/components/osds-breadcrumb/interfaces/attributes";
+import { ODS_LINK_REFERRER_POLICY } from "./link/src";
 import { OdsBreadcrumbAttributeItem as OdsBreadcrumbAttributeItem1 } from "./breadcrumb/src/components/osds-breadcrumb/public-api";
 import { ODS_BUTTON_SIZE } from "./button/src/components/osds-button/constants/button-size";
 import { ODS_BUTTON_TYPE } from "./button/src/components/osds-button/constants/button-type";
@@ -74,10 +75,11 @@ import { ODS_TOOLTIP_VARIANT } from "./tooltip/src/components/osds-tooltip/const
 export { ODS_THEME_COLOR_INTENT } from "@ovhcloud/ods-common-theming";
 export { ODS_ACCORDION_SIZE } from "./accordion/src/components/osds-accordion/constants/accordion-size";
 export { OsdsAccordion } from "./accordion/src/components/osds-accordion/osds-accordion";
-export { OdsBreadcrumbAttributeItem } from "./breadcrumb/src/components/osds-breadcrumb/interfaces/attributes";
 export { ODS_ICON_NAME } from "./icon/src";
-export { ODS_LINK_REFERRER_POLICY } from "./link/src";
+export { OdsAutocompleteValueChangeEventDetail } from "./autocomplete/src/components/osds-autocomplete/interfaces/events";
 export { ODS_COUNTRY_ISO_CODE, ODS_LOCALE, ODS_PERIOD_ISO_CODE, OdsErrorStateControl, OdsFormControl, OdsFormForbiddenValues, OdsHTMLAnchorElementRel, OdsHTMLAnchorElementTarget, OdsI18nHook, OdsInputValue, OdsTextAreaValidityState, OdsValidityState } from "@ovhcloud/ods-common-core";
+export { OdsBreadcrumbAttributeItem } from "./breadcrumb/src/components/osds-breadcrumb/interfaces/attributes";
+export { ODS_LINK_REFERRER_POLICY } from "./link/src";
 export { OdsBreadcrumbAttributeItem as OdsBreadcrumbAttributeItem1 } from "./breadcrumb/src/components/osds-breadcrumb/public-api";
 export { ODS_BUTTON_SIZE } from "./button/src/components/osds-button/constants/button-size";
 export { ODS_BUTTON_TYPE } from "./button/src/components/osds-button/constants/button-type";
@@ -174,6 +176,102 @@ export namespace Components {
           * @see OdsAccordionGroupMethod.unRegisterAccordion
          */
         "unRegisterAccordion": (accordion: OsdsAccordion) => Promise<void>;
+    }
+    interface OsdsAutocomplete {
+        /**
+          * The corresponding aria-label describing its content
+          * @see OdsAutocompleteAttribute.ariaLabel
+         */
+        "ariaLabel": HTMLElement['ariaLabel'];
+        /**
+          * The ID to an external description
+          * @see OdsAutocompleteAttribute.ariaLabelledby
+         */
+        "ariaLabelledby": string;
+        /**
+          * Erase the current selection
+         */
+        "clear": () => Promise<void>;
+        /**
+          * Defines if the Autocomplete should be clearable or not (displays a clear button)
+          * @see OdsAutocompleteAttribute.clearable
+         */
+        "clearable": boolean;
+        /**
+          * Default value of the Autocomplete
+          * @see OdsAutocompleteAttribute.defaultValue
+         */
+        "defaultValue": string;
+        /**
+          * Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)
+          * @see OdsAutocompleteAttribute.disabled
+         */
+        "disabled": boolean;
+        /**
+          * Defines if the Autocomplete should display an error state
+          * @see OdsAutocompleteAttribute.error
+         */
+        "error": boolean;
+        /**
+          * Get the validity state
+         */
+        "getValidity": () => Promise<OdsValidityState>;
+        /**
+          * Defines if the Autocomplete should display an icon in the input field
+          * @see OdsAutocompleteAttribute.icon
+         */
+        "icon"?: ODS_ICON_NAME;
+        /**
+          * Indicates if the Autocomplete is full width or not: see component principles
+          * @see OdsAutocompleteAttribute.inline
+         */
+        "inline": boolean;
+        /**
+          * Defines the Autocomplete's minimum number of characters to open the dropdown
+          * @see OdsAutocompleteAttribute.minimumNumberOfCharacters
+         */
+        "minimumNumberOfCharacters": number;
+        /**
+          * Name of the Autocomplete field
+          * @see OdsAutocompleteAttribute.name
+         */
+        "name"?: string;
+        /**
+          * Defines if the Autocomplete dropdown is opened or not
+          * @see OdsAutocompleteAttribute.opened
+         */
+        "opened": boolean;
+        /**
+          * Defines if the Autocomplete should display a placeholder message
+          * @see OdsAutocompleteAttribute.placeholder
+         */
+        "placeholder"?: string;
+        /**
+          * Defines if a value has to be selected or not
+          * @see OdsAutocompleteAttribute.required
+         */
+        "required": boolean;
+        /**
+          * Reset the value to the initial one (default value)
+         */
+        "reset": () => Promise<void>;
+        /**
+          * Focus the element
+         */
+        "setFocus": () => Promise<void>;
+        /**
+          * Set tab index on the component
+         */
+        "setInputTabindex": (value: number) => Promise<void>;
+        /**
+          * check if the Autocomplete is valid. In case of required field, the validation will check the entered value and set the field in error if it is not fulfilled
+         */
+        "validate": () => Promise<OdsValidityState>;
+        /**
+          * Defines the Autocomplete's value
+          * @see OdsAutocompleteAttribute.value
+         */
+        "value": string;
     }
     interface OsdsBreadcrumb {
         /**
@@ -1953,6 +2051,10 @@ export interface OsdsAccordionCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOsdsAccordionElement;
 }
+export interface OsdsAutocompleteCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLOsdsAutocompleteElement;
+}
 export interface OsdsBreadcrumbItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOsdsBreadcrumbItemElement;
@@ -2072,6 +2174,25 @@ declare global {
     var HTMLOsdsAccordionGroupElement: {
         prototype: HTMLOsdsAccordionGroupElement;
         new (): HTMLOsdsAccordionGroupElement;
+    };
+    interface HTMLOsdsAutocompleteElementEventMap {
+        "odsValueChange": OdsAutocompleteValueChangeEventDetail;
+        "odsFocus": void;
+        "odsBlur": void;
+    }
+    interface HTMLOsdsAutocompleteElement extends Components.OsdsAutocomplete, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLOsdsAutocompleteElementEventMap>(type: K, listener: (this: HTMLOsdsAutocompleteElement, ev: OsdsAutocompleteCustomEvent<HTMLOsdsAutocompleteElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLOsdsAutocompleteElementEventMap>(type: K, listener: (this: HTMLOsdsAutocompleteElement, ev: OsdsAutocompleteCustomEvent<HTMLOsdsAutocompleteElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLOsdsAutocompleteElement: {
+        prototype: HTMLOsdsAutocompleteElement;
+        new (): HTMLOsdsAutocompleteElement;
     };
     interface HTMLOsdsBreadcrumbElement extends Components.OsdsBreadcrumb, HTMLStencilElement {
     }
@@ -2775,6 +2896,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "osds-accordion": HTMLOsdsAccordionElement;
         "osds-accordion-group": HTMLOsdsAccordionGroupElement;
+        "osds-autocomplete": HTMLOsdsAutocompleteElement;
         "osds-breadcrumb": HTMLOsdsBreadcrumbElement;
         "osds-breadcrumb-item": HTMLOsdsBreadcrumbItemElement;
         "osds-button": HTMLOsdsButtonElement;
@@ -2874,6 +2996,90 @@ declare namespace LocalJSX {
         "size"?: ODS_ACCORDION_SIZE;
     }
     interface OsdsAccordionGroup {
+    }
+    interface OsdsAutocomplete {
+        /**
+          * The corresponding aria-label describing its content
+          * @see OdsAutocompleteAttribute.ariaLabel
+         */
+        "ariaLabel"?: HTMLElement['ariaLabel'];
+        /**
+          * The ID to an external description
+          * @see OdsAutocompleteAttribute.ariaLabelledby
+         */
+        "ariaLabelledby"?: string;
+        /**
+          * Defines if the Autocomplete should be clearable or not (displays a clear button)
+          * @see OdsAutocompleteAttribute.clearable
+         */
+        "clearable"?: boolean;
+        /**
+          * Default value of the Autocomplete
+          * @see OdsAutocompleteAttribute.defaultValue
+         */
+        "defaultValue"?: string;
+        /**
+          * Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)
+          * @see OdsAutocompleteAttribute.disabled
+         */
+        "disabled"?: boolean;
+        /**
+          * Defines if the Autocomplete should display an error state
+          * @see OdsAutocompleteAttribute.error
+         */
+        "error"?: boolean;
+        /**
+          * Defines if the Autocomplete should display an icon in the input field
+          * @see OdsAutocompleteAttribute.icon
+         */
+        "icon"?: ODS_ICON_NAME;
+        /**
+          * Indicates if the Autocomplete is full width or not: see component principles
+          * @see OdsAutocompleteAttribute.inline
+         */
+        "inline"?: boolean;
+        /**
+          * Defines the Autocomplete's minimum number of characters to open the dropdown
+          * @see OdsAutocompleteAttribute.minimumNumberOfCharacters
+         */
+        "minimumNumberOfCharacters"?: number;
+        /**
+          * Name of the Autocomplete field
+          * @see OdsAutocompleteAttribute.name
+         */
+        "name"?: string;
+        /**
+          * Event triggered on Autocomplete's blur
+         */
+        "onOdsBlur"?: (event: OsdsAutocompleteCustomEvent<void>) => void;
+        /**
+          * Event triggered on Autocomplete's focus
+         */
+        "onOdsFocus"?: (event: OsdsAutocompleteCustomEvent<void>) => void;
+        /**
+          * Events
+         */
+        "onOdsValueChange"?: (event: OsdsAutocompleteCustomEvent<OdsAutocompleteValueChangeEventDetail>) => void;
+        /**
+          * Defines if the Autocomplete dropdown is opened or not
+          * @see OdsAutocompleteAttribute.opened
+         */
+        "opened"?: boolean;
+        /**
+          * Defines if the Autocomplete should display a placeholder message
+          * @see OdsAutocompleteAttribute.placeholder
+         */
+        "placeholder"?: string;
+        /**
+          * Defines if a value has to be selected or not
+          * @see OdsAutocompleteAttribute.required
+         */
+        "required"?: boolean;
+        /**
+          * Defines the Autocomplete's value
+          * @see OdsAutocompleteAttribute.value
+         */
+        "value"?: string;
     }
     interface OsdsBreadcrumb {
         /**
@@ -4672,6 +4878,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "osds-accordion": OsdsAccordion;
         "osds-accordion-group": OsdsAccordionGroup;
+        "osds-autocomplete": OsdsAutocomplete;
         "osds-breadcrumb": OsdsBreadcrumb;
         "osds-breadcrumb-item": OsdsBreadcrumbItem;
         "osds-button": OsdsButton;
@@ -4743,6 +4950,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "osds-accordion": LocalJSX.OsdsAccordion & JSXBase.HTMLAttributes<HTMLOsdsAccordionElement>;
             "osds-accordion-group": LocalJSX.OsdsAccordionGroup & JSXBase.HTMLAttributes<HTMLOsdsAccordionGroupElement>;
+            "osds-autocomplete": LocalJSX.OsdsAutocomplete & JSXBase.HTMLAttributes<HTMLOsdsAutocompleteElement>;
             "osds-breadcrumb": LocalJSX.OsdsBreadcrumb & JSXBase.HTMLAttributes<HTMLOsdsBreadcrumbElement>;
             "osds-breadcrumb-item": LocalJSX.OsdsBreadcrumbItem & JSXBase.HTMLAttributes<HTMLOsdsBreadcrumbItemElement>;
             "osds-button": LocalJSX.OsdsButton & JSXBase.HTMLAttributes<HTMLOsdsButtonElement>;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -44,3 +44,5 @@ export * from './textarea/src';
 export * from './tile/src';
 export * from './toggle/src';
 export * from './tooltip/src';
+
+export * from './autocomplete/src';

--- a/packages/storybook/stories/components/autocomplete/1_specifications.stories.mdx
+++ b/packages/storybook/stories/components/autocomplete/1_specifications.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta } from '@storybook/addon-docs';
+import Specifications from '@ovhcloud/ods-components/src/autocomplete/documentation/specifications/specifications-autocomplete.mdx';
+
+<Meta title="ODS Components/Form/Autocomplete [organism]/Specifications" />
+
+# Autocomplete - Design Specifications
+----
+
+Autocompletes allow users to enter any combination of letters, numbers, or symbols of their choosing (unless otherwise restricted), and receive one or more suggested matches in a list below the input.
+It is a visual component, meaning sorting logics must be integrated besides the Autocomplete component.
+
+<div>
+  <osds-autocomplete clearable="true" placeholder="Select a language...">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+</div>
+
+# Autocomplete - Technical Specification
+----
+
+<Specifications />

--- a/packages/storybook/stories/components/autocomplete/2_usage.stories.mdx
+++ b/packages/storybook/stories/components/autocomplete/2_usage.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs';
+import Usage from '@ovhcloud/ods-components/src/autocomplete/documentation/usage-guidelines/usage.mdx';
+
+<Meta title="ODS Components/Form/Autocomplete [organism]/Usage Guidelines" />
+
+# Autocomplete - Usage Guidelines
+----
+
+<Usage />

--- a/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
@@ -1,0 +1,79 @@
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/osds-autocomplete';
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import { ODS_ICON_NAMES } from '@ovhcloud/ods-components';
+import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
+
+defineCustomElement();
+
+/* WithoutLogic story parameters  */
+/* Default story parameters  */
+const storyParams = {
+  clearable: {
+    category: 'General',
+    defaultValue: true,
+  },
+  extraOptions: {
+    category: 'Slot',
+    defaultValue: '<osds-select-option value="DE">Guten tag</osds-select-option>',
+  },
+  disabled: {
+    category: 'General',
+    defaultValue: false,
+  },
+  error: {
+    category: 'Misc',
+    defaultValue: false,
+  },
+  icon: {
+    category: 'General',
+    defaultValue: '',
+    options: ODS_ICON_NAMES,
+    control: { type: 'select' },
+  },
+  inline: {
+    category: 'General',
+    defaultValue: false,
+  },
+  minimumNumberOfCharacters: {
+    category: 'General',
+    defaultValue: 0,
+  },
+  opened: {
+    category: 'Misc',
+    defaultValue: false,
+  },
+  placeholder: {
+    category: 'General',
+    defaultValue: '',
+  },
+  required: {
+    category: 'Misc',
+    defaultValue: false,
+  },
+  value: {
+    category: 'Misc',
+    defaultValue: '',
+  },
+};
+
+export default {
+  title: 'ODS Components/Form/Autocomplete [organism]/Demo',
+  id: 'autocomplete',
+  argTypes: extractArgTypes(storyParams)
+};
+
+/* WithoutLogic */
+const TemplateWithoutLogic = (args:any) => html`
+  <osds-autocomplete ...=${getTagAttributes(args)}>
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+    ${unsafeHTML(args.extraOptions)}
+  </osds-autocomplete>
+`;
+export const WithoutLogic = TemplateWithoutLogic.bind({});
+// @ts-ignore
+WithoutLogic.args = {
+  ...extractStoryParams(storyParams),
+};

--- a/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
@@ -2,6 +2,7 @@ import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/os
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { ODS_ICON_NAMES } from '@ovhcloud/ods-components';
+import { AutocompletePlay } from './demo.logic.stories';
 import { extractArgTypes, extractStoryParams, getTagAttributes } from '../../../core/componentHTMLUtils';
 
 defineCustomElement();
@@ -76,8 +77,26 @@ const TemplateWithoutLogic = (args:any) => html`
     ${unsafeHTML(args.extraOptions)}
   </osds-autocomplete>
 `;
+
 export const WithoutLogic = TemplateWithoutLogic.bind({});
 // @ts-ignore
 WithoutLogic.args = {
   ...extractStoryParams(storyParams),
 };
+
+/* WithLogic */
+const TemplateWithLogic = (args:any) => html`
+  <osds-autocomplete ...=${getTagAttributes(args)}>
+  </osds-autocomplete>
+`;
+
+export const WithLogic = TemplateWithLogic.bind({});
+
+type WithLogicProps = {
+  args: Record<string, unknown>;
+  play: () => Promise<void>;
+};
+(WithLogic as unknown as WithLogicProps).args = {
+  ...(extractStoryParams(storyParams) as Record<string, unknown>),
+};
+(WithLogic as unknown as WithLogicProps).play = AutocompletePlay;

--- a/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
@@ -35,6 +35,10 @@ const storyParams = {
     category: 'General',
     defaultValue: false,
   },
+  isLoading: {
+    category: 'General',
+    defaultValue: false,
+  },
   minimumNumberOfCharacters: {
     category: 'General',
     defaultValue: 0,

--- a/packages/storybook/stories/components/autocomplete/demo.logic.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/demo.logic.stories.ts
@@ -1,0 +1,44 @@
+import type { OsdsAutocomplete } from '@ovhcloud/ods-components';
+
+const database = [
+  { value: 'Hello', text: 'Hello World' },
+  { value: 'How', text: 'How are you today?' },
+  { value: 'Bonjour', text: 'Bonjour tout le monde' },
+  { value: 'Hola', text: 'Hola Mundo' },
+  { value: 'Fizz', text: 'Buzz' },
+  { value: 'Auto', text: 'Autocomplete' },
+];
+
+export const AutocompletePlay = async() => {
+  await customElements.whenDefined('osds-autocomplete');
+  const autocomplete = document.querySelector('osds-autocomplete') as (HTMLElement & OsdsAutocomplete) | null;
+
+  if (autocomplete) {
+    const updateOptions = (value: string) => {
+      while (autocomplete.firstChild) {
+        autocomplete.removeChild(autocomplete.firstChild);
+      }
+
+      const regex = new RegExp(value, 'i');
+      database.forEach(entry => {
+        if (regex.test(entry.text)) {
+          const optionElement = document.createElement('osds-select-option');
+          optionElement.value = entry.value;
+
+          const textElem = document.createElement('span');
+          textElem.innerHTML = entry.text.replace(regex, '<b>$&</b>');
+          optionElement.appendChild(textElem);
+
+          autocomplete.appendChild(optionElement);
+        }
+      });
+    };
+
+    autocomplete.addEventListener('odsValueChange', (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      updateOptions(detail.value);
+    });
+
+    updateOptions('');
+  }
+};

--- a/scripts/testing-report/index.html
+++ b/scripts/testing-report/index.html
@@ -71,6 +71,7 @@
     // TODO transform this file as a template and generate it with all components when generating report on CI
     const odsComponents = [
       {name: 'osds-accordion', id: 'accordion'},
+      {name: 'osds-autocomplete', id: 'autocomplete'},
       {name: 'osds-breadcrumb', id: 'breadcrumb'},
       {name: 'osds-button', id: 'button'},
       {name: 'osds-cart', id: 'cart'},

--- a/yarn.lock
+++ b/yarn.lock
@@ -5220,11 +5220,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-autocomplete@workspace:packages/components/src/autocomplete"
   dependencies:
-    "@ovhcloud/ods-common-core": 17.1.0
-    "@ovhcloud/ods-common-stencil": 17.1.0
-    "@ovhcloud/ods-common-testing": 17.1.0
-    "@ovhcloud/ods-common-theming": 17.1.0
-    "@ovhcloud/ods-stencil-dev": 17.1.0
+    "@ovhcloud/ods-cdk": 17.2.1
+    "@ovhcloud/ods-common-core": 17.2.1
+    "@ovhcloud/ods-common-stencil": 17.2.1
+    "@ovhcloud/ods-common-testing": 17.2.1
+    "@ovhcloud/ods-common-theming": 17.2.1
+    "@ovhcloud/ods-stencil-dev": 17.2.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5216,6 +5216,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ovhcloud/ods-component-autocomplete@workspace:packages/components/src/autocomplete":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-autocomplete@workspace:packages/components/src/autocomplete"
+  dependencies:
+    "@ovhcloud/ods-common-core": 17.1.0
+    "@ovhcloud/ods-common-stencil": 17.1.0
+    "@ovhcloud/ods-common-testing": 17.1.0
+    "@ovhcloud/ods-common-theming": 17.1.0
+    "@ovhcloud/ods-stencil-dev": 17.1.0
+  languageName: unknown
+  linkType: soft
+
 "@ovhcloud/ods-component-breadcrumb@workspace:packages/components/src/breadcrumb":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-breadcrumb@workspace:packages/components/src/breadcrumb"


### PR DESCRIPTION
## Description

`OsdsAutocomplete` is a new component that allows users to type into an input that will open a dropdown displaying a list of selectable options from which the user can choose from.

> Keep in mind the `OsdsAutocomplete` component is not meant to implement the logic of sorting or filtering the elements that we put inside it. Example of one possible filtering logic is to be found in the `index.html` but is only for testing purpose.

## Content

- New component `OsdsAutocomplete`
- Documentation
- Storybook stories

## To review

Check if the component works properly in multiple environments and situations. Also make sure that documentation is up to the requirements. Look for any potential mistakes or improvements we could address.

## To be added

- Loading state
- BEM SCSS & remove !important (there was an issue with linters being investigated)
- Add a "With logic" page to Storybook
