### PR TITLE
feat(breadcrumb): implement component

### DIFF
--- a/packages/ods/react/tests/_app/src/components.ts
+++ b/packages/ods/react/tests/_app/src/components.ts
@@ -20,6 +20,7 @@ const componentNames = [
   'medium',
   'input',
   'textarea',
+  'breadcrumb',
   //--generator-anchor--
 ];
 

--- a/packages/ods/react/tests/_app/src/components/ods-breadcrumb.tsx
+++ b/packages/ods/react/tests/_app/src/components/ods-breadcrumb.tsx
@@ -1,0 +1,14 @@
+import React from 'react-dom/client';
+import { OdsBreadcrumb, OdsBreadcrumbItem } from 'ods-components-react';
+
+const Breadcrumb = () => {
+  return (
+    <OdsBreadcrumb>
+      <OdsBreadcrumbItem href="" icon="home" />
+      <OdsBreadcrumbItem href="" label="Link" />
+      <OdsBreadcrumbItem href="" label="Text" />
+    </OdsBreadcrumb>
+  );
+};
+
+export default Breadcrumb;

--- a/packages/ods/react/tests/e2e/ods-breadcrumb.e2e.ts
+++ b/packages/ods/react/tests/e2e/ods-breadcrumb.e2e.ts
@@ -1,0 +1,23 @@
+import type { Page } from 'puppeteer';
+import { goToComponentPage, setupBrowser } from '../setup';
+
+describe('ods-breadcrumb react', () => {
+  const setup = setupBrowser();
+  let page: Page;
+
+  beforeAll(async () => {
+    page = setup().page;
+  });
+
+  beforeEach(async () => {
+    await goToComponentPage(page, 'ods-breadcrumb');
+  });
+
+  it('render the component correctly', async () => {
+    const elem = await page.$('ods-breadcrumb');
+    const boundingBox = await elem?.boundingBox();
+
+    expect(boundingBox?.height).toBeGreaterThan(0);
+    expect(boundingBox?.width).toBeGreaterThan(0);
+  });
+});

--- a/packages/ods/scripts/generate-typedoc-md.js
+++ b/packages/ods/scripts/generate-typedoc-md.js
@@ -6,8 +6,8 @@
 
 /**
  * Script to generate the file spec.md for one specific component
- * The file is created in <path>/documentation/specifications
- * The script need a json typedoc file in <path>/docs-api/typedoc.json
+ * The file is created in <path>/documentation
+ * The script need a json typedoc file in <path>/typedoc.json
  *
  * You can pass an optional --prefix <value> to manage components that are not
  * in the default "components" package, ex:
@@ -92,6 +92,7 @@ function getClasses(jsonItems) {
 
   const props = children
     .filter(({ kind, decorators }) => kind === ReflectionKind.Property && decorators[0].escapedText === 'Prop')
+    .filter((prop) => prop.flags.isPublic)
     .map((prop) => {
       return [
         `### ${prop.name}`,

--- a/packages/ods/src/components/breadcrumb/.gitignore
+++ b/packages/ods/src/components/breadcrumb/.gitignore
@@ -1,0 +1,5 @@
+# Local Stencil command generates external ods component build at the root of the project
+# Excluding them is a temporary solution to avoid pushing generated files
+# But the issue may cause main build (ods-component package) to fails, as it detects multiples occurences
+# of the same component and thus you have to delete all those generated dir manually
+*/src/

--- a/packages/ods/src/components/breadcrumb/package.json
+++ b/packages/ods/src/components/breadcrumb/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ovhcloud/ods-component-breadcrumb",
+  "version": "17.1.0",
+  "private": true,
+  "description": "ODS Breadcrumb component",
+  "main": "dist/index.cjs.js",
+  "collection": "dist/collection/collection-manifest.json",
+  "scripts": {
+    "clean": "rimraf .stencil coverage dist docs-api www",
+    "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
+    "lint:scss": "stylelint 'src/components/**/*.scss'",
+    "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
+    "start": "stencil build --dev --watch --serve",
+    "test:e2e": "stencil test --e2e --config stencil.config.ts",
+    "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --config stencil.config.ts",
+    "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+  }
+}

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.scss
@@ -2,7 +2,8 @@
 
 :host(.ods-breadcrumb-item) {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
+  font-size: 0.875rem;
   font-weight: link.$ods-link-font-weight;
 }
 

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.scss
@@ -1,0 +1,17 @@
+@use '../../../../../style/link';
+
+:host(.ods-breadcrumb-item) {
+  display: inline-flex;
+  align-items: center;
+  font-weight: link.$ods-link-font-weight;
+}
+
+:host(.ods-breadcrumb-item--collapsed) {
+  display: none;
+}
+
+.ods-breadcrumb-item {
+  &__last {
+    color: var(--ods-color-text);
+  }
+}

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
@@ -52,7 +52,7 @@ export class OdsBreadcrumbItem {
 
         {
           !this.isExpandable && (this.isLast
-            ? <span class="ods-breadcrumb-item__last">
+            ? <span class="ods-breadcrumb-item__last" aria-current="page">
               { this.label }
             </span>
             : <ods-link

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
@@ -1,0 +1,74 @@
+import { Component, Event, type EventEmitter, type FunctionalComponent, Host, Prop, h } from '@stencil/core';
+import { type OdsIconName } from '../../../../icon/src/constants/icon-name';
+
+@Component({
+  shadow: true,
+  styleUrl: 'ods-breadcrumb-item.scss',
+  tag: 'ods-breadcrumb-item',
+})
+export class OdsBreadcrumbItem {
+  @Prop() isCollapsed: boolean = false;
+  @Prop() isExpandable: boolean = false;
+  @Prop() isLast: boolean = false;
+
+  @Prop({ reflect: true }) public href!: string;
+  @Prop({ reflect: true }) public icon?: OdsIconName;
+  @Prop({ reflect: true }) public isDisabled: boolean = false;
+  @Prop({ reflect: true }) public label?: string;
+  @Prop({ reflect: true }) public referrerpolicy?: ReferrerPolicy;
+  @Prop({ reflect: true }) public rel?: HTMLAnchorElement['rel'];
+  @Prop({ reflect: true }) public target?: HTMLAnchorElement['target'];
+
+  @Event() odsBreadcrumbItemClick!: EventEmitter<globalThis.Event>;
+  @Event() odsBreadcrumbItemExpand!: EventEmitter<void>;
+
+  onExpandClick(e: Event): void {
+    e.preventDefault();
+    e.stopPropagation();
+
+    this.odsBreadcrumbItemExpand.emit();
+  }
+
+  onLinkClick(e: globalThis.Event): void {
+    if (!this.isDisabled) {
+      this.odsBreadcrumbItemClick.emit(e);
+    }
+  }
+
+  render(): FunctionalComponent {
+    return (
+      <Host class={{
+        'ods-breadcrumb-item': true,
+        ['ods-breadcrumb-item--collapsed']: this.isCollapsed && !this.isExpandable,
+      }}>
+        {
+          this.isExpandable &&
+          <ods-link
+            href=""
+            label="&hellip;"
+            onClick={ (e: globalThis.Event) => this.onExpandClick(e) }>
+          </ods-link>
+        }
+
+        {
+          !this.isExpandable && (this.isLast
+            ? <span class="ods-breadcrumb-item__last">
+              { this.label }
+            </span>
+            : <ods-link
+              exportparts="link"
+              href={ this.href }
+              icon={ this.icon }
+              isDisabled={ this.isDisabled }
+              label={ this.label }
+              onClick={ (e: globalThis.Event) => this.onLinkClick(e) }
+              referrerpolicy={ this.referrerpolicy }
+              rel={ this.rel }
+              target={ this.target }>
+            </ods-link>
+          )
+        }
+      </Host>
+    );
+  }
+}

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb-item/ods-breadcrumb-item.tsx
@@ -19,7 +19,7 @@ export class OdsBreadcrumbItem {
   @Prop({ reflect: true }) public rel?: HTMLAnchorElement['rel'];
   @Prop({ reflect: true }) public target?: HTMLAnchorElement['target'];
 
-  @Event() odsBreadcrumbItemClick!: EventEmitter<globalThis.Event>;
+  @Event() odsBreadcrumbItemClick!: EventEmitter<MouseEvent>;
   @Event() odsBreadcrumbItemExpand!: EventEmitter<void>;
 
   onExpandClick(e: Event): void {
@@ -29,7 +29,7 @@ export class OdsBreadcrumbItem {
     this.odsBreadcrumbItemExpand.emit();
   }
 
-  onLinkClick(e: globalThis.Event): void {
+  onLinkClick(e: MouseEvent): void {
     if (!this.isDisabled) {
       this.odsBreadcrumbItemClick.emit(e);
     }
@@ -39,14 +39,14 @@ export class OdsBreadcrumbItem {
     return (
       <Host class={{
         'ods-breadcrumb-item': true,
-        ['ods-breadcrumb-item--collapsed']: this.isCollapsed && !this.isExpandable,
+        'ods-breadcrumb-item--collapsed': this.isCollapsed && !this.isExpandable,
       }}>
         {
           this.isExpandable &&
           <ods-link
             href=""
             label="&hellip;"
-            onClick={ (e: globalThis.Event) => this.onExpandClick(e) }>
+            onClick={ (e: MouseEvent) => this.onExpandClick(e) }>
           </ods-link>
         }
 
@@ -61,7 +61,7 @@ export class OdsBreadcrumbItem {
               icon={ this.icon }
               isDisabled={ this.isDisabled }
               label={ this.label }
-              onClick={ (e: globalThis.Event) => this.onLinkClick(e) }
+              onClick={ (e: MouseEvent) => this.onLinkClick(e) }
               referrerpolicy={ this.referrerpolicy }
               rel={ this.rel }
               target={ this.target }>

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
@@ -9,9 +9,8 @@ $breadcrumb-spacing: 8px;
   ::slotted(ods-breadcrumb-item:not(:last-child)) {
     &::after {
       padding-left: $breadcrumb-spacing;
-      line-height: 1.5rem;
       color: var(--ods-color-text);
-      font-size: 1.1rem;
+      font-size: 1rem;
       font-weight: 700;
       content: '|';
     }

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
@@ -9,9 +9,10 @@ $breadcrumb-spacing: 8px;
   ::slotted(ods-breadcrumb-item:not(:last-child)) {
     &::after {
       padding-left: $breadcrumb-spacing;
+      line-height: 1.5rem;
       color: var(--ods-color-text);
-      font-size: 1.25rem;
-      font-weight: 400;
+      font-size: 1.1rem;
+      font-weight: 700;
       content: '|';
     }
   }

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
@@ -4,7 +4,7 @@ $breadcrumb-spacing: 8px;
   display: flex;
   flex-wrap: wrap;
   column-gap: $breadcrumb-spacing;
-  align-items: center;
+  align-items: baseline;
 
   ::slotted(ods-breadcrumb-item:not(:last-child)) {
     &::after {

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.scss
@@ -1,0 +1,18 @@
+$breadcrumb-spacing: 8px;
+
+:host(.ods-breadcrumb) {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: $breadcrumb-spacing;
+  align-items: center;
+
+  ::slotted(ods-breadcrumb-item:not(:last-child)) {
+    &::after {
+      padding-left: $breadcrumb-spacing;
+      color: var(--ods-color-text);
+      font-size: 1.25rem;
+      font-weight: 400;
+      content: '|';
+    }
+  }
+}

--- a/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.tsx
+++ b/packages/ods/src/components/breadcrumb/src/components/ods-breadcrumb/ods-breadcrumb.tsx
@@ -1,0 +1,30 @@
+import { Component, Element, type FunctionalComponent, Host, Listen, h } from '@stencil/core';
+import { expandItems, setupItems } from '../../controller/ods-breadcrumb';
+
+@Component({
+  shadow: true,
+  styleUrl: 'ods-breadcrumb.scss',
+  tag: 'ods-breadcrumb',
+})
+export class OdsBreadcrumb {
+  @Element() el!: HTMLElement;
+
+  @Listen('odsBreadcrumbItemExpand')
+  onOdsBreadcrumbItemExpand(): void {
+    expandItems(Array.from(this.el.children));
+  }
+
+  onSlotChange(): void {
+    setupItems(Array.from(this.el.children));
+  }
+
+  render(): FunctionalComponent {
+    return (
+      <Host
+        class="ods-breadcrumb"
+        role="navigation">
+        <slot onSlotchange={ () => this.onSlotChange() }></slot>
+      </Host>
+    );
+  }
+}

--- a/packages/ods/src/components/breadcrumb/src/controller/ods-breadcrumb.ts
+++ b/packages/ods/src/components/breadcrumb/src/controller/ods-breadcrumb.ts
@@ -1,0 +1,36 @@
+const MAX_ITEM = 4;
+
+function expandItems(items: Element[]): void {
+  items
+    .filter((child) => child.tagName.toLowerCase() === 'ods-breadcrumb-item')
+    .forEach((item) => {
+      item.setAttribute('is-collapsed', 'false');
+      item.setAttribute('is-expandable', 'false');
+    });
+}
+
+function setupItems(items: Element[]): void {
+  const breadcrumbItems = items
+    .filter((child) => child.tagName.toLowerCase() === 'ods-breadcrumb-item');
+
+  if (breadcrumbItems.length) {
+    breadcrumbItems[breadcrumbItems.length - 1].setAttribute('is-last', 'true');
+  }
+
+  if (breadcrumbItems.length > MAX_ITEM) {
+    breadcrumbItems.forEach((breadcrumbItem, idx) => {
+      if (idx > 0 && idx < breadcrumbItems.length - 1) {
+        breadcrumbItem.setAttribute('is-collapsed', 'true');
+      }
+
+      if (idx === 1) {
+        breadcrumbItem.setAttribute('is-expandable', 'true');
+      }
+    });
+  }
+}
+
+export {
+  expandItems,
+  setupItems,
+};

--- a/packages/ods/src/components/breadcrumb/src/globals.ts
+++ b/packages/ods/src/components/breadcrumb/src/globals.ts
@@ -1,0 +1,9 @@
+/**
+ * Import here all the external ODS component that you need to run the current component
+ * when running dev server (yarn start) or e2e tests
+ *
+ * ex:
+ *   import '../../text/src';
+ */
+import '../../icon/src';
+import '../../link/src';

--- a/packages/ods/src/components/breadcrumb/src/index.html
+++ b/packages/ods/src/components/breadcrumb/src/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html dir='ltr' lang='en'>
+<head>
+  <meta charset='utf-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0' />
+  <title>Dev ods-breadcrumb</title>
+
+  <script type='module' src='/build/ods-breadcrumb.esm.js'></script>
+  <script nomodule src='/build/ods-breadcrumb.js'></script>
+  <link rel="stylesheet" href="/build/ods-breadcrumb.css">
+</head>
+
+<body>
+  <p>Default</p>
+  <ods-breadcrumb>
+    <ods-breadcrumb-item href="#"
+                         icon="home">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Link">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         icon="arrow-up"
+                         label="Link icon">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Text">
+    </ods-breadcrumb-item>
+  </ods-breadcrumb>
+
+  <p>Collapsed</p>
+  <ods-breadcrumb>
+    <ods-breadcrumb-item href="#"
+                         icon="home">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="First">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Second">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Third">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Last">
+    </ods-breadcrumb-item>
+  </ods-breadcrumb>
+
+  <p>Custom link style</p>
+  <ods-breadcrumb>
+    <ods-breadcrumb-item href="#"
+                         icon="home">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Link">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item class="my-link"
+                         href="#"
+                         label="Link custom">
+    </ods-breadcrumb-item>
+
+    <ods-breadcrumb-item href="#"
+                         label="Text">
+    </ods-breadcrumb-item>
+  </ods-breadcrumb>
+  <style>
+    .my-link::part(link) {
+      color: green;
+    }
+  </style>
+</body>
+</html>

--- a/packages/ods/src/components/breadcrumb/src/index.html
+++ b/packages/ods/src/components/breadcrumb/src/index.html
@@ -22,7 +22,7 @@
     </ods-breadcrumb-item>
 
     <ods-breadcrumb-item href="#"
-                         icon="arrow-up"
+                         icon="arrow-right"
                          label="Link icon">
     </ods-breadcrumb-item>
 

--- a/packages/ods/src/components/breadcrumb/src/index.ts
+++ b/packages/ods/src/components/breadcrumb/src/index.ts
@@ -1,0 +1,3 @@
+export { OdsBreadcrumb } from './components/ods-breadcrumb/ods-breadcrumb';
+export { OdsBreadcrumbItem } from './components/ods-breadcrumb-item/ods-breadcrumb-item';
+export { type OdsBreadcrumbItemClickEvent, type OdsBreadcrumbItemExpandEvent } from './interfaces/events';

--- a/packages/ods/src/components/breadcrumb/src/interfaces/events.ts
+++ b/packages/ods/src/components/breadcrumb/src/interfaces/events.ts
@@ -1,0 +1,7 @@
+type OdsBreadcrumbItemClickEvent = CustomEvent<Event>;
+type OdsBreadcrumbItemExpandEvent = CustomEvent<void>;
+
+export {
+  type OdsBreadcrumbItemClickEvent,
+  type OdsBreadcrumbItemExpandEvent,
+};

--- a/packages/ods/src/components/breadcrumb/src/interfaces/events.ts
+++ b/packages/ods/src/components/breadcrumb/src/interfaces/events.ts
@@ -1,4 +1,4 @@
-type OdsBreadcrumbItemClickEvent = CustomEvent<Event>;
+type OdsBreadcrumbItemClickEvent = CustomEvent<MouseEvent>;
 type OdsBreadcrumbItemExpandEvent = CustomEvent<void>;
 
 export {

--- a/packages/ods/src/components/breadcrumb/stencil.config.ts
+++ b/packages/ods/src/components/breadcrumb/stencil.config.ts
@@ -1,0 +1,7 @@
+import { getStencilConfig } from '../../config/stencil';
+
+export const config = getStencilConfig({
+  args: process.argv.slice(2),
+  componentCorePackage: '@ovhcloud/ods-component-breadcrumb',
+  namespace: 'ods-breadcrumb',
+});

--- a/packages/ods/src/components/breadcrumb/tests/accessibility/ods-breadcrumb.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/accessibility/ods-breadcrumb.e2e.ts
@@ -20,4 +20,21 @@ describe('ods-breadcrumb accessibility', () => {
     expect(el.shadowRoot).not.toBeNull();
     expect(el.getAttribute('role')).toBe('navigation');
   });
+
+  it('should render the last item with aria-current set', async() => {
+    await setup(`
+<ods-breadcrumb>
+  <ods-breadcrumb-item id="first" label="First">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item id="last" label="Last">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+    `);
+
+    const firstItem = await page.find('ods-breadcrumb > #first');
+    const lastItem = await page.find('ods-breadcrumb > #last');
+
+    expect(firstItem?.shadowRoot?.querySelector('[aria-current]')).toBeNull();
+    expect(lastItem?.shadowRoot?.querySelector('[aria-current]')).not.toBeNull();
+  });
 });

--- a/packages/ods/src/components/breadcrumb/tests/accessibility/ods-breadcrumb.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/accessibility/ods-breadcrumb.e2e.ts
@@ -1,0 +1,23 @@
+import type { E2EElement, E2EPage } from '@stencil/core/testing';
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ods-breadcrumb accessibility', () => {
+  let el: E2EElement;
+  let page: E2EPage;
+
+  async function setup(content: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    el = await page.find('ods-breadcrumb');
+  }
+
+  it('should render the web component with the right role', async() => {
+    await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+    expect(el.shadowRoot).not.toBeNull();
+    expect(el.getAttribute('role')).toBe('navigation');
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/behaviour/ods-breadcrumb-item.spec.ts
+++ b/packages/ods/src/components/breadcrumb/tests/behaviour/ods-breadcrumb-item.spec.ts
@@ -1,0 +1,61 @@
+import { type SpecPage, newSpecPage } from '@stencil/core/testing';
+import { OdsBreadcrumbItem } from '../../src';
+
+describe('ods-breadcrumb-item behaviour', () => {
+  const listenerSpy = jest.fn();
+  const mockEvent = {
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+  };
+  let page: SpecPage;
+  let root: HTMLElement | undefined;
+  let rootInstance: OdsBreadcrumbItem | undefined;
+
+  async function setup(html: string): Promise<void> {
+    page = await newSpecPage({
+      components: [OdsBreadcrumbItem],
+      html,
+    });
+
+    root = page.root;
+    rootInstance = page.rootInstance;
+  }
+
+  beforeEach(jest.clearAllMocks);
+
+  describe('onExpandClick', () => {
+    it('should emit an event', async() => {
+      await setup('<ods-breadcrumb-item></ods-breadcrumb-item>');
+      root?.addEventListener('odsBreadcrumbItemExpand', listenerSpy);
+
+      // @ts-ignore for test purpose
+      rootInstance?.onExpandClick(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockEvent.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onLinkClick', () => {
+    it('should emit an event', async() => {
+      await setup('<ods-breadcrumb-item></ods-breadcrumb-item>');
+      root?.addEventListener('odsBreadcrumbItemClick', listenerSpy);
+
+      // @ts-ignore for test purpose
+      rootInstance?.onLinkClick();
+
+      expect(listenerSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should do nothing if disabled', async() => {
+      await setup('<ods-breadcrumb-item is-disabled></ods-breadcrumb-item>');
+      root?.addEventListener('odsBreadcrumbItemClick', listenerSpy);
+
+      // @ts-ignore for test purpose
+      rootInstance?.onLinkClick();
+
+      expect(listenerSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/controller/ods-breadcrumb.spec.ts
+++ b/packages/ods/src/components/breadcrumb/tests/controller/ods-breadcrumb.spec.ts
@@ -1,0 +1,84 @@
+import { expandItems, setupItems } from '../../src/controller/ods-breadcrumb';
+
+type TestItem = {
+  'is-collapsed'?: string,
+  'is-expandable'?: string,
+  'is-last'?: string,
+  tagName: string,
+  setAttribute: jest.Mock,
+}
+
+describe('ods-breadcrumb controller', () => {
+  const setAttributeSpy = jest.fn()
+    .mockImplementation(function(attr, value) {
+      // @ts-ignore "this" is the actual item
+      this[attr] = value;
+    });
+
+  beforeEach(jest.clearAllMocks);
+
+  describe('expandItems', () => {
+    it('should update the attributes of ods-breadcrumb-item only', () => {
+      const dummyItems: TestItem[] = [
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BUTTON' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+      ];
+
+      // @ts-ignore for test purpose
+      expandItems(dummyItems);
+
+      expect(setAttributeSpy).toHaveBeenCalledTimes(4);
+      expect(dummyItems[0]['is-collapsed']).toBe('false');
+      expect(dummyItems[0]['is-expandable']).toBe('false');
+      expect(dummyItems[1]['is-collapsed']).toBeUndefined();
+      expect(dummyItems[1]['is-expandable']).toBeUndefined();
+      expect(dummyItems[2]['is-collapsed']).toBe('false');
+      expect(dummyItems[2]['is-expandable']).toBe('false');
+    });
+  });
+
+  describe('expandItems', () => {
+    it('should do nothing if there are no ods-breadcrumb-item', () => {
+      const dummyItems: TestItem[] = [
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BUTTON' },
+        { setAttribute: setAttributeSpy, tagName: 'SPAN' },
+      ];
+
+      // @ts-ignore for test purpose
+      setupItems(dummyItems);
+
+      expect(setAttributeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should setup the ods-breadcrumb-item attributes', () => {
+      const dummyItems: TestItem[] = [
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+        { setAttribute: setAttributeSpy, tagName: 'ODS-BREADCRUMB-ITEM' },
+      ];
+
+      // @ts-ignore for test purpose
+      setupItems(dummyItems);
+
+      expect(setAttributeSpy).toHaveBeenCalled();
+      expect(dummyItems[0]['is-collapsed']).toBeUndefined();
+      expect(dummyItems[0]['is-expandable']).toBeUndefined();
+      expect(dummyItems[0]['is-last']).toBeUndefined();
+      expect(dummyItems[1]['is-collapsed']).toBe('true');
+      expect(dummyItems[1]['is-expandable']).toBe('true');
+      expect(dummyItems[1]['is-last']).toBeUndefined();
+      expect(dummyItems[2]['is-collapsed']).toBe('true');
+      expect(dummyItems[2]['is-expandable']).toBeUndefined();
+      expect(dummyItems[2]['is-last']).toBeUndefined();
+      expect(dummyItems[3]['is-collapsed']).toBe('true');
+      expect(dummyItems[3]['is-expandable']).toBeUndefined();
+      expect(dummyItems[3]['is-last']).toBeUndefined();
+      expect(dummyItems[4]['is-collapsed']).toBeUndefined();
+      expect(dummyItems[4]['is-expandable']).toBeUndefined();
+      expect(dummyItems[4]['is-last']).toBe('true');
+    });
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb-item.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb-item.e2e.ts
@@ -1,0 +1,65 @@
+import { type E2EElement, type E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('ods-breadcrumb-item navigation', () => {
+  let el: E2EElement;
+  let page: E2EPage;
+
+  async function isFocused(): Promise<boolean> {
+    return await page.evaluate(() => {
+      const element = document.querySelector('ods-breadcrumb-item');
+      return document.activeElement === element;
+    });
+  }
+
+  async function setup(content: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    el = await page.find('ods-breadcrumb-item');
+  }
+
+  beforeEach(jest.clearAllMocks);
+
+  it('should be focused on tabulation', async() => {
+    await setup('<ods-breadcrumb-item label="Dummy item"></ods-breadcrumb-item>');
+
+    expect(await isFocused()).toBe(false);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isFocused()).toBe(true);
+  });
+
+  it('should not be focusable if disabled', async() => {
+    await setup('<ods-breadcrumb-item is-disabled label="Dummy item"></ods-breadcrumb-item>');
+
+    expect(await isFocused()).toBe(false);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isFocused()).toBe(false);
+  });
+
+  it('should emit an event on click', async() => {
+    await setup('<ods-breadcrumb-item label="Dummy item"></ods-breadcrumb-item>');
+    const eventSpy = await el.spyOnEvent('odsBreadcrumbItemClick');
+
+    await Promise.all([el.waitForEvent('odsBreadcrumbItemClick'), el.click()]);
+
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it('should not be clickable if disabled', async() => {
+    await setup('<ods-breadcrumb-item is-disabled label="Dummy item"></ods-breadcrumb-item>');
+    const eventSpy = await el.spyOnEvent('odsBreadcrumbItemClick');
+
+    await el.click();
+    await page.waitForChanges();
+
+    expect(eventSpy).not.toHaveReceivedEvent();
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb.e2e.ts
@@ -1,0 +1,76 @@
+import { type E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('ods-breadcrumb navigation', () => {
+  let page: E2EPage;
+
+  async function isItemFocused(itemId: string): Promise<boolean> {
+    return await page.evaluate((id) => {
+      const element = document.querySelector(`#${id}`);
+      return document.activeElement === element;
+    }, itemId);
+  }
+
+  async function setup(content: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+    await page.waitForChanges();
+  }
+
+  beforeEach(jest.clearAllMocks);
+
+  it('should focus items on tabulation in sequence except the last', async() => {
+    await setup(`
+<ods-breadcrumb>
+  <ods-breadcrumb-item id="first" label="First"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="second" label="Second"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="last" label="Last"></ods-breadcrumb-item>
+</ods-breadcrumb>
+`);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('first')).toBe(true);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('second')).toBe(true);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('first')).toBe(true);
+    expect(await isItemFocused('last')).toBe(false);
+  });
+
+  it('should focus only first and expandable items if there is more than the max items', async() => {
+    await setup(`
+<ods-breadcrumb>
+  <ods-breadcrumb-item id="first" label="First"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="second" label="Second"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="third" label="Third"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="fourth" label="Fourth"></ods-breadcrumb-item>
+  <ods-breadcrumb-item id="last" label="Last"></ods-breadcrumb-item>
+</ods-breadcrumb>
+<button id="button">Dummy</button>
+`);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('first')).toBe(true);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('second')).toBe(true);
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await isItemFocused('button')).toBe(true);
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/navigation/ods-breadcrumb.e2e.ts
@@ -27,6 +27,7 @@ describe('ods-breadcrumb navigation', () => {
   <ods-breadcrumb-item id="second" label="Second"></ods-breadcrumb-item>
   <ods-breadcrumb-item id="last" label="Last"></ods-breadcrumb-item>
 </ods-breadcrumb>
+<button id="button">Dummy</button>
 `);
 
     await page.keyboard.press('Tab');
@@ -42,8 +43,7 @@ describe('ods-breadcrumb navigation', () => {
     await page.keyboard.press('Tab');
     await page.waitForChanges();
 
-    expect(await isItemFocused('first')).toBe(true);
-    expect(await isItemFocused('last')).toBe(false);
+    expect(await isItemFocused('button')).toBe(true);
   });
 
   it('should focus only first and expandable items if there is more than the max items', async() => {

--- a/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.e2e.ts
@@ -1,0 +1,59 @@
+import { type E2EElement, type E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('ods-breadcrumb-item rendering', () => {
+  let el: E2EElement;
+  let page: E2EPage;
+
+  async function setup(content: string, customStyle?: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    if (customStyle) {
+      await page.addStyleTag({ content: customStyle });
+    }
+
+    el = await page.find('ods-breadcrumb-item');
+  }
+
+  it('should render the web component', async() => {
+    await setup('<ods-breadcrumb-item></ods-breadcrumb-item>');
+
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it('should render a specific link if expandable', async() => {
+    const dummyLabel = 'dummy label';
+    await setup(`<ods-breadcrumb-item is-expandable label="${dummyLabel}"></ods-breadcrumb-item>`);
+    const linkElement = await el.shadowRoot.querySelector('ods-link');
+
+    expect(linkElement).not.toBeNull();
+    expect(linkElement?.getAttribute('label')).not.toBe(dummyLabel);
+  });
+
+  it('should render a text if last', async() => {
+    const dummyLabel = 'dummy label';
+    await setup(`<ods-breadcrumb-item is-last label="${dummyLabel}"></ods-breadcrumb-item>`);
+    const linkElement = await el.shadowRoot.querySelector('ods-link');
+    const textElement = await el.shadowRoot.querySelector('span');
+
+    expect(linkElement).toBeNull();
+    expect(textElement).not.toBeNull();
+  });
+
+  it('should render a link by default', async() => {
+    const dummyLabel = 'dummy label';
+    await setup(`<ods-breadcrumb-item label="${dummyLabel}"></ods-breadcrumb-item>`);
+    const linkElement = await el.shadowRoot.querySelector('ods-link');
+
+    expect(linkElement).not.toBeNull();
+    expect(linkElement?.getAttribute('label')).toBe(dummyLabel);
+  });
+
+  it('should not be visible if collapsed', async() => {
+    await setup('<ods-breadcrumb-item is-collapsed label="dummy-label"></ods-breadcrumb-item>');
+
+    expect(await el.isVisible()).toBe(false);
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.spec.ts
+++ b/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.spec.ts
@@ -48,11 +48,9 @@ describe('ods-breadcrumb-item rendering', () => {
 
   describe('isCollapsed', () => {
     it('should be reflected', async() => {
-      const dummyValue = 'dummy value';
+      await setup('<ods-breadcrumb-item is-collapsed></ods-breadcrumb-item>');
 
-      await setup(`<ods-breadcrumb-item is-collapsed="${dummyValue}"></ods-breadcrumb-item>`);
-
-      expect(root?.getAttribute('is-collapsed')).toBe(dummyValue);
+      expect(root?.getAttribute('is-collapsed')).toBe('');
     });
 
     it('should not be set by default', async() => {
@@ -64,11 +62,9 @@ describe('ods-breadcrumb-item rendering', () => {
 
   describe('isDisabled', () => {
     it('should be reflected', async() => {
-      const dummyValue = 'dummy value';
+      await setup('<ods-breadcrumb-item is-disabled></ods-breadcrumb-item>');
 
-      await setup(`<ods-breadcrumb-item is-disabled="${dummyValue}"></ods-breadcrumb-item>`);
-
-      expect(root?.getAttribute('is-disabled')).toBe(dummyValue);
+      expect(root?.getAttribute('is-disabled')).toBe('');
     });
 
     it('should not be set by default', async() => {
@@ -80,11 +76,9 @@ describe('ods-breadcrumb-item rendering', () => {
 
   describe('isExpandable', () => {
     it('should be reflected', async() => {
-      const dummyValue = 'dummy value';
+      await setup('<ods-breadcrumb-item is-expandable></ods-breadcrumb-item>');
 
-      await setup(`<ods-breadcrumb-item is-expandable="${dummyValue}"></ods-breadcrumb-item>`);
-
-      expect(root?.getAttribute('is-expandable')).toBe(dummyValue);
+      expect(root?.getAttribute('is-expandable')).toBe('');
     });
 
     it('should not be set by default', async() => {
@@ -96,11 +90,9 @@ describe('ods-breadcrumb-item rendering', () => {
 
   describe('isLast', () => {
     it('should be reflected', async() => {
-      const dummyValue = 'dummy value';
+      await setup('<ods-breadcrumb-item is-last></ods-breadcrumb-item>');
 
-      await setup(`<ods-breadcrumb-item is-last="${dummyValue}"></ods-breadcrumb-item>`);
-
-      expect(root?.getAttribute('is-last')).toBe(dummyValue);
+      expect(root?.getAttribute('is-last')).toBe('');
     });
 
     it('should not be set by default', async() => {

--- a/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.spec.ts
+++ b/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb-item.spec.ts
@@ -1,0 +1,176 @@
+import { type SpecPage, newSpecPage } from '@stencil/core/testing';
+import { OdsBreadcrumbItem } from '../../src';
+
+describe('ods-breadcrumb-item rendering', () => {
+  let page: SpecPage;
+  let root: HTMLElement | undefined;
+
+  async function setup(html: string): Promise<void> {
+    page = await newSpecPage({
+      components: [OdsBreadcrumbItem],
+      html,
+    });
+
+    root = page.root;
+  }
+
+  describe('href', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item href="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('href')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('href')).toBeNull();
+    });
+  });
+
+  describe('icon', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item icon="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('icon')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('icon')).toBeNull();
+    });
+  });
+
+  describe('isCollapsed', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item is-collapsed="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('is-collapsed')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('is-collapsed')).toBeNull();
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item is-disabled="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('is-disabled')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('is-disabled')).toBeNull();
+    });
+  });
+
+  describe('isExpandable', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item is-expandable="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('is-expandable')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('is-expandable')).toBeNull();
+    });
+  });
+
+  describe('isLast', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item is-last="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('is-last')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('is-last')).toBeNull();
+    });
+  });
+
+  describe('label', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item label="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('label')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('label')).toBeNull();
+    });
+  });
+
+  describe('referrerpolicy', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item referrerpolicy="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('referrerpolicy')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('referrerpolicy')).toBeNull();
+    });
+  });
+
+  describe('rel', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item rel="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('rel')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('rel')).toBeNull();
+    });
+  });
+
+  describe('target', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-breadcrumb-item target="${dummyValue}"></ods-breadcrumb-item>`);
+
+      expect(root?.getAttribute('target')).toBe(dummyValue);
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+      expect(root?.getAttribute('target')).toBeNull();
+    });
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb.e2e.ts
+++ b/packages/ods/src/components/breadcrumb/tests/rendering/ods-breadcrumb.e2e.ts
@@ -1,0 +1,26 @@
+import type { E2EElement, E2EPage } from '@stencil/core/testing';
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ods-breadcrumb rendering', () => {
+  let el: E2EElement;
+  let page: E2EPage;
+
+  async function setup(content: string, customStyle?: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    if (customStyle) {
+      await page.addStyleTag({ content: customStyle });
+    }
+
+    el = await page.find('ods-breadcrumb');
+  }
+
+  it('should render the web component', async() => {
+    await setup('<ods-breadcrumb></ods-breadcrumb>');
+
+    expect(el.shadowRoot).not.toBeNull();
+  });
+});

--- a/packages/ods/src/components/breadcrumb/tsconfig.json
+++ b/packages/ods/src/components/breadcrumb/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/packages/ods/src/components/breadcrumb/typedoc.json
+++ b/packages/ods/src/components/breadcrumb/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "hideGenerator": true,
+  "json": "dist/docs-api/typedoc.json",
+  "out": "dist/docs-api/",
+  "tsconfig":"tsconfig.json"
+}

--- a/packages/ods/src/components/icon/src/components/ods-icon/ods-icon.tsx
+++ b/packages/ods/src/components/icon/src/components/ods-icon/ods-icon.tsx
@@ -8,8 +8,8 @@ import { Component, Host, Prop, h } from '@stencil/core';
   tag: 'ods-icon',
 })
 export class OdsIcon {
-  @Prop({ reflect: true }) alt?: string = '';
-  @Prop({ reflect: true }) name!: OdsIconName;
+  @Prop({ reflect: true }) public alt?: string = '';
+  @Prop({ reflect: true }) public name!: OdsIconName;
 
   render(): FunctionalComponent {
     return (

--- a/packages/ods/src/components/index.ts
+++ b/packages/ods/src/components/index.ts
@@ -19,3 +19,4 @@ export * from './table/src';
 export * from './medium/src';
 export * from './input/src';
 export * from './textarea/src';
+export * from './breadcrumb/src';

--- a/packages/ods/src/components/link/src/components/ods-link/ods-link.scss
+++ b/packages/ods/src/components/link/src/components/ods-link/ods-link.scss
@@ -31,5 +31,9 @@
         background-size: 0;
       }
     }
+
+    &__icon {
+      display: flex;
+    }
   }
 }

--- a/packages/ods/src/components/link/src/components/ods-link/ods-link.tsx
+++ b/packages/ods/src/components/link/src/components/ods-link/ods-link.tsx
@@ -41,14 +41,25 @@ export class OdsLink {
         rel={ this.rel }
         tabindex={ this.isDisabled ? -1 : 0 }
         target={ this.target }>
-          <span>
-            { this.label }
-          </span>
+          {
+            !!this.label &&
+            <span>
+              { this.label }
+            </span>
+          }
 
           {
             !!this.icon &&
-            <ods-icon name={ this.icon }>
-            </ods-icon>
+            <div class="ods-link__link__icon">
+              {/* If there is no label, we display a zero-width space to simulate the correct baseline */}
+              {
+                !this.label &&
+                <span>&#8203;</span>
+              }
+
+              <ods-icon name={ this.icon }>
+              </ods-icon>
+            </div>
           }
         </a>
       </Host>

--- a/packages/ods/src/components/link/src/index.html
+++ b/packages/ods/src/components/link/src/index.html
@@ -15,12 +15,21 @@
   <ods-link href="test" label="link clickable" target="_blank">
   </ods-link>
 
+  <p>With text</p>
+  <p>
+    Want to discover OVH? Check <ods-link href="test" label="OVH website ppp" target="_blank"></ods-link>
+  </p>
+
   <p>Disabled</p>
   <ods-link href="test" label="link disabled" is-disabled target="_blank">
   </ods-link>
 
   <p>Icon</p>
   <ods-link href="test" label="link icon clickable" icon="arrow-right">
+  </ods-link>
+
+  <p>Icon Only</p>
+  <ods-link href="test" icon="arrow-right">
   </ods-link>
 
   <p>Icon Disabled</p>

--- a/packages/ods/src/components/spinner/src/components/ods-spinner/ods-spinner.tsx
+++ b/packages/ods/src/components/spinner/src/components/ods-spinner/ods-spinner.tsx
@@ -12,8 +12,8 @@ import { ODS_SPINNER_SIZE } from '../../constants/spinner-size';
   tag: 'ods-spinner',
 })
 export class OdsSpinner {
-  @Prop({ reflect: true }) color: OdsSpinnerColor = ODS_SPINNER_COLOR.primary;
-  @Prop({ reflect: true }) size: OdsSpinnerSize = ODS_SPINNER_SIZE.md;
+  @Prop({ reflect: true }) public color: OdsSpinnerColor = ODS_SPINNER_COLOR.primary;
+  @Prop({ reflect: true }) public size: OdsSpinnerSize = ODS_SPINNER_SIZE.md;
 
   render(): FunctionalComponent {
     return (

--- a/packages/ods/src/style/_link.scss
+++ b/packages/ods/src/style/_link.scss
@@ -1,22 +1,23 @@
 @use './focus';
 
+$ods-link-font-weight: 600;
+
 @mixin ods-link() {
   display: inline-flex;
   flex-flow: row;
   grid-gap: 8px;
   align-items: center;
-  transition: background-size .2s ease-in, color ease-in-out .1s;
+  transition: background-size .2s ease-out;
   background-image: linear-gradient(currentcolor, currentcolor);
   background-position: 0 100%;
   background-repeat: no-repeat;
   background-size: 0 1px;
   cursor: pointer;
   text-decoration: none;
-  font-weight: 600;
+  font-weight: $ods-link-font-weight;
 
   &:focus-visible,
   &:hover {
-    transition: background-size .2s ease-out;
     background-size: 100% 1px;
   }
 

--- a/packages/ods/vue/tests/_app/src/components.ts
+++ b/packages/ods/vue/tests/_app/src/components.ts
@@ -20,6 +20,7 @@ const componentNames = [
   'medium',
   'input',
   'textarea',
+  'breadcrumb',
   //--generator-anchor--
 ];
 

--- a/packages/ods/vue/tests/_app/src/components/ods-breadcrumb.vue
+++ b/packages/ods/vue/tests/_app/src/components/ods-breadcrumb.vue
@@ -1,0 +1,20 @@
+<template>
+  <OdsBreadcrumb>
+    <OdsBreadcrumbItem href="" icon="home" />
+    <OdsBreadcrumbItem href="" label="Link" />
+    <OdsBreadcrumbItem href="" label="Text" />
+  </OdsBreadcrumb>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import { OdsBreadcrumb, OdsBreadcrumbItem } from '@ovhcloud/ods-components/vue';
+
+  export default defineComponent({
+    name: 'Breadcrumb',
+    components: {
+      OdsBreadcrumb,
+      OdsBreadcrumbItem,
+    },
+  });
+</script>

--- a/packages/ods/vue/tests/e2e/ods-breadcrumb.e2e.ts
+++ b/packages/ods/vue/tests/e2e/ods-breadcrumb.e2e.ts
@@ -1,0 +1,23 @@
+import type { Page } from 'puppeteer';
+import { goToComponentPage, setupBrowser } from '../setup';
+
+describe('ods-breadcrumb vue', () => {
+  const setup = setupBrowser();
+  let page: Page;
+
+  beforeAll(async () => {
+    page = setup().page;
+  });
+
+  beforeEach(async () => {
+    await goToComponentPage(page, 'ods-breadcrumb');
+  });
+
+  it('render the component correctly', async () => {
+    const elem = await page.$('ods-breadcrumb');
+    const boundingBox = await elem?.boundingBox();
+
+    expect(boundingBox?.height).toBeGreaterThan(0);
+    expect(boundingBox?.width).toBeGreaterThan(0);
+  });
+});

--- a/packages/storybook/stories/components/badge/documentation.mdx
+++ b/packages/storybook/stories/components/badge/documentation.mdx
@@ -16,8 +16,6 @@ Badge show concise metadata or the current status for an item, in a compact form
 
 <DocNavigator of={ BadgeStories } />
 
-# API
-
 <Markdown>{ SpecificationsBadge }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/breadcrumb/breadcrumb.stories.ts
+++ b/packages/storybook/stories/components/breadcrumb/breadcrumb.stories.ts
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-breadcrumb';
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { CONTROL_CATEGORY, orderControls } from '../../control';
+
+defineCustomElement();
+
+const meta: Meta = {
+  title: 'ODS Components/Navigation/Breadcrumb',
+  component: 'ods-breadcrumb',
+};
+
+export default meta;
+
+export const Demo: StoryObj = {
+  render: (arg) => html`
+<ods-breadcrumb>
+  ${unsafeHTML(arg.items)}
+</ods-breadcrumb>
+  `,
+  argTypes: orderControls({
+    items: {
+      table: {
+        category: CONTROL_CATEGORY.slot,
+        defaultValue: { summary: 'ø' },
+      },
+      control: 'text',
+      description: 'Set the <ods-breadcrumb-item> list',
+    },
+  }),
+  args: {
+    items: `<ods-breadcrumb-item href="" icon="home">
+</ods-breadcrumb-item>
+<ods-breadcrumb-item href="" label="Parent">
+</ods-breadcrumb-item>
+<ods-breadcrumb-item href="" label="Current">
+</ods-breadcrumb-item>`,
+  },
+};
+
+export const ClickedItem: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-breadcrumb id="my-breadcrumb-clicked">
+  <ods-breadcrumb-item id="home" href="" icon="home">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item id="link1" href="" label="Link 1">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item id="link2" href="" label="Link 2">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Last">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+<script>
+  const breadcrumbEl = document.querySelector('#my-breadcrumb-clicked');
+  breadcrumbEl.addEventListener('odsBreadcrumbItemClick', (event) => {
+    // event.target.id will refer to the clicked element
+  });
+</script>
+  `,
+};
+
+export const Collapsed: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="" icon="home">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="First">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Second">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Third">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Fourth">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Last">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+  `,
+};
+
+export const CustomCSS: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="" icon="home">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Basic">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item class="my-link" href="" label="Custom">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Last">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+<style>
+  .my-link::part(link) {
+    color: #008000;
+  }
+</style>
+  `,
+};
+
+export const CustomItem: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="" icon="home">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Blank" target="_blank">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" is-disabled label="Disabled">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Last">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+  `,
+};
+
+export const Default: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="" icon="home">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Parent">
+  </ods-breadcrumb-item>
+  <ods-breadcrumb-item href="" label="Current">
+  </ods-breadcrumb-item>
+</ods-breadcrumb>
+  `,
+};

--- a/packages/storybook/stories/components/breadcrumb/documentation.mdx
+++ b/packages/storybook/stories/components/breadcrumb/documentation.mdx
@@ -16,8 +16,6 @@ A list of links showing the current page location in the navigational hierarchy:
 
 <DocNavigator of={ BreadcrumbStories } />
 
-# API
-
 <Markdown>{ SpecificationsBreadcrumb }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/breadcrumb/documentation.mdx
+++ b/packages/storybook/stories/components/breadcrumb/documentation.mdx
@@ -1,0 +1,54 @@
+import { Canvas, Meta, Markdown } from '@storybook/blocks';
+import SpecificationsBreadcrumb from '@ovhcloud/ods-components/src/components/breadcrumb/documentation/spec.md?raw';
+import { Banner } from '../../banner';
+import { DocNavigator } from '../../doc-navigator';
+import * as BreadcrumbStories from './breadcrumb.stories';
+
+<Meta of={ BreadcrumbStories } name='Documentation' />
+
+<Banner of={ BreadcrumbStories } />
+
+# Overview
+
+A list of links showing the current page location in the navigational hierarchy:
+
+<Canvas of={ BreadcrumbStories.Default } sourceState='none' />
+
+<DocNavigator of={ BreadcrumbStories } />
+
+# API
+
+<Markdown>{ SpecificationsBreadcrumb }</Markdown>
+
+# Style customization
+
+The breadcrumb component wraps and apply style on the breadcrumb items you set inside of it.
+
+You can add directly some css classes on each item you want to customize.
+
+If you want to go deeper and customize the item link directly, you can use the part `link`
+
+<Canvas of={ BreadcrumbStories.CustomCSS } sourceState='shown'/>
+
+# Examples
+
+## Default
+
+<Canvas of={ BreadcrumbStories.Default } sourceState='shown' />
+
+## Collapsed
+
+<Canvas of={ BreadcrumbStories.Collapsed } sourceState='shown' />
+
+## Get the clicked item
+
+If you need to perform specific actions when a breadcrumb item is clicked,
+you can observe the `odsBreadcrumbItemClick` event, that will return the target of the click.
+
+<Canvas of={ BreadcrumbStories.ClickedItem } sourceState='shown' />
+
+## Breadcrumb item attributes
+
+Each breadcrumb item supports the same attribute list as the [ods-link](?path=/docs/ods-components-actions-link--documentation#properties) component.
+
+<Canvas of={ BreadcrumbStories.CustomItem } sourceState='shown' />

--- a/packages/storybook/stories/components/breadcrumb/migration.from.17.x.mdx
+++ b/packages/storybook/stories/components/breadcrumb/migration.from.17.x.mdx
@@ -1,0 +1,105 @@
+import { Meta } from '@storybook/blocks';
+import * as BreadcrumbStories from './breadcrumb.stories';
+
+<Meta of={ BreadcrumbStories } name='Migration From 17.x' />
+
+# Breadcrumb - migrate from v17 to v18
+----
+
+## Usage changes
+
+Previous to v18, breadcrumb items were passed as an array attribute, with a strict definition of expected attributes.
+
+New component now works more like other ods components, child items are now declared as slotted element directly in the DOM.
+
+This way you can easily manipulate the list item DOM and each item separately.
+
+```html
+<osds-breadcrumb id="default-breadcrumb"></osds-breadcrumb>
+<script>
+document.querySelector('#default-breadcrumb').items = JSON.stringify([
+  { href: "#home", label: "Home" },
+  { href: "#services", label: "Services" },
+  { href: "#products", label: "Products" },
+  { href: "#web", label: "Web" },
+]);
+</script>
+```
+
+The same result would now be achieved using:
+```html
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="#home" label="Home"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#services" label="Services"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#products" label="Products"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#web" label="Web"></ods-breadcrumb-item>
+</ods-breadcrumb>
+```
+
+## Design changes
+
+The last item of the breadcrumb is now automatically rendered as a text, it is no longer a disabled link.
+
+## Attributes changes
+
+`contrasted ` <img src="https://img.shields.io/badge/removed-FF0000" />
+
+Has been removed.
+
+You can use the style customization to achieve the same result, until a new color get validated by the design team.
+
+`items` <img src="https://img.shields.io/badge/removed-FF0000" />
+
+Has been removed.
+
+You should now use `<ods-breadcrumb-item>` directly in the DOM of the `<ods-breadcrumb>` component.
+
+The attribute list is the same as the [ods-link](?path=/docs/ods-components-actions-link--documentation#properties) component.
+
+Which means you have the same attributes, following the link [migration guide](?path=/docs/ods-components-actions-link--migration-from-17-x).
+
+## Migration examples
+
+Basic breadcrumb:
+```html
+<osds-breadcrumb id="default-breadcrumb"></osds-breadcrumb>
+<script>
+document.querySelector('#default-breadcrumb').items = JSON.stringify([
+  { href: "#home", label: "Home" },
+  { href: "#services", label: "Services" },
+  { href: "#products", label: "Products" },
+  { href: "#web", label: "Web" },
+]);
+</script>
+
+<!-- is now -->
+
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="#home" label="Home"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#services" label="Services"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#products" label="Products"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#web" label="Web"></ods-breadcrumb-item>
+</ods-breadcrumb>
+```
+
+Custom breadcrumb item:
+```html
+<osds-breadcrumb id="default-breadcrumb"></osds-breadcrumb>
+<script>
+document.querySelector('#default-breadcrumb').items = JSON.stringify([
+  { href: "#home", label: "Home" },
+  { href: "#services", label: "Services", target: "_blank" },
+  { href: "#products", label: "Products", disabled: true },
+  { href: "#web", label: "Web" },
+]);
+</script>
+
+<!-- is now -->
+
+<ods-breadcrumb>
+  <ods-breadcrumb-item href="#home" label="Home"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#services" label="Services" target="_blank"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#products" is-disabled label="Products"></ods-breadcrumb-item>
+  <ods-breadcrumb-item href="#web" label="Web"></ods-breadcrumb-item>
+</ods-breadcrumb>
+```

--- a/packages/storybook/stories/components/button/documentation.mdx
+++ b/packages/storybook/stories/components/button/documentation.mdx
@@ -16,8 +16,6 @@ Button component aims to initiate an action. Its text indicates the related inte
 
 <DocNavigator of={ ButtonStories } />
 
-# API
-
 <Markdown>{ SpecificationsButton }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/icon/documentation.mdx
+++ b/packages/storybook/stories/components/icon/documentation.mdx
@@ -16,8 +16,6 @@ Icon is a visual context used to represent a command, navigation, status or comm
 
 <DocNavigator of={ IconStories } />
 
-# API
-
 <Markdown>{ SpecificationsIcon }</Markdown>
 
 # Examples

--- a/packages/storybook/stories/components/input/documentation.mdx
+++ b/packages/storybook/stories/components/input/documentation.mdx
@@ -16,8 +16,6 @@ Input component is an input field where users can type into:
 
 <DocNavigator of={ InputStories } />
 
-# API
-
 <Markdown> { SpecificationsInput } </Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/link/documentation.mdx
+++ b/packages/storybook/stories/components/link/documentation.mdx
@@ -16,8 +16,6 @@ Link is a component that enables redirection to a new page, section, website or 
 
 <DocNavigator of={ LinkStories } />
 
-# API
-
 <Markdown>{ SpecificationsLink }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/medium/documentation.mdx
+++ b/packages/storybook/stories/components/medium/documentation.mdx
@@ -16,8 +16,6 @@ Medium is a wrapper for displaying assets such as images:
 
 <DocNavigator of={ MediumStories } />
 
-# API
-
 <Markdown>{ SpecificationsMedium }</Markdown>
 
 # Examples

--- a/packages/storybook/stories/components/skeleton/documentation.mdx
+++ b/packages/storybook/stories/components/skeleton/documentation.mdx
@@ -16,8 +16,6 @@ Skeleton component indicates that data is loading. It improves the perceived loa
 
 <DocNavigator of={ SkeletonStories } />
 
-# API
-
 <Markdown> { SpecificationsSkeleton } </Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/spinner/documentation.mdx
+++ b/packages/storybook/stories/components/spinner/documentation.mdx
@@ -16,8 +16,6 @@ A visual indicator that a process is happening in the background but the interfa
 
 <DocNavigator of={ SpinnerStories } />
 
-# API
-
 <Markdown>{ SpecificationsSpinner }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/table/documentation.mdx
+++ b/packages/storybook/stories/components/table/documentation.mdx
@@ -16,8 +16,6 @@ Table is a wrapper for displaying tables:
 
 <DocNavigator of={ TableStories } />
 
-# API
-
 <Markdown>{ SpecificationsTable }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/tag/documentation.mdx
+++ b/packages/storybook/stories/components/tag/documentation.mdx
@@ -16,8 +16,6 @@ Tag show concise metadata or the current status for an item, in a compact format
 
 <DocNavigator of={ TagStories } />
 
-# API
-
 <Markdown>{ SpecificationsTag }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/text/documentation.mdx
+++ b/packages/storybook/stories/components/text/documentation.mdx
@@ -16,8 +16,6 @@ The text component is used to display text with a specific font & style.
 
 <DocNavigator of={ TextStories } />
 
-# API
-
 <Markdown> { SpecificationsText } </Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/textarea/documentation.mdx
+++ b/packages/storybook/stories/components/textarea/documentation.mdx
@@ -16,8 +16,6 @@ Textarea component is used to type long content:
 
 <DocNavigator of={ TextareaStories } />
 
-# API
-
 <Markdown>{ SpecificationsTextarea }</Markdown>
 
 # Style customization

--- a/packages/storybook/stories/components/tooltip/documentation.mdx
+++ b/packages/storybook/stories/components/tooltip/documentation.mdx
@@ -14,8 +14,6 @@ import * as TooltipStories from './tooltip.stories';
 
 <DocNavigator of={ TooltipStories } />
 
-# API
-
 <Markdown> { SpecificationsTooltip } </Markdown>
 
 # Style customization

--- a/packages/themes/src/default/index.scss
+++ b/packages/themes/src/default/index.scss
@@ -39,13 +39,13 @@
   --ods-color-primary-700: #{var.$ods-primary-700};
   --ods-color-primary-800: #{var.$ods-primary-800};
   --ods-color-primary-900: #{var.$ods-primary-900};
-  --ods-color-text: #{var.$ods-single-color-text};
   --ods-color-success-000: #{var.$ods-color-green-000};
   --ods-color-success-050: #{var.$ods-color-green-050};
   --ods-color-success-100: #{var.$ods-color-green-100};
   --ods-color-success-200: #{var.$ods-color-green-200};
   --ods-color-success-300: #{var.$ods-color-green-300};
   --ods-color-success-900: #{var.$ods-color-green-900};
+  --ods-color-text: #{var.$ods-single-color-text};
   --ods-color-warning-000: #{var.$ods-color-orange-000};
   --ods-color-warning-050: #{var.$ods-color-orange-050};
   --ods-color-warning-100: #{var.$ods-color-orange-100};

--- a/scripts/component-generator/templates/storybook/documentation.mdx.hbs
+++ b/scripts/component-generator/templates/storybook/documentation.mdx.hbs
@@ -16,8 +16,6 @@ TODO Some text about the component
 
 <DocNavigator of={ {{> ComponentName }}Stories } />
 
-# API
-
 <Markdown>{ Specifications{{> ComponentName }} }</Markdown>
 
 # Style customization [IF RELEVANT]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3849,6 +3849,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ovhcloud/ods-component-breadcrumb@workspace:packages/ods/src/components/breadcrumb":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-breadcrumb@workspace:packages/ods/src/components/breadcrumb"
+  languageName: unknown
+  linkType: soft
+
 "@ovhcloud/ods-component-button@workspace:packages/ods/src/components/button":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-button@workspace:packages/ods/src/components/button"


### PR DESCRIPTION
- update ods-link to allow icon-only link (waiting for design input on this as the rendering on breadcrumb is strange)
- update doc generator to hide non public Prop (and update some component accordingly)
- update doc generator to handle multiple sub-components
- KNOWN ISSUE: unable to prevent breadcrumb link on documentation page to not redirect on click (won't fix here, should be worked on during Doc improvement task)