### PR TITLE
fix(doc): Handle composed names for Zeroheight links

### DIFF
--- a/packages/storybook/stories/components/badge/documentation.mdx
+++ b/packages/storybook/stories/components/badge/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsBadge from '@ovhcloud/ods-components/src/components/badge/d
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as BadgeStories from './badge.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ BadgeStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Badge show concise metadata or the current status for an item, in a compact form
 
 <Canvas of={ BadgeStories.Default } sourceState='none' />
 
-<DocNavigator of={ BadgeStories } />
+<DocNavigator of={ BadgeStories } linkId={ LINK_ID.BADGE } />
 
 <Markdown>{ SpecificationsBadge }</Markdown>
 

--- a/packages/storybook/stories/components/breadcrumb/documentation.mdx
+++ b/packages/storybook/stories/components/breadcrumb/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsBreadcrumb from '@ovhcloud/ods-components/src/components/br
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as BreadcrumbStories from './breadcrumb.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ BreadcrumbStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ A list of links showing the current page location in the navigational hierarchy:
 
 <Canvas of={ BreadcrumbStories.Default } sourceState='none' />
 
-<DocNavigator of={ BreadcrumbStories } />
+<DocNavigator of={ BreadcrumbStories } linkId={ LINK_ID.BREADCRUMB } />
 
 <Markdown>{ SpecificationsBreadcrumb }</Markdown>
 

--- a/packages/storybook/stories/components/button/documentation.mdx
+++ b/packages/storybook/stories/components/button/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsButton from '@ovhcloud/ods-components/src/components/button
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as ButtonStories from './button.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ ButtonStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Button component aims to initiate an action. Its text indicates the related inte
 
 <Canvas of={ ButtonStories.Default } sourceState='none' />
 
-<DocNavigator of={ ButtonStories } />
+<DocNavigator of={ ButtonStories } linkId={ LINK_ID.BUTTON } />
 
 <Markdown>{ SpecificationsButton }</Markdown>
 

--- a/packages/storybook/stories/components/clipboard/documentation.mdx
+++ b/packages/storybook/stories/components/clipboard/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsClipboard from '@ovhcloud/ods-components/src/components/cli
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as ClipboardStories from './clipboard.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ ClipboardStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Clipboard component allows user to preview and copy crucial information to its c
 
 <Canvas of={ ClipboardStories.Default } sourceState='none' />
 
-<DocNavigator of={ ClipboardStories } />
+<DocNavigator of={ ClipboardStories } linkId={ LINK_ID.CLIPBOARD } />
 
 <Markdown>{ SpecificationsClipboard }</Markdown>
 

--- a/packages/storybook/stories/components/code/documentation.mdx
+++ b/packages/storybook/stories/components/code/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsCode from '@ovhcloud/ods-components/src/components/code/doc
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as CodeStories from './code.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ CodeStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Code component highlights strings or small blocks of code so it makes them easie
 
 <Canvas of={ CodeStories.Default } sourceState='none' />
 
-<DocNavigator of={ CodeStories } />
+<DocNavigator of={ CodeStories } linkId={ LINK_ID.CODE } />
 
 <Markdown>{ SpecificationsCode }</Markdown>
 

--- a/packages/storybook/stories/components/divider/documentation.mdx
+++ b/packages/storybook/stories/components/divider/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsDivider from '@ovhcloud/ods-components/src/components/divid
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as DividerStories from './divider.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ DividerStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ The divider is a spacer dedicated to represent the empty space. it displays a si
 
 <Canvas of={ DividerStories.Default } sourceState='none' />
 
-<DocNavigator of={ DividerStories } />
+<DocNavigator of={ DividerStories } linkId={ LINK_ID.DIVIDER } />
 
 <Markdown>{ SpecificationsDivider }</Markdown>
 

--- a/packages/storybook/stories/components/icon/documentation.mdx
+++ b/packages/storybook/stories/components/icon/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsIcon from '@ovhcloud/ods-components/src/components/icon/doc
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as IconStories from './icon.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ IconStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Icon is a visual context used to represent a command, navigation, status or comm
 
 <Canvas of={ IconStories.Default } sourceState='none' />
 
-<DocNavigator of={ IconStories } />
+<DocNavigator of={ IconStories } linkId={ LINK_ID.ICON } />
 
 <Markdown>{ SpecificationsIcon }</Markdown>
 

--- a/packages/storybook/stories/components/input/documentation.mdx
+++ b/packages/storybook/stories/components/input/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsInput from '@ovhcloud/ods-components/src/components/input/d
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as InputStories from './input.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ InputStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Input component is an input field where users can type into:
 
 <Canvas of={ InputStories.Default } sourceState='none' />
 
-<DocNavigator of={ InputStories } />
+<DocNavigator of={ InputStories } linkId={ LINK_ID.INPUT } />
 
 <Markdown> { SpecificationsInput } </Markdown>
 

--- a/packages/storybook/stories/components/link/documentation.mdx
+++ b/packages/storybook/stories/components/link/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsLink from '@ovhcloud/ods-components/src/components/link/doc
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as LinkStories from './link.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ LinkStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Link is a component that enables redirection to a new page, section, website or 
 
 <Canvas of={ LinkStories.Default } sourceState='none' />
 
-<DocNavigator of={ LinkStories } />
+<DocNavigator of={ LinkStories } linkId={ LINK_ID.LINK } />
 
 <Markdown>{ SpecificationsLink }</Markdown>
 

--- a/packages/storybook/stories/components/medium/documentation.mdx
+++ b/packages/storybook/stories/components/medium/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsMedium from '@ovhcloud/ods-components/src/components/medium
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as MediumStories from './medium.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ MediumStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Medium is a wrapper for displaying assets such as images:
 
 <Canvas of={ MediumStories.Default } sourceState='none' />
 
-<DocNavigator of={ MediumStories } />
+<DocNavigator of={ MediumStories } linkId={ LINK_ID.MEDIUM } />
 
 <Markdown>{ SpecificationsMedium }</Markdown>
 

--- a/packages/storybook/stories/components/password/documentation.mdx
+++ b/packages/storybook/stories/components/password/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsPassword from '@ovhcloud/ods-components/src/components/pass
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as PasswordStories from './password.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ PasswordStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Password component is an input field for entering a password that can be hidden 
 
 <Canvas of={ PasswordStories.Default } sourceState='none' />
 
-<DocNavigator of={ PasswordStories } />
+<DocNavigator of={ PasswordStories } linkId={ LINK_ID.PASSWORD } />
 
 <Markdown>{ SpecificationsPassword }</Markdown>
 

--- a/packages/storybook/stories/components/popover/documentation.mdx
+++ b/packages/storybook/stories/components/popover/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsPopover from '@ovhcloud/ods-components/src/components/popov
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as PopoverStories from './popover.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ PopoverStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Popover component is triggered by click and is used to provide additional inform
 
 <Canvas of={ PopoverStories.Overview } sourceState='none' />
 
-<DocNavigator of={ PopoverStories } />
+<DocNavigator of={ PopoverStories } linkId={ LINK_ID.POPOVER } />
 
 <Markdown>{ SpecificationsPopover }</Markdown>
 

--- a/packages/storybook/stories/components/quantity/documentation.mdx
+++ b/packages/storybook/stories/components/quantity/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsQuantity from '@ovhcloud/ods-components/src/components/quan
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as QuantityStories from './quantity.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ QuantityStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Quantity is a component used to enter and modify a numeric value in a responsive
 
 <Canvas of={ QuantityStories.Default } sourceState='none' />
 
-<DocNavigator of={ QuantityStories } />
+<DocNavigator of={ QuantityStories } linkId={ LINK_ID.QUANTITY } />
 
 <Markdown>{ SpecificationsQuantity }</Markdown>
 

--- a/packages/storybook/stories/components/skeleton/documentation.mdx
+++ b/packages/storybook/stories/components/skeleton/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsSkeleton from '@ovhcloud/ods-components/src/components/skel
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as SkeletonStories from './skeleton.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ SkeletonStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Skeleton component indicates that data is loading. It improves the perceived loa
 
 <Canvas of={SkeletonStories.Default} sourceState='none' />
 
-<DocNavigator of={ SkeletonStories } />
+<DocNavigator of={ SkeletonStories } linkId={ LINK_ID.SKELETON } />
 
 <Markdown> { SpecificationsSkeleton } </Markdown>
 

--- a/packages/storybook/stories/components/spinner/documentation.mdx
+++ b/packages/storybook/stories/components/spinner/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsSpinner from '@ovhcloud/ods-components/src/components/spinn
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as SpinnerStories from './spinner.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ SpinnerStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ A visual indicator that a process is happening in the background but the interfa
 
 <Canvas of={ SpinnerStories.Default } sourceState='none' />
 
-<DocNavigator of={ SpinnerStories } />
+<DocNavigator of={ SpinnerStories } linkId={ LINK_ID.SPINNER } />
 
 <Markdown>{ SpecificationsSpinner }</Markdown>
 

--- a/packages/storybook/stories/components/table/documentation.mdx
+++ b/packages/storybook/stories/components/table/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsTable from '@ovhcloud/ods-components/src/components/table/d
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as TableStories from './table.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ TableStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Table is a wrapper for displaying tables:
 
 <Canvas of={ TableStories.Default } sourceState='none' />
 
-<DocNavigator of={ TableStories } />
+<DocNavigator of={ TableStories } linkId={ LINK_ID.TABLE } />
 
 <Markdown>{ SpecificationsTable }</Markdown>
 

--- a/packages/storybook/stories/components/tag/documentation.mdx
+++ b/packages/storybook/stories/components/tag/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsTag from '@ovhcloud/ods-components/src/components/tag/docum
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as TagStories from './tag.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ TagStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Tag show concise metadata or the current status for an item, in a compact format
 
 <Canvas of={ TagStories.Default } sourceState='none' />
 
-<DocNavigator of={ TagStories } />
+<DocNavigator of={ TagStories } linkId={ LINK_ID.TAG } />
 
 <Markdown>{ SpecificationsTag }</Markdown>
 

--- a/packages/storybook/stories/components/text/documentation.mdx
+++ b/packages/storybook/stories/components/text/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsText from '@ovhcloud/ods-components/src/components/text/doc
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as TextStories from './text.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ TextStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ The text component is used to display text with a specific font & style.
 
 <Canvas of={ TextStories.Default } sourceState='none' />
 
-<DocNavigator of={ TextStories } />
+<DocNavigator of={ TextStories } linkId={ LINK_ID.TEXT } />
 
 <Markdown> { SpecificationsText } </Markdown>
 

--- a/packages/storybook/stories/components/textarea/documentation.mdx
+++ b/packages/storybook/stories/components/textarea/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsTextarea from '@ovhcloud/ods-components/src/components/text
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as TextareaStories from './textarea.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ TextareaStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Textarea component is used to type long content:
 
 <Canvas of={ TextareaStories.Default } sourceState='none' />
 
-<DocNavigator of={ TextareaStories } />
+<DocNavigator of={ TextareaStories } linkId={ LINK_ID.TEXTAREA } />
 
 <Markdown>{ SpecificationsTextarea }</Markdown>
 

--- a/packages/storybook/stories/components/toggle/documentation.mdx
+++ b/packages/storybook/stories/components/toggle/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsToggle from '@ovhcloud/ods-components/src/components/toggle
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as ToggleStories from './toggle.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ ToggleStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Toggle component is used to allow the user to switch between two states, on and 
 
 <Canvas of={ ToggleStories.Default } sourceState='none' />
 
-<DocNavigator of={ ToggleStories } />
+<DocNavigator of={ ToggleStories } linkId={ LINK_ID.TOGGLE } />
 
 <Markdown>{ SpecificationsToggle }</Markdown>
 

--- a/packages/storybook/stories/components/tooltip/documentation.mdx
+++ b/packages/storybook/stories/components/tooltip/documentation.mdx
@@ -3,6 +3,7 @@ import SpecificationsTooltip from '@ovhcloud/ods-components/src/components/toolt
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as TooltipStories from './tooltip.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ TooltipStories } name='Documentation' />
 
@@ -14,7 +15,7 @@ Tooltip component is used to display contextual information when the user hovers
 
 <Canvas of={ TooltipStories.Overview } sourceState='none' />
 
-<DocNavigator of={ TooltipStories } />
+<DocNavigator of={ TooltipStories } linkId={ LINK_ID.TOOLTIP } />
 
 <Markdown> { SpecificationsTooltip } </Markdown>
 

--- a/packages/storybook/stories/doc-navigator.tsx
+++ b/packages/storybook/stories/doc-navigator.tsx
@@ -4,23 +4,9 @@ import { navigate } from '@storybook/addon-links';
 import { OdsButton, OdsLink } from '@ovhcloud/ods-components-react';
 import { ODS_BUTTON_VARIANT, ODS_ICON_NAME } from '@ovhcloud/ods-components';
 import React, { useEffect, useState } from 'react';
-import { BASE_URL, LINK_ID } from './zeroheight';
+import { BASE_URL } from './zeroheight';
 
-function extractLinkId(storyId: string): string | null {
-  const storyComponentName = storyId.split('--').shift()?.split('-').pop() || '';
-
-  for (const id of Object.values(LINK_ID)) {
-    const idPart = id.split('-');
-    const componentPart = idPart.slice(1).join('-');
-
-    if (storyComponentName === componentPart) {
-      return id;
-    }
-  }
-  return null;
-}
-
-const DocNavigator = ({ of }: { of: ModuleExports }) => {
+const DocNavigator = ({ of, linkId }: { of: ModuleExports, linkId: string }) => {
   const resolvedOf = useOf(of || 'story', ['meta']);
   const [href, setHref] = useState('');
   const [storyId, setStoryId] = useState('');
@@ -28,16 +14,15 @@ const DocNavigator = ({ of }: { of: ModuleExports }) => {
   useEffect(() => {
     const demoStoryKeys = Object.keys(resolvedOf.csfFile.stories || {}).filter((storyKey) => storyKey.includes('--demo'));
     const storyId = demoStoryKeys[0];
-    const linkId = extractLinkId(storyId);
 
     setStoryId(storyId);
 
     if (linkId) {
       setHref(`${BASE_URL}${linkId}/b/40a887`);
     } else {
-      console.error('No Zeroheight link id matching storyId', storyId);
+      console.error('No Zeroheight link id provided.');
     }
-  }, [extractLinkId]);
+  }, [linkId]);
 
   return (
     <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', columnGap: '20px' }}>

--- a/scripts/component-generator/templates/storybook/documentation.mdx.hbs
+++ b/scripts/component-generator/templates/storybook/documentation.mdx.hbs
@@ -3,6 +3,7 @@ import Specifications{{> ComponentName }} from '@ovhcloud/ods-{{> component-dir}
 import { Banner } from '../../banner';
 import { DocNavigator } from '../../doc-navigator';
 import * as {{> ComponentName }}Stories from './{{> component-name }}.stories';
+import { LINK_ID } from '../../zeroheight';
 
 <Meta of={ {{> ComponentName }}Stories } name='Documentation' />
 
@@ -14,7 +15,7 @@ TODO Some text about the component
 
 <Canvas of={ {{> ComponentName }}Stories.Default } sourceState='none' />
 
-<DocNavigator of={ {{> ComponentName }}Stories } />
+<DocNavigator of={ {{> ComponentName }}Stories } linkId={ LINK_ID.{{> COMPONENT_NAME }} } />
 
 <Markdown>{ Specifications{{> ComponentName }} }</Markdown>
 


### PR DESCRIPTION
## Description
Components with composed names _(eg: Form Field, Progress Bar)_ were not taken in charge in the current doc-navigator system, leading to issues with the generated zeroheight link in the Documentation.

## Content
- Updated `doc-navigator.tsx` to accept a `linkId` property, based on the `zeroheight.ts` enum, removed unused code.
- Updated all existing components with the new system.
- Updated the `component-generator` to fit with the new code. 

## To review
Check if the component links are well connected to the proper zeroheight. Look for any discrepancies in the code. Check if the new component-generator works properly.