### PR TITLE
refactor(link): normalize boolean prop naming

### DIFF
--- a/packages/ods/src/components/link/src/components/ods-link/ods-link.tsx
+++ b/packages/ods/src/components/link/src/components/ods-link/ods-link.tsx
@@ -9,10 +9,10 @@ import { ODS_LINK_COLOR, type OdsLinkColor } from '../../constant/link-color';
 })
 export class OdsLink {
   @Prop({ reflect: true }) public color: OdsLinkColor = ODS_LINK_COLOR.primary;
-  @Prop({ reflect: true }) public disabled: boolean = false;
   @Prop({ reflect: true }) public download?: HTMLAnchorElement['download'];
   @Prop({ reflect: true }) public href!: string;
   @Prop({ reflect: true }) public icon?: OdsIconName;
+  @Prop({ reflect: true }) public isDisabled: boolean = false;
   @Prop({ reflect: true }) public label?: string;
   @Prop({ reflect: true }) public referrerpolicy?: ReferrerPolicy;
   @Prop({ reflect: true }) public rel?: HTMLAnchorElement['rel'];
@@ -20,7 +20,7 @@ export class OdsLink {
 
   @Listen('click')
   onClick(event: MouseEvent): void {
-    if (this.disabled) {
+    if (this.isDisabled) {
       event.preventDefault();
       event.stopPropagation();
     }
@@ -31,7 +31,7 @@ export class OdsLink {
       <Host class="ods-link">
         <a class={{
           'ods-link__link': true,
-          'ods-link__link--disabled': this.disabled ?? false,
+          'ods-link__link--disabled': this.isDisabled ?? false,
           [`ods-link__link--${this.color}`]: true,
         }}
         download={ this.download }
@@ -39,7 +39,7 @@ export class OdsLink {
         part="link"
         referrerPolicy={ this.referrerpolicy }
         rel={ this.rel }
-        tabindex={ this.disabled ? -1 : 0 }
+        tabindex={ this.isDisabled ? -1 : 0 }
         target={ this.target }>
           <span>
             { this.label }

--- a/packages/ods/src/components/link/src/index.html
+++ b/packages/ods/src/components/link/src/index.html
@@ -16,7 +16,7 @@
   </ods-link>
 
   <p>Disabled</p>
-  <ods-link href="test" label="link disabled" disabled target="_blank">
+  <ods-link href="test" label="link disabled" is-disabled target="_blank">
   </ods-link>
 
   <p>Icon</p>
@@ -24,7 +24,7 @@
   </ods-link>
 
   <p>Icon Disabled</p>
-  <ods-link href="test" label="link icon disabled" icon="arrow-right" disabled>
+  <ods-link href="test" label="link icon disabled" icon="arrow-right" is-disabled>
   </ods-link>
 
   <p>Custom CSS</p>

--- a/packages/ods/src/components/link/tests/navigation/ods-link.e2e.ts
+++ b/packages/ods/src/components/link/tests/navigation/ods-link.e2e.ts
@@ -22,7 +22,7 @@ describe('ods-link navigation', () => {
   });
 
   it('should not be focused when  disabled', async() => {
-    await setup('<ods-link label="some link" disabled href="https://www.ovhcloud.com/fr/"></ods-link>');
+    await setup('<ods-link label="some link" is-disabled href="https://www.ovhcloud.com/fr/"></ods-link>');
     await page.keyboard.press('Tab');
     const focusedTagName = await page.evaluate(() => document.activeElement?.tagName);
     expect(focusedTagName).not.toBe('ODS-LINK');
@@ -39,7 +39,7 @@ describe('ods-link navigation', () => {
 
   it('should not trigger link on Enter when disabled', async() => {
     const href = 'https://www.ovhcloud.com/fr/';
-    await setup(`<ods-link label="some link" disabled href="${href}"></ods-link>`);
+    await setup(`<ods-link label="some link" is-disabled href="${href}"></ods-link>`);
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
     await page.waitForNetworkIdle();
@@ -56,7 +56,7 @@ describe('ods-link navigation', () => {
 
   it('should not trigger link on click when disabled', async() => {
     const href = 'https://www.ovhcloud.com/fr/';
-    await setup(`<ods-link label="some link" disabled href="${href}"></ods-link>`);
+    await setup(`<ods-link label="some link" is-disabled href="${href}"></ods-link>`);
     await el.click();
     await page.waitForNetworkIdle();
     expect(page.url()).not.toBe(href);

--- a/packages/ods/src/components/link/tests/rendering/ods-link.e2e.ts
+++ b/packages/ods/src/components/link/tests/rendering/ods-link.e2e.ts
@@ -39,9 +39,9 @@ describe('ods-link rendering', () => {
   });
 
   it('should get class disabled', async() => {
-    await setup('<ods-link disabled></ods-link>');
+    await setup('<ods-link is-disabled></ods-link>');
 
-    expect(el.getAttribute('disabled')).toBe('');
+    expect(el.getAttribute('is-disabled')).toBe('');
     expect(aElement.classList.contains('ods-link__link--disabled')).toBe(true);
   });
 

--- a/packages/ods/src/components/link/tests/rendering/ods-link.spec.ts
+++ b/packages/ods/src/components/link/tests/rendering/ods-link.spec.ts
@@ -35,15 +35,15 @@ describe('ods-link rendering', () => {
 
   describe('disabled', () => {
     it('should be reflected', async() => {
-      await setup(`<ods-link disabled></ods-link>`);
+      await setup(`<ods-link is-disabled></ods-link>`);
 
-      expect(root?.getAttribute('disabled')).toBe('');
+      expect(root?.getAttribute('is-disabled')).toBe('');
     });
 
     it('should render with expected default value', async() => {
       await setup(`<ods-link></ods-link>`);
 
-      expect(root?.getAttribute('disabled')).toBe(null);
+      expect(root?.getAttribute('is-disabled')).toBe(null);
     });
   });
 

--- a/packages/storybook/stories/components/link/link.stories.ts
+++ b/packages/storybook/stories/components/link/link.stories.ts
@@ -18,10 +18,10 @@ export const Demo: StoryObj = {
     <ods-link
       class="my-link-demo"
       color="${args.color}"
-      disabled="${args.disabled}"
       download="${args.download}"
       href="${args.href}"
       icon="${args.icon}"
+      is-disabled="${args.isDisabled}"
       label="${args.label}"
       rel="${args.rel}"
       referrerpolicy="${args.referrerpolicy}"
@@ -64,14 +64,6 @@ export const Demo: StoryObj = {
       control: 'text',
       description: 'Set a custom style properties on the icon. Example: "width: 2rem; height: 2rem;"',
     },
-    disabled: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
     download: {
       table: {
         category: CONTROL_CATEGORY.general,
@@ -96,6 +88,14 @@ export const Demo: StoryObj = {
       control: 'select',
       options: ODS_ICON_NAMES,
       description: 'See the whole list [here](/?path=/docs/ods-components-content-icon--documentation#name)'
+    },
+    isDisabled: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+      control: 'boolean',
     },
     label: {
       table: {
@@ -132,7 +132,7 @@ export const Demo: StoryObj = {
   }),
   args: {
     color: ODS_LINK_COLOR.primary,
-    disabled: false,
+    isDisabled: false,
     label: 'my label',
   },
 };
@@ -151,14 +151,12 @@ export const Color: StoryObj = {
   `,
 };
 
-
 export const Disabled: StoryObj = {
   tags: ['isHidden'],
   render: () => html`
-<ods-link href="https://www.ovhcloud.com/" disabled="false" label="Not Disabled"></ods-link>
-<ods-link href="https://www.ovhcloud.com/" disabled label="Disabled"></ods-link>  `,
+<ods-link href="https://www.ovhcloud.com/" is-disabled="false" label="Not Disabled"></ods-link>
+<ods-link href="https://www.ovhcloud.com/" is-disabled label="Disabled"></ods-link>  `,
 };
-
 
 export const Icon: StoryObj = {
   tags: ['isHidden'],
@@ -166,7 +164,6 @@ export const Icon: StoryObj = {
 <ods-link href="https://www.ovhcloud.com/" label="Icon Link" icon="warning"></ods-link>
   `,
 };
-
 
 export const Target: StoryObj = {
   tags: ['isHidden'],
@@ -179,7 +176,6 @@ export const Target: StoryObj = {
 </div>
   `,
 };
-
 
 export const CustomCSSLink: StoryObj = {
   tags: ['isHidden'],

--- a/packages/storybook/stories/components/link/migration.from.17.x.mdx
+++ b/packages/storybook/stories/components/link/migration.from.17.x.mdx
@@ -14,6 +14,12 @@ Has been removed.
 
 You can use the style customization to achieve the same result, until a new color get validated by the design team.
 
+`disabled` <img src="https://img.shields.io/badge/updated-00FFFF" />
+
+Has been updated.
+
+You can use the new `isDisabled` attribute to obtain the same behavior.
+
 `slot ` <img src="https://img.shields.io/badge/removed-FF0000" />
 
 Has been removed.
@@ -25,11 +31,25 @@ You can use the new attributes `label` and `icon` to achieve that.
 
 Label link:
 ```html
-<osds-link href="/page">Content</osds-link>
+<osds-link href="/page">
+  My link
+</osds-link>
 
 <!-- is now -->
 
 <ods-link href="/page" label="Content"></ods-link>
+```
+
+Disabled link:
+```html
+<osds-link href="/page" disabled>
+  My link
+</osds-link>
+
+<!-- is now -->
+
+<ods-link href="/page" label="My link" is-disabled>
+</ods-link>
 ```
 
 Icon link:


### PR DESCRIPTION
As discused, all boolean prop will follow a specific naming convention (`isProp`, `hasProp`, `withProp`)