### PR TITLE
feat(autocomplete): loading state

### DIFF
--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
@@ -9,6 +9,7 @@ const DEFAULT_ATTRIBUTE: OdsAutocompleteAttribute = Object.freeze({
   error: false,
   icon: undefined,
   inline: false,
+  isLoading: false,
   minimumNumberOfCharacters: 0,
   name: undefined,
   opened: false,

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
@@ -34,6 +34,10 @@ interface OdsAutocompleteAttribute {
    */
   inline: boolean;
   /**
+   * Defines if the Autocomplete should display a loading spinner in the dropdown
+   */
+  isLoading: boolean;
+  /**
    * Defines the Autocomplete's minimum number of characters to open the dropdown
    */
   minimumNumberOfCharacters: number;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
@@ -7,7 +7,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 describe('e2e:osds-autocomplete', () => {
   let page: E2EPage;
   let el: E2EElement;
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
 
   async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
@@ -6,7 +6,7 @@ import { newE2EPage } from '@stencil/core/testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 describe('e2e:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: E2EPage;
   let el: E2EElement;
   let inputElement: E2EElement;
@@ -203,6 +203,14 @@ describe('e2e:osds-autocomplete', () => {
       await page.click('body');
       await page.waitForChanges();
       expect(await el.getProperty('opened')).toBe(false);
+    });
+  });
+
+  describe('isLoading', () => {
+    it('should display a loading spinner', async() => {
+      await setup({ attributes: { isLoading: true } });
+      const spinner = await page.find('osds-autocomplete >>> osds-spinner');
+      expect(spinner).not.toBeNull();
     });
   });
 

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -39,6 +39,14 @@
   animation: appear 0.2s ease-in-out;
 }
 
+:host(.ods-autocomplete) .anchor .overlay .loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ods-size-03);
+  height: var(--ods-size-09);
+}
+
 :host(.ods-autocomplete[opened]) {
   .anchor .overlay {
     display: flex;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
@@ -22,7 +22,7 @@ global.MutationObserver = mutationObserverMock;
 OdsMockPropertyDescriptor(HTMLInputElement.prototype, 'validity', () => DEFAULT_VALIDITY_STATE);
 
 describe('spec:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: SpecPage;
   let instance: OsdsAutocomplete;
 
@@ -138,6 +138,17 @@ describe('spec:osds-autocomplete', () => {
         name: 'inline',
         newValue: true,
         setup: (value) => setup({ attributes: { ['inline']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('isLoading', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'isLoading'>({
+        defaultValue: DEFAULT_ATTRIBUTE.isLoading,
+        name: 'isLoading',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['isLoading']: value } }),
         value: false,
         ...config,
       });

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -71,6 +71,9 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
   /** @see OdsAutocompleteAttribute.inline */
   @Prop({ reflect: true }) inline: boolean = DEFAULT_ATTRIBUTE.inline;
 
+  /** @see OdsAutocompleteAttribute.isLoading */
+  @Prop({ mutable: true, reflect: true }) isLoading: boolean = DEFAULT_ATTRIBUTE.isLoading;
+
   /** @see OdsAutocompleteAttribute.minimumNumberOfCharacters */
   @Prop({ reflect: true }) minimumNumberOfCharacters: number = DEFAULT_ATTRIBUTE.minimumNumberOfCharacters;
 
@@ -355,7 +358,12 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
                 this.syncReferences();
               }
             }}>
-            <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            {this.isLoading
+              ? <div class="loading">
+                <osds-spinner inline size='sm'/>
+              </div>
+              : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            }
           </ocdk-surface>
         </div>
       </Host>

--- a/packages/components/src/autocomplete/src/globals.ts
+++ b/packages/components/src/autocomplete/src/globals.ts
@@ -7,6 +7,7 @@
  */
 import '../../content-addon/src';
 import '../../icon/src';
-import '../../text/src';
-import '../../select/src';
 import '../../input/src';
+import '../../select/src';
+import '../../spinner/src';
+import '../../text/src';

--- a/packages/components/src/autocomplete/src/index.html
+++ b/packages/components/src/autocomplete/src/index.html
@@ -44,6 +44,22 @@
     <osds-select-option value="HG">High Grade</osds-select-option>
   </osds-autocomplete>
 
+  <osds-text>Autocomplete 5 (isLoading)</osds-text>
+
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+
+  <osds-text>Autocomplete 6 (isLoading)</osds-text>
+
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." inline is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+
   <script>
     const database = [
       { value: 'Hello', text: 'Hello World' },

--- a/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
@@ -35,6 +35,10 @@ const storyParams = {
     category: 'General',
     defaultValue: false,
   },
+  isLoading: {
+    category: 'General',
+    defaultValue: false,
+  },
   minimumNumberOfCharacters: {
     category: 'General',
     defaultValue: 0,


### PR DESCRIPTION
## Description

`OsdsAutocomplete` is a new component that allows users to type into an input that will open a dropdown displaying a list of selectable options from which the user can choose from.

This addition allows users to add an `isLoading` attribute to the component.

## Content

- `isLoading` will display an `OsdsSpinner` inside the Autocomplete component instead of the slot for the options.

## To review

Check if the `isLoading` attribute works and reacts properly with the correct styling.