### PR TITLE
Refactor/ods fix icon name

### DIFF
--- a/packages/storybook/stories/components/icon/documentation.mdx
+++ b/packages/storybook/stories/components/icon/documentation.mdx
@@ -11,7 +11,7 @@ import * as IconStories from './icon.stories';
 
 Icon is a visual context used to represent a command, navigation, status or common action.
 
-<Canvas of={ IconStories.Overview } sourceState='none' />
+<Canvas of={ IconStories.Default } sourceState='none' />
 
 <div>
   <a href="#"

--- a/packages/storybook/stories/components/icon/icon.stories.ts
+++ b/packages/storybook/stories/components/icon/icon.stories.ts
@@ -61,7 +61,7 @@ export const All: StoryObj = {
   },
 };
 
-export const Overview: StoryObj = {
+export const Default: StoryObj = {
   tags: ['isHidden'],
   parameters: {
     layout: 'centered',

--- a/packages/storybook/stories/components/icon/migration.from.17.x.mdx
+++ b/packages/storybook/stories/components/icon/migration.from.17.x.mdx
@@ -53,7 +53,7 @@ Contrasted icon:
 <!-- is now -->
 
 <ods-icon class="custom"
-          name="warning">
+          name="warning-triangle">
 </ods-icon>
 
 <style>
@@ -72,7 +72,7 @@ Icon size:
 <!-- is now -->
 
 <ods-icon class="custom"
-          name="warning">
+          name="warning-triangle">
 </ods-icon>
 
 <style>

--- a/packages/storybook/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/storybook/stories/components/tooltip/tooltip.stories.ts
@@ -81,10 +81,10 @@ export const Default: StoryObj = {
   tags: ['isHidden'],
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
-<ods-icon id="trigger-3"
+<ods-icon id="trigger-4"
           name="help-circle">
 </ods-icon>
-<ods-tooltip trigger-id="trigger-3">
+<ods-tooltip trigger-id="trigger-4">
   Tooltip content
 </ods-tooltip>
   `,
@@ -94,10 +94,10 @@ export const ArrowTip: StoryObj = {
   tags: ['isHidden'],
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
-<ods-icon id="trigger-4"
+<ods-icon id="trigger-5"
           name="help-circle">
 </ods-icon>
-<ods-tooltip trigger-id="trigger-4"
+<ods-tooltip trigger-id="trigger-5"
              with-arrow>
   Tooltip content
 </ods-tooltip>
@@ -108,11 +108,11 @@ export const CustomCSS: StoryObj = {
   tags: ['isHidden'],
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
-<ods-icon id="trigger-5"
+<ods-icon id="trigger-3"
           name="help-circle">
 </ods-icon>
 <ods-tooltip position="top-start"
-             trigger-id="trigger-5"
+             trigger-id="trigger-3"
              with-arrow>
   <p class="custom-tooltip">
     Top-start tooltip

--- a/packages/storybook/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/storybook/stories/components/tooltip/tooltip.stories.ts
@@ -24,7 +24,7 @@ export const Demo: StoryObj = {
   render: (args) => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
 <ods-icon id="trigger-1"
-          name="warning">
+          name="help-circle">
 </ods-icon>
 <ods-tooltip position="${args.position}"
              trigger-id="trigger-1"
@@ -69,7 +69,7 @@ export const Overview: StoryObj = {
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
 <ods-icon id="trigger-2"
-          name="warning">
+          name="help-circle">
 </ods-icon>
 <ods-tooltip trigger-id="trigger-2">
   Tooltip content
@@ -82,7 +82,7 @@ export const Default: StoryObj = {
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
 <ods-icon id="trigger-3"
-          name="warning">
+          name="help-circle">
 </ods-icon>
 <ods-tooltip trigger-id="trigger-3">
   Tooltip content
@@ -95,7 +95,7 @@ export const ArrowTip: StoryObj = {
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
 <ods-icon id="trigger-4"
-          name="warning">
+          name="help-circle">
 </ods-icon>
 <ods-tooltip trigger-id="trigger-4"
              with-arrow>
@@ -109,7 +109,7 @@ export const CustomCSS: StoryObj = {
   render: () => html`
 <ods-text preset="paragraph">Lorem ipsum &nbsp;</ods-text>
 <ods-icon id="trigger-5"
-          name="warning">
+          name="help-circle">
 </ods-icon>
 <ods-tooltip position="top-start"
              trigger-id="trigger-5"


### PR DESCRIPTION
- Fix wrong icon name breaking Tooltip
- Overview no longer exists in stories for Canvas -> Default should be enough

