### PR TITLE
Stencil bumps & tasks updates

### DIFF
--- a/packages/ods/package.json
+++ b/packages/ods/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.6.3",
-    "@stencil/core": "4.12.2",
+    "@stencil/core": "4.16.0",
     "google-libphonenumber": "3.2.35",
     "tom-select": "2.3.1",
     "vanillajs-datepicker": "1.3.4"
@@ -35,7 +35,7 @@
     "@jest/types": "29.6.3",
     "@stencil-community/postcss": "2.2.0",
     "@stencil/react-output-target": "0.5.3",
-    "@stencil/sass": "3.0.9",
+    "@stencil/sass": "3.0.12",
     "@stencil/vue-output-target": "0.8.8",
     "@types/google-libphonenumber": "7.4.30",
     "@types/jest": "29.5.12",

--- a/packages/ods/package.json
+++ b/packages/ods/package.json
@@ -19,10 +19,11 @@
     "build:stencil": "stencil build --prod --config stencil.config.ts",
     "build:style": "npm --prefix style run build",
     "build:vue": "npm --prefix vue run build",
+    "clean": "rimraf dist",
     "lint:scss": "stylelint 'src/style/*.scss'",
     "lint:ts": "eslint '{src,tests}/!(components)/**/*.{ts,tsx}'",
     "test:spec": "jest --config jest.config.ts --coverage",
-    "test:spec:ci": "npm run test:spec"
+    "test:spec:ci": "jest --config jest.config.ts"
   },
   "dependencies": {
     "@floating-ui/dom": "1.6.3",

--- a/packages/ods/src/components/accordion/package.json
+++ b/packages/ods/src/components/accordion/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/badge/package.json
+++ b/packages/ods/src/components/badge/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/breadcrumb/package.json
+++ b/packages/ods/src/components/breadcrumb/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/button/package.json
+++ b/packages/ods/src/components/button/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/card/package.json
+++ b/packages/ods/src/components/card/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/checkbox/package.json
+++ b/packages/ods/src/components/checkbox/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --runInBand --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/clipboard/package.json
+++ b/packages/ods/src/components/clipboard/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/code/package.json
+++ b/packages/ods/src/components/code/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/datepicker/package.json
+++ b/packages/ods/src/components/datepicker/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --runInBand --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/divider/package.json
+++ b/packages/ods/src/components/divider/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/file-upload/package.json
+++ b/packages/ods/src/components/file-upload/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --runInBand --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/form-field/package.json
+++ b/packages/ods/src/components/form-field/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,7 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage",
-    "toto": "jest"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/icon/package.json
+++ b/packages/ods/src/components/icon/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/input/package.json
+++ b/packages/ods/src/components/input/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/link/package.json
+++ b/packages/ods/src/components/link/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint 'src/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/medium/package.json
+++ b/packages/ods/src/components/medium/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint --allow-empty-input 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/message/package.json
+++ b/packages/ods/src/components/message/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/modal/package.json
+++ b/packages/ods/src/components/modal/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/pagination/package.json
+++ b/packages/ods/src/components/pagination/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/password/package.json
+++ b/packages/ods/src/components/password/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/phone-number/package.json
+++ b/packages/ods/src/components/phone-number/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "npm run validate && eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,7 +14,7 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage",
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci",
     "validate": "node scripts/validate-i18n-keys.js 'src/i18n/*.json'"
   }
 }

--- a/packages/ods/src/components/popover/package.json
+++ b/packages/ods/src/components/popover/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/progress-bar/package.json
+++ b/packages/ods/src/components/progress-bar/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/quantity/package.json
+++ b/packages/ods/src/components/quantity/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/radio/package.json
+++ b/packages/ods/src/components/radio/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/range/package.json
+++ b/packages/ods/src/components/range/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --runInBand --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/select/package.json
+++ b/packages/ods/src/components/select/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/skeleton/package.json
+++ b/packages/ods/src/components/skeleton/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/spinner/package.json
+++ b/packages/ods/src/components/spinner/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/switch/package.json
+++ b/packages/ods/src/components/switch/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/table/package.json
+++ b/packages/ods/src/components/table/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/tabs/package.json
+++ b/packages/ods/src/components/tabs/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/tag/package.json
+++ b/packages/ods/src/components/tag/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/text/package.json
+++ b/packages/ods/src/components/text/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/textarea/package.json
+++ b/packages/ods/src/components/textarea/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/timepicker/package.json
+++ b/packages/ods/src/components/timepicker/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --runInBand --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/toggle/package.json
+++ b/packages/ods/src/components/toggle/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/packages/ods/src/components/tooltip/package.json
+++ b/packages/ods/src/components/tooltip/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts --max-workers=2",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/scripts/component-generator/templates/component/package.json.hbs
+++ b/scripts/component-generator/templates/component/package.json.hbs
@@ -6,7 +6,7 @@
   "main": "dist/index.cjs.js",
   "collection": "dist/collection/collection-manifest.json",
   "scripts": {
-    "clean": "rimraf .stencil coverage dist docs-api www",
+    "clean": "rimraf .stencil coverage dist documentation www",
     "doc": "typedoc --pretty --plugin ../../../scripts/typedoc-plugin-decorator.js && node ../../../scripts/generate-typedoc-md.js",
     "lint:scss": "stylelint 'src/components/**/*.scss'",
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
@@ -14,6 +14,6 @@
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
     "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
-    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci --coverage"
+    "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4138,9 +4138,9 @@ __metadata:
     "@floating-ui/dom": 1.6.3
     "@jest/types": 29.6.3
     "@stencil-community/postcss": 2.2.0
-    "@stencil/core": 4.12.2
+    "@stencil/core": 4.16.0
     "@stencil/react-output-target": 0.5.3
-    "@stencil/sass": 3.0.9
+    "@stencil/sass": 3.0.12
     "@stencil/vue-output-target": 0.8.8
     "@types/google-libphonenumber": 7.4.30
     "@types/jest": 29.5.12
@@ -4424,12 +4424,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:4.12.2":
-  version: 4.12.2
-  resolution: "@stencil/core@npm:4.12.2"
+"@stencil/core@npm:4.16.0":
+  version: 4.16.0
+  resolution: "@stencil/core@npm:4.16.0"
   bin:
     stencil: bin/stencil
-  checksum: 85bcb310448cf3647b80cdc3df061ff2fac5879a56920ba7e24150722a773024dbe6522be3e3ae206c66d4a3a10e4547318a5568d32aaafbf2e8dd089d55f3f9
+  checksum: 70a660596a496959e5dc9fa876ac8bc7a2c2d4043c64bf86305e0722378dd484ce1a80e58466b8370831f68a9667efd40e7e4853ec1c8752181740bbac4f87fd
   languageName: node
   linkType: hard
 
@@ -4442,12 +4442,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/sass@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@stencil/sass@npm:3.0.9"
+"@stencil/sass@npm:3.0.12":
+  version: 3.0.12
+  resolution: "@stencil/sass@npm:3.0.12"
   peerDependencies:
     "@stencil/core": ">=2.0.0 || >=3.0.0-beta.0 || >= 4.0.0-beta.0 || >= 4.0.0"
-  checksum: 2265ac3af2db425b7be0b836ea52aabbd44f55cb97d869eceab5468e8a47dc1ff79e5ef19b2d40a99542f5c3d8a2f812f6829fef18b6f7d551ba6e886c333a3c
+  checksum: 838e9b367b57a0845302ae0df0130f92b2244ce129fcc0d6965b4503c3e39a2a2a31b90f6b34d963b215ac42c6334a28b380523136780aad90a1ec0b230a2256
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps Stencil to 4.16
Latest version today is 4.19, but they did a major internal changes in 4.17, switching from rollup to esbuild. This does brake our current build process, plus switching may cause issue to other project building stencil components on top of ODS.
Moving to 4.17+ will require more work and testing.

Removing coverage on test:spec:ci does speed up the task a bit.
As we don't use those in the CI anymore, it was useless anyway.