### PR TITLE
feat(autocomplete): loading state

### DIFF
--- a/packages/components/src/autocomplete/documentation/specifications/spec.md
+++ b/packages/components/src/autocomplete/documentation/specifications/spec.md
@@ -1,0 +1,48 @@
+* [**Interfaces**](#interfaces)
+
+## Interfaces
+
+### OdsAutocompleteAttribute
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`ariaLabel`** | `undefined` \| `string` | ✴️ |  | The corresponding aria-label describing its content|
+|**`ariaLabelledby`** | _string_ | ✴️ |  | The ID to an external description|
+|**`clearable`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be clearable or not (displays a clear button)|
+|**`defaultValue`** | _string_ | ✴️ |  | Default value of the Autocomplete|
+|**`disabled`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should be disabled or not (lower opacity and not interactable)|
+|**`error`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should display an error state|
+|**`icon`** | `ODS_ICON_NAME` |  |  | Defines if the Autocomplete should display an icon in the input field|
+|**`inline`** | _boolean_ | ✴️ |  | Indicates if the Autocomplete is full width or not: see component principles|
+|**`isLoading`** | _boolean_ | ✴️ |  | Defines if the Autocomplete should display a loading spinner in the dropdown|
+|**`minimumNumberOfCharacters`** | _number_ | ✴️ |  | Defines the Autocomplete's minimum number of characters to open the dropdown|
+|**`name`** | _string_ |  |  | Name of the Autocomplete field|
+|**`opened`** | _boolean_ | ✴️ |  | Defines if the Autocomplete dropdown is opened or not|
+|**`placeholder`** | _string_ |  |  | Defines if the Autocomplete should display a placeholder message|
+|**`required`** | _boolean_ | ✴️ |  | Defines if a value has to be selected or not|
+|**`value`** | _string_ | ✴️ |  | Defines the Autocomplete's value|
+
+### OdsAutocompleteEvent
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`odsBlur`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's blur|
+|**`odsFocus`** | `EventEmitter<void>` | ✴️ |  | Event triggered on Autocomplete's focus|
+|**`odsValueChange`** | `EventEmitter<OdsAutocompleteValueChangeEventDetail>` | ✴️ |  | Event emitted on value change|
+
+### OdsAutocompleteMethod
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`clear`** | `Promise<void>` | ✴️ |  | Erase the current selection|
+|**`getValidity`** | `Promise<OdsValidityState>` | ✴️ |  | Get the validity state|
+|**`reset`** | `Promise<void>` | ✴️ |  | Reset the value to the initial one (default value)|
+|**`setFocus`** | `Promise<void>` | ✴️ |  | Focus the element|
+|**`setInputTabindex`** | `Promise<void>` | ✴️ |  | Set tab index on the component|
+|**`validate`** | `Promise<OdsValidityState>` | ✴️ |  | check if the Autocomplete is valid.In case of required field, the validation will check the entered valueand set the field in error if it is not fulfilled|
+
+### OdsAutocompleteValueChangeEventDetail
+|Name | Type | Required | Default | Description|
+|---|---|:---:|---|---|
+|**`name`** | _string_ |  |  | |
+|**`oldValue`** | `OdsInputValue` |  |  | |
+|**`selection`** | `undefined` \| `OsdsSelectOption` | ✴️ |  | |
+|**`validity`** | `OdsValidityState` | ✴️ |  | |
+|**`value`** | `OdsInputValue` | ✴️ |  | |

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/constants/default-attributes.ts
@@ -9,6 +9,7 @@ const DEFAULT_ATTRIBUTE: OdsAutocompleteAttribute = Object.freeze({
   error: false,
   icon: undefined,
   inline: false,
+  isLoading: false,
   minimumNumberOfCharacters: 0,
   name: undefined,
   opened: false,

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/interfaces/attributes.ts
@@ -34,6 +34,10 @@ interface OdsAutocompleteAttribute {
    */
   inline: boolean;
   /**
+   * Defines if the Autocomplete should display a loading spinner in the dropdown
+   */
+  isLoading: boolean;
+  /**
    * Defines the Autocomplete's minimum number of characters to open the dropdown
    */
   minimumNumberOfCharacters: number;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.screenshot.ts
@@ -7,7 +7,7 @@ import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 describe('e2e:osds-autocomplete', () => {
   let page: E2EPage;
   let el: E2EElement;
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
 
   async function setup({ attributes = {}, html = '' }: { attributes?: Partial<OdsAutocompleteAttribute>, html?: string } = {}): Promise<void> {
     const stringAttributes = odsComponentAttributes2StringAttributes<OdsAutocompleteAttribute>({ ...baseAttribute, ...attributes }, DEFAULT_ATTRIBUTE);

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.e2e.ts
@@ -6,7 +6,7 @@ import { newE2EPage } from '@stencil/core/testing';
 import { DEFAULT_ATTRIBUTE } from './constants/default-attributes';
 
 describe('e2e:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 0, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: E2EPage;
   let el: E2EElement;
   let inputElement: E2EElement;
@@ -203,6 +203,14 @@ describe('e2e:osds-autocomplete', () => {
       await page.click('body');
       await page.waitForChanges();
       expect(await el.getProperty('opened')).toBe(false);
+    });
+  });
+
+  describe('isLoading', () => {
+    it('should display a loading spinner', async() => {
+      await setup({ attributes: { isLoading: true } });
+      const spinner = await page.find('osds-autocomplete >>> osds-spinner');
+      expect(spinner).not.toBeNull();
     });
   });
 

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -11,22 +11,21 @@
 :host(.autocomplete) {
   display: flex;
   flex-direction: column;
-  width: 100%;
 }
 
 .autocomplete {
   display: flex;
   flex-direction: column;
-  width: 100%;
-
-  &--inline {
-    width: fit-content;
-  }
 
   &__anchor {
+    width: 100%;
     position: relative;
     padding: 0;
     text-align: initial;
+
+    &--inline {
+      width: fit-content;
+    }
   }
 
   &__input {
@@ -37,6 +36,7 @@
   }
 
   &__surface {
+    width: 100%;
     box-sizing: border-box;
     display: none;
     flex-direction: column;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -18,9 +18,9 @@
   flex-direction: column;
 
   &__anchor {
-    width: 100%;
     position: relative;
     padding: 0;
+    width: 100%;
     text-align: initial;
 
     &--inline {
@@ -36,7 +36,6 @@
   }
 
   &__surface {
-    width: 100%;
     box-sizing: border-box;
     display: none;
     flex-direction: column;
@@ -46,6 +45,7 @@
     border-radius: 0 0 var(--ods-size-03) var(--ods-size-03);
     border-color: var(--ods-color-primary-200);
     background: var(--ods-color-gray-000);
+    width: 100%;
     max-height: calc(var(--ods-size-stack-11) * 7.5);
     overflow: auto;
     animation: appear 0.2s ease-in-out;

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.scss
@@ -53,5 +53,13 @@
     &--opened {
       display: flex;
     }
+
+    &__loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--ods-size-03);
+      height: var(--ods-size-09);
+    }
   }
 }

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.spec.ts
@@ -22,7 +22,7 @@ global.MutationObserver = mutationObserverMock;
 OdsMockPropertyDescriptor(HTMLInputElement.prototype, 'validity', () => DEFAULT_VALIDITY_STATE);
 
 describe('spec:osds-autocomplete', () => {
-  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
+  const baseAttribute = { ariaLabel: null, ariaLabelledby: '', clearable: false, defaultValue: '', disabled: false, error: false, icon: undefined, inline: false, isLoading: false, minimumNumberOfCharacters: 2, name: undefined, opened: false, placeholder: '', required: false, value: '' };
   let page: SpecPage;
   let instance: OsdsAutocomplete;
 
@@ -138,6 +138,17 @@ describe('spec:osds-autocomplete', () => {
         name: 'inline',
         newValue: true,
         setup: (value) => setup({ attributes: { ['inline']: value } }),
+        value: false,
+        ...config,
+      });
+    });
+
+    describe('isLoading', () => {
+      odsUnitTestAttribute<OdsAutocompleteAttribute, 'isLoading'>({
+        defaultValue: DEFAULT_ATTRIBUTE.isLoading,
+        name: 'isLoading',
+        newValue: true,
+        setup: (value) => setup({ attributes: { ['isLoading']: value } }),
         value: false,
         ...config,
       });

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -344,9 +344,9 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
         tabindex: disabled ? -1 : this.tabindex,
       }}>
         <div class={{
-            'autocomplete__anchor': true,
-            'autocomplete__anchor--inline': inline,
-          }}>
+          'autocomplete__anchor': true,
+          'autocomplete__anchor--inline': inline,
+        }}>
           <osds-input
             class={{
               'autocomplete__input': true,

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -343,7 +343,10 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
         },
         tabindex: disabled ? -1 : this.tabindex,
       }}>
-        <div class='autocomplete__anchor'>
+        <div class={{
+            'autocomplete__anchor': true,
+            'autocomplete__anchor--inline': inline,
+          }}>
           <osds-input
             class={{
               'autocomplete__input': true,
@@ -372,7 +375,7 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
               }
             }}>
             {this.isLoading
-              ? <div class="loading">
+              ? <div class='autocomplete__surface__loading'>
                 <osds-spinner inline size='sm'/>
               </div>
               : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>

--- a/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/components/osds-autocomplete/osds-autocomplete.tsx
@@ -71,6 +71,9 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
   /** @see OdsAutocompleteAttribute.inline */
   @Prop({ reflect: true }) inline: boolean = DEFAULT_ATTRIBUTE.inline;
 
+  /** @see OdsAutocompleteAttribute.isLoading */
+  @Prop({ mutable: true, reflect: true }) isLoading: boolean = DEFAULT_ATTRIBUTE.isLoading;
+
   /** @see OdsAutocompleteAttribute.minimumNumberOfCharacters */
   @Prop({ reflect: true }) minimumNumberOfCharacters: number = DEFAULT_ATTRIBUTE.minimumNumberOfCharacters;
 
@@ -368,7 +371,12 @@ export class OsdsAutocomplete implements OdsAutocompleteAttribute, OdsAutocomple
                 this.syncReferences();
               }
             }}>
-            <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            {this.isLoading
+              ? <div class="loading">
+                <osds-spinner inline size='sm'/>
+              </div>
+              : <slot onSlotchange={(): Promise<void> => this.handleSlotChange()}></slot>
+            }
           </ocdk-surface>
         </div>
       </Host>

--- a/packages/components/src/autocomplete/src/globals.ts
+++ b/packages/components/src/autocomplete/src/globals.ts
@@ -7,6 +7,7 @@
  */
 import '../../content-addon/src';
 import '../../icon/src';
-import '../../text/src';
-import '../../select/src';
 import '../../input/src';
+import '../../select/src';
+import '../../spinner/src';
+import '../../text/src';

--- a/packages/components/src/autocomplete/src/index.html
+++ b/packages/components/src/autocomplete/src/index.html
@@ -44,11 +44,27 @@
     <osds-select-option value="HG">High Grade</osds-select-option>
   </osds-autocomplete>
 
-  <div style="width: 100%; height: 55vh;"></div>
+  <osds-text>Autocomplete 5 (isLoading)</osds-text>
 
-  <osds-text>Autocomplete 5 (At the bottom of the page)</osds-text>
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
 
-  <osds-autocomplete id="autocomplete5" clearable="true" placeholder="Select a server...">
+  <osds-text>Autocomplete 6 (isLoading)</osds-text>
+
+  <osds-autocomplete id="autocomplete3" clearable="true" placeholder="Select a language..." inline is-loading="true">
+    <osds-select-option value="FR">Bonjour</osds-select-option>
+    <osds-select-option value="IT">Bongiorno</osds-select-option>
+    <osds-select-option value="EN">Hello</osds-select-option>
+  </osds-autocomplete>
+
+  <div style="width: 100%; height: 45vh;"></div>
+
+  <osds-text>Autocomplete 7 (At the bottom of the page)</osds-text>
+
+  <osds-autocomplete id="autocomplete7" clearable="true" placeholder="Select a server...">
     <osds-select-option value="RS">Rise</osds-select-option>
     <osds-select-option value="AV">Advance</osds-select-option>
     <osds-select-option value="GM">Game</osds-select-option>

--- a/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
+++ b/packages/storybook/stories/components/autocomplete/3_demo.stories.ts
@@ -35,6 +35,10 @@ const storyParams = {
     category: 'General',
     defaultValue: false,
   },
+  isLoading: {
+    category: 'General',
+    defaultValue: false,
+  },
   minimumNumberOfCharacters: {
     category: 'General',
     defaultValue: 0,


### PR DESCRIPTION

## Description

`OsdsAutocomplete` is a new component that allows users to type into an input that will open a dropdown displaying a list of selectable options from which the user can choose from.

This addition allows users to add an `isLoading` attribute to the component.

## Content

- `isLoading` will display an `OsdsSpinner` inside the Autocomplete component instead of the slot for the options.

## To review

Check if the `isLoading` attribute works and reacts properly with the correct styling.
