### PR TITLE
feat(code): implement component

### DIFF
--- a/packages/ods/react/tests/_app/src/components.ts
+++ b/packages/ods/react/tests/_app/src/components.ts
@@ -25,6 +25,7 @@ const componentNames = [
   'toggle',
   'clipboard',
   'divider',
+  'code',
   //--generator-anchor--
 ];
 

--- a/packages/ods/react/tests/_app/src/components/ods-code.tsx
+++ b/packages/ods/react/tests/_app/src/components/ods-code.tsx
@@ -1,0 +1,12 @@
+import React from 'react-dom/client';
+import { OdsCode } from 'ods-components-react';
+
+const Code = () => {
+  return (
+    <OdsCode>
+      Some code to copy
+    </OdsCode>
+  );
+};
+
+export default Code;

--- a/packages/ods/react/tests/e2e/ods-code.e2e.ts
+++ b/packages/ods/react/tests/e2e/ods-code.e2e.ts
@@ -1,0 +1,23 @@
+import type { Page } from 'puppeteer';
+import { goToComponentPage, setupBrowser } from '../setup';
+
+describe('ods-code react', () => {
+  const setup = setupBrowser();
+  let page: Page;
+
+  beforeAll(async () => {
+    page = setup().page;
+  });
+
+  beforeEach(async () => {
+    await goToComponentPage(page, 'ods-code');
+  });
+
+  it('render the component correctly', async () => {
+    const elem = await page.$('ods-code');
+    const boundingBox = await elem?.boundingBox();
+
+    expect(boundingBox?.height).toBeGreaterThan(0);
+    expect(boundingBox?.width).toBeGreaterThan(0);
+  });
+});

--- a/packages/ods/src/components/code/.gitignore
+++ b/packages/ods/src/components/code/.gitignore
@@ -1,0 +1,5 @@
+# Local Stencil command generates external ods component build at the root of the project
+# Excluding them is a temporary solution to avoid pushing generated files
+# But the issue may cause main build (ods-component package) to fails, as it detects multiples occurences
+# of the same component and thus you have to delete all those generated dir manually
+*/src/

--- a/packages/ods/src/components/code/package.json
+++ b/packages/ods/src/components/code/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ovhcloud/ods-component-code",
+  "version": "17.1.0",
+  "private": true,
+  "description": "ODS Code component",
+  "main": "dist/index.cjs.js",
+  "collection": "dist/collection/collection-manifest.json",
+  "scripts": {
+    "clean": "rimraf .stencil coverage dist docs-api www",
+    "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
+    "lint:scss": "stylelint 'src/components/**/*.scss'",
+    "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
+    "start": "stencil build --dev --watch --serve",
+    "test:e2e": "stencil test --e2e --config stencil.config.ts",
+    "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --config stencil.config.ts",
+    "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+  }
+}

--- a/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
+++ b/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
@@ -28,6 +28,7 @@ $ods-code-secondary-color: #000;
   }
 
   &__copy::part(button) {
+    height: input.$ods-input-input-height;
     color: $ods-code-primary-color;
 
     &:hover {

--- a/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
+++ b/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
@@ -10,7 +10,7 @@ $ods-code-secondary-color: #000;
   column-gap: 8px;
   border-radius: var(--ods-border-radius-sm);
   background-color: $ods-code-secondary-color;
-  padding: 8px;
+  padding: 12px;
   min-height: input.$ods-input-input-height;
   color: $ods-code-primary-color;
 }

--- a/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
+++ b/packages/ods/src/components/code/src/components/ods-code/ods-code.scss
@@ -1,0 +1,45 @@
+@use '../../../../../style/input';
+
+// As there are no variant or design token dedicated to this component, we'll just set local variable for now
+$ods-code-primary-color: #fff;
+$ods-code-secondary-color: #000;
+
+:host(.ods-code) {
+  display: inline-flex;
+  flex-flow: row;
+  column-gap: 8px;
+  border-radius: var(--ods-border-radius-sm);
+  background-color: $ods-code-secondary-color;
+  padding: 8px;
+  min-height: input.$ods-input-input-height;
+  color: $ods-code-primary-color;
+}
+
+.ods-code {
+  &__preformat {
+    display: flex;
+    align-items: center;
+    margin: 0;
+
+    &__code {
+      white-space: pre-line;
+      font-family: var(--ods-font-family-code);
+    }
+  }
+
+  &__copy::part(button) {
+    color: $ods-code-primary-color;
+
+    &:hover {
+      background-color: var(--ods-color-neutral-600);
+    }
+
+    &:active {
+      background-color: var(--ods-color-neutral-700);
+    }
+
+    &:focus {
+      outline-color: $ods-code-primary-color;
+    }
+  }
+}

--- a/packages/ods/src/components/code/src/components/ods-code/ods-code.tsx
+++ b/packages/ods/src/components/code/src/components/ods-code/ods-code.tsx
@@ -1,0 +1,51 @@
+import { Component, Event, type EventEmitter, type FunctionalComponent, Host, Method, Prop, h } from '@stencil/core';
+import { copyToClipboard } from '../../../../../utils/dom';
+import { ODS_BUTTON_VARIANT } from '../../../../button/src';
+import { ODS_ICON_NAME } from '../../../../icon/src';
+
+@Component({
+  shadow: true,
+  styleUrl: 'ods-code.scss',
+  tag: 'ods-code',
+})
+export class OdsCode {
+  private codeElement?: HTMLElement;
+
+  @Prop({ reflect: true }) public canCopy: boolean = false;
+
+  @Event() odsCodeCopy!: EventEmitter<string>;
+
+  @Method()
+  async copy(): Promise<void> {
+    const value = this.codeElement?.querySelector<HTMLSlotElement>('slot')?.assignedNodes()
+      .map((node) => node.textContent).join('').trim();
+
+    await copyToClipboard(value || '');
+    this.odsCodeCopy.emit(value);
+  }
+
+  render(): FunctionalComponent {
+    return (
+      <Host class="ods-code">
+        <pre class="ods-code__preformat">
+          <code
+            class="ods-code__preformat__code"
+            ref={ (el) => this.codeElement = el }>
+            <slot></slot>
+          </code>
+        </pre>
+
+        {
+          this.canCopy &&
+          <ods-button
+            class="ods-code__copy"
+            icon={ ODS_ICON_NAME.filesCopy }
+            label=""
+            onClick={ () => this.copy() }
+            variant={ ODS_BUTTON_VARIANT.ghost }>
+          </ods-button>
+        }
+      </Host>
+    );
+  }
+}

--- a/packages/ods/src/components/code/src/globals.ts
+++ b/packages/ods/src/components/code/src/globals.ts
@@ -1,0 +1,8 @@
+/**
+ * Import here all the external ODS component that you need to run the current component
+ * when running dev server (yarn start) or e2e tests
+ *
+ * ex:
+ *   import '../../text/src';
+ */
+import '../../button/src';

--- a/packages/ods/src/components/code/src/index.html
+++ b/packages/ods/src/components/code/src/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html dir='ltr' lang='en'>
+<head>
+  <meta charset='utf-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0' />
+  <title>Dev ods-code</title>
+
+  <script type='module' src='/build/ods-code.esm.js'></script>
+  <script nomodule src='/build/ods-code.js'></script>
+  <link rel="stylesheet" href="/build/ods-code.css">
+</head>
+
+<body>
+  <p>Default</p>
+  <ods-code>
+    import { OsdsText } from '@ovhcloud/ods-components/react';
+  </ods-code>
+
+  <p>Large text</p>
+  <ods-code>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </ods-code>
+
+  <p>Can copy</p>
+  <ods-code can-copy>
+    import { OsdsText } from '@ovhcloud/ods-components/react';
+  </ods-code>
+
+  <p>Large text copy</p>
+  <ods-code can-copy>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </ods-code>
+
+  <p>Multiple children</p>
+  <ods-code can-copy>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+      Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+    </p>
+  </ods-code>
+</body>
+</html>

--- a/packages/ods/src/components/code/src/index.ts
+++ b/packages/ods/src/components/code/src/index.ts
@@ -1,0 +1,1 @@
+export { OdsCode } from './components/ods-code/ods-code';

--- a/packages/ods/src/components/code/stencil.config.ts
+++ b/packages/ods/src/components/code/stencil.config.ts
@@ -1,0 +1,7 @@
+import { getStencilConfig } from '../../config/stencil';
+
+export const config = getStencilConfig({
+  args: process.argv.slice(2),
+  componentCorePackage: '@ovhcloud/ods-component-code',
+  namespace: 'ods-code',
+});

--- a/packages/ods/src/components/code/tests/behaviour/ods-code.e2e.ts
+++ b/packages/ods/src/components/code/tests/behaviour/ods-code.e2e.ts
@@ -1,0 +1,41 @@
+import { type E2EElement, type E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('ods-code behaviour', () => {
+  let el: E2EElement;
+  let page: E2EPage;
+
+  async function setup(content: string, customStyle?: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    if (customStyle) {
+      await page.addStyleTag({ content: customStyle });
+    }
+
+    el = await page.find('ods-code');
+  }
+
+  beforeEach(jest.clearAllMocks);
+
+  describe('methods', () => {
+    describe('copy', () => {
+      it('should emit an odsCodeCopy event', async() => {
+        const dummyValue = 'dummy value';
+        await setup(`<ods-code can-copy>${dummyValue}</ods-code>`);
+        const copySpy = await page.spyOnEvent('odsCodeCopy');
+
+        // We have to focus the document to be able to call the navigator copy function
+        await page.keyboard.press('Tab');
+        await page.waitForChanges();
+
+        await el.callMethod('copy');
+        await page.waitForChanges();
+
+        expect(copySpy).toHaveReceivedEventTimes(1);
+        expect(copySpy).toHaveReceivedEventDetail(dummyValue);
+      });
+    });
+  });
+});

--- a/packages/ods/src/components/code/tests/navigation/ods-code.e2e.ts
+++ b/packages/ods/src/components/code/tests/navigation/ods-code.e2e.ts
@@ -1,0 +1,78 @@
+import type { E2EPage } from '@stencil/core/testing';
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ods-code navigation', () => {
+  let page: E2EPage;
+
+  async function setup(content: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+  }
+
+  it('should not be focusable if canCopy is false', async() => {
+    await setup('<ods-code>Dummy code</ods-code>');
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => {
+      return document.activeElement?.tagName === 'ODS-CODE';
+    })).toBe(false);
+  });
+
+  it('should focus copy button if canCopy is true', async() => {
+    await setup('<ods-code can-copy>Dummy code</ods-code>');
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => {
+      return document.activeElement?.shadowRoot?.activeElement?.tagName === 'ODS-BUTTON';
+    })).toBe(true);
+  });
+
+  it('should trigger on "Enter" when button is focused', async() => {
+    const dummyCode = 'Dummy code';
+    await setup(`<ods-code can-copy>${dummyCode}</ods-code>`);
+    const copySpy = await page.spyOnEvent( 'odsCodeCopy' );
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    await page.keyboard.press('Enter');
+    await page.waitForChanges();
+
+    expect(copySpy).toHaveReceivedEventTimes(1);
+    expect(copySpy).toHaveReceivedEventDetail(dummyCode);
+  });
+
+  it('should trigger on "Space" when button is focused', async() => {
+    const dummyCode = 'Dummy code';
+    await setup(`<ods-code can-copy>${dummyCode}</ods-code>`);
+    const copySpy = await page.spyOnEvent( 'odsCodeCopy' );
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    await page.keyboard.press('Space');
+    await page.waitForChanges();
+
+    expect(copySpy).toHaveReceivedEventTimes(1);
+    expect(copySpy).toHaveReceivedEventDetail(dummyCode);
+  });
+
+  it('should trigger on copy button click', async() => {
+    const dummyCode = 'Dummy code';
+    await setup(`<ods-code can-copy>${dummyCode}</ods-code>`);
+    const copySpy = await page.spyOnEvent( 'odsCodeCopy' );
+    const copyButton = await page.find('ods-code >>> ods-button');
+
+    await copyButton.click();
+    await page.waitForChanges();
+
+    expect(copySpy).toHaveReceivedEventTimes(1);
+    expect(copySpy).toHaveReceivedEventDetail(dummyCode);
+  });
+});

--- a/packages/ods/src/components/code/tests/rendering/ods-code.e2e.ts
+++ b/packages/ods/src/components/code/tests/rendering/ods-code.e2e.ts
@@ -1,0 +1,36 @@
+import type { E2EElement, E2EPage } from '@stencil/core/testing';
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ods-code rendering', () => {
+  let el: E2EElement;
+  let copyButton: E2EElement;
+  let page: E2EPage;
+
+  async function setup(content: string, customStyle?: string): Promise<void> {
+    page = await newE2EPage();
+
+    await page.setContent(content);
+    await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    if (customStyle) {
+      await page.addStyleTag({ content: customStyle });
+    }
+
+    el = await page.find('ods-code');
+    copyButton = await page.find('ods-code >>> ods-button');
+  }
+
+  it('should render the web component', async() => {
+    await setup('<ods-code></ods-code>');
+
+    expect(el.shadowRoot).not.toBeNull();
+    expect(copyButton).toBeNull();
+  });
+
+  it('should render the copy button if set', async() => {
+    await setup('<ods-code can-copy></ods-code>');
+
+    expect(el.shadowRoot).not.toBeNull();
+    expect(copyButton).not.toBeNull();
+  });
+});

--- a/packages/ods/src/components/code/tests/rendering/ods-code.spec.ts
+++ b/packages/ods/src/components/code/tests/rendering/ods-code.spec.ts
@@ -1,0 +1,31 @@
+import type { SpecPage } from '@stencil/core/testing';
+import { newSpecPage } from '@stencil/core/testing';
+import { OdsCode } from '../../src';
+
+describe('ods-code rendering', () => {
+  let page: SpecPage;
+  let root: HTMLElement | undefined;
+
+  async function setup(html: string): Promise<void> {
+    page = await newSpecPage({
+      components: [OdsCode],
+      html,
+    });
+
+    root = page.root;
+  }
+
+  describe('canCopy', () => {
+    it('should be reflected', async() => {
+      await setup('<ods-code can-copy></ods-code>');
+
+      expect(root?.getAttribute('can-copy')).toBe('');
+    });
+
+    it('should not be set by default', async() => {
+      await setup('<ods-code></ods-code>');
+
+      expect(root?.getAttribute('can-copy')).toBeNull();
+    });
+  });
+});

--- a/packages/ods/src/components/code/tsconfig.json
+++ b/packages/ods/src/components/code/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "src",
+    "tests"
+  ]
+}

--- a/packages/ods/src/components/code/typedoc.json
+++ b/packages/ods/src/components/code/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "hideGenerator": true,
+  "json": "dist/docs-api/typedoc.json",
+  "out": "dist/docs-api/",
+  "tsconfig":"tsconfig.json"
+}

--- a/packages/ods/src/components/index.ts
+++ b/packages/ods/src/components/index.ts
@@ -24,3 +24,4 @@ export * from './breadcrumb/src';
 export * from './toggle/src';
 export * from './clipboard/src';
 export * from './divider/src';
+export * from './code/src';

--- a/packages/ods/vue/tests/_app/src/components.ts
+++ b/packages/ods/vue/tests/_app/src/components.ts
@@ -25,7 +25,8 @@ const componentNames = [
   'toggle',
   'clipboard',
   'divider',
-  //--generator-anchor--y
+  'code',
+  //--generator-anchor--
 ];
 
 export { componentNames };

--- a/packages/ods/vue/tests/_app/src/components/ods-code.vue
+++ b/packages/ods/vue/tests/_app/src/components/ods-code.vue
@@ -1,0 +1,17 @@
+<template>
+  <OdsCode>
+    Some code to copy
+  </OdsCode>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import { OdsCode } from '@ovhcloud/ods-components/vue';
+
+  export default defineComponent({
+    name: 'Code',
+    components: {
+      OdsCode,
+    },
+  });
+</script>

--- a/packages/ods/vue/tests/e2e/ods-code.e2e.ts
+++ b/packages/ods/vue/tests/e2e/ods-code.e2e.ts
@@ -1,0 +1,23 @@
+import type { Page } from 'puppeteer';
+import { goToComponentPage, setupBrowser } from '../setup';
+
+describe('ods-code vue', () => {
+  const setup = setupBrowser();
+  let page: Page;
+
+  beforeAll(async () => {
+    page = setup().page;
+  });
+
+  beforeEach(async () => {
+    await goToComponentPage(page, 'ods-code');
+  });
+
+  it('render the component correctly', async () => {
+    const elem = await page.$('ods-code');
+    const boundingBox = await elem?.boundingBox();
+
+    expect(boundingBox?.height).toBeGreaterThan(0);
+    expect(boundingBox?.width).toBeGreaterThan(0);
+  });
+});

--- a/packages/storybook/stories/components/clipboard/clipboard.stories.ts
+++ b/packages/storybook/stories/components/clipboard/clipboard.stories.ts
@@ -27,14 +27,6 @@ export const Demo: StoryObj = {
 </style>
   `,
   argTypes: orderControls({
-    isDisabled: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
     customTooltipCss: {
       table: {
         category: CONTROL_CATEGORY.design,
@@ -43,6 +35,14 @@ export const Demo: StoryObj = {
       },
       control: 'text',
       description: 'Set a custom style to the tooltip. Example: "width: 200px;"',
+    },
+    isDisabled: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+      control: 'boolean',
     },
     labelCopy: {
       table: {

--- a/packages/storybook/stories/components/code/code.stories.ts
+++ b/packages/storybook/stories/components/code/code.stories.ts
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-code';
+import { html } from 'lit-html';
+import { CONTROL_CATEGORY, orderControls } from '../../control';
+
+defineCustomElement();
+
+const meta: Meta = {
+  title: 'ODS Components/Content/Code',
+  component: 'ods-code',
+};
+
+export default meta;
+
+export const Demo: StoryObj = {
+  render: (arg) => html`
+<ods-code can-copy="${arg.canCopy}">${arg.content}</ods-code>
+  `,
+  argTypes: orderControls({
+    canCopy: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+      control: 'boolean',
+    },
+    content: {
+      table: {
+        category: CONTROL_CATEGORY.slot,
+        defaultValue: { summary: 'ø' },
+      },
+      control: 'text',
+    },
+  }),
+  args: {
+    canCopy: false,
+    content: 'import { OsdsText } from \'@ovhcloud/ods-components/react\';'
+  },
+};
+
+export const CanCopy: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-code can-copy>import { OsdsText } from '@ovhcloud/ods-components/react';
+</ods-code>
+  `,
+};
+
+export const CustomCSS: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-code class="my-code">import { OsdsText } from '@ovhcloud/ods-components/react';
+</ods-code>
+<style>
+  .my-code {
+    display: flex;
+    color: cyan;
+  }
+</style>
+  `,
+};
+
+export const Default: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-code>import { OsdsText } from '@ovhcloud/ods-components/react';
+</ods-code>
+  `,
+};

--- a/packages/storybook/stories/components/code/documentation.mdx
+++ b/packages/storybook/stories/components/code/documentation.mdx
@@ -1,0 +1,34 @@
+import { Canvas, Meta, Markdown } from '@storybook/blocks';
+import SpecificationsCode from '@ovhcloud/ods-components/src/components/code/documentation/spec.md?raw';
+import { Banner } from '../../banner';
+import { DocNavigator } from '../../doc-navigator';
+import * as CodeStories from './code.stories';
+
+<Meta of={ CodeStories } name='Documentation' />
+
+<Banner of={ CodeStories } />
+
+# Overview
+
+Code component highlights strings or small blocks of code so it makes them easier to read and understand:
+
+<Canvas of={ CodeStories.Default } sourceState='none' />
+
+<DocNavigator of={ CodeStories } />
+
+<Markdown>{ SpecificationsCode }</Markdown>
+
+# Style customization
+
+You can update the container directly by adding your own class to it.
+
+<Canvas of={ CodeStories.CustomCSS } sourceState='shown'/>
+
+# Examples
+
+## Default
+
+<Canvas of={ CodeStories.Default } sourceState='shown' />
+
+## With copy button enabled
+<Canvas of={ CodeStories.CanCopy } sourceState='shown' />

--- a/packages/storybook/stories/components/code/migration.from.17.x.mdx
+++ b/packages/storybook/stories/components/code/migration.from.17.x.mdx
@@ -1,0 +1,68 @@
+import { Meta } from '@storybook/blocks';
+import * as CodeStories from './code.stories';
+
+<Meta of={ CodeStories } name='Migration From 17.x' />
+
+# Code - migrate from v17 to v18
+----
+
+## Usage changes
+
+To add a copy button on the previous component, you had to add your own button in the `copy` slot.
+
+This slot as been removed, you can now toggle the copy button using the new `can-copy` attribute.
+
+## Attributes changes
+
+`canCopy` <img src="https://img.shields.io/badge/new-008000" />
+
+New attribute (optional).
+
+Set this to add a copy button on the right side of the code container.
+
+`color ` <img src="https://img.shields.io/badge/removed-FF0000" />
+
+Has been removed.
+
+You can use the style customization to achieve the same result.
+
+`contrasted` <img src="https://img.shields.io/badge/removed-FF0000" />
+
+Has been removed.
+
+You can use the style customization to achieve the same result, until a new color get validated by the design team.
+
+`size ` <img src="https://img.shields.io/badge/removed-FF0000" />
+
+Has been removed.
+
+You can use the style customization to achieve the same result.
+
+## Migration examples
+
+Default usage:
+```html
+<osds-code>
+  import { OsdsText } from '@ovhcloud/ods-components/react';
+</osds-code>
+
+<!-- is now -->
+
+<ods-code>
+  import { OsdsText } from '@ovhcloud/ods-components/react';
+</ods-code>
+```
+
+With a copy button:
+```html
+<osds-code>
+  <osds-button slot="copy" variant="stroked">Copy</osds-button>
+  import { OsdsText } from '@ovhcloud/ods-components/react';
+</osds-code>
+
+<!-- is now -->
+
+<ods-code can-copy>
+  import { OsdsText } from '@ovhcloud/ods-components/react';
+</ods-code>
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -3886,9 +3886,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+<<<<<<< HEAD
 "@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider"
+=======
+"@ovhcloud/ods-component-code@workspace:packages/ods/src/components/code":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-code@workspace:packages/ods/src/components/code"
+>>>>>>> e20159c0 (feat(code): implement component)
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3886,15 +3886,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-<<<<<<< HEAD
-"@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider":
-  version: 0.0.0-use.local
-  resolution: "@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider"
-=======
 "@ovhcloud/ods-component-code@workspace:packages/ods/src/components/code":
   version: 0.0.0-use.local
   resolution: "@ovhcloud/ods-component-code@workspace:packages/ods/src/components/code"
->>>>>>> e20159c0 (feat(code): implement component)
+  languageName: unknown
+  linkType: soft
+
+"@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider":
+  version: 0.0.0-use.local
+  resolution: "@ovhcloud/ods-component-divider@workspace:packages/ods/src/components/divider"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
As there are no specific designs for this component, I went with the simpliest version, which is the same as the actual.
Which means no toolip on copy button (unlike clipboard), could be added on another iteration if actually asked for.