### PR TITLE
fix(timepicker): story timepicker arg

### DIFF
--- a/packages/storybook/stories/components/timepicker/technical-information.mdx
+++ b/packages/storybook/stories/components/timepicker/technical-information.mdx
@@ -43,6 +43,10 @@ Custom timepicker CSS:
 
 <Canvas of={ TimepickerStories.Timezones } sourceState='shown' />
 
+### Timezones Custom
+
+<Canvas of={ TimepickerStories.TimezonesCustom } sourceState='shown' />
+
 ### WithSeconds
 
 <Canvas of={ TimepickerStories.WithSeconds } sourceState='shown' />

--- a/packages/storybook/stories/components/timepicker/timepicker.stories.ts
+++ b/packages/storybook/stories/components/timepicker/timepicker.stories.ts
@@ -96,7 +96,7 @@ export const Demo: StoryObj = {
   },
 };
 
-export const TimeZones: StoryObj = {
+export const DemoTimezones: StoryObj = {
   render: (arg) => html`
   <ods-timepicker class="my-timepicker-demo-timezones"
     aria-label="${arg.ariaLabel}"
@@ -105,7 +105,7 @@ export const TimeZones: StoryObj = {
     has-error="${arg.hasError}"
     is-disabled="${arg.isDisabled}"
     is-readonly="${arg.isReadonly}"
-    timezones="${arg.timezones}"
+    timezones="${arg.timezones.includes('all') ? 'all' : JSON.stringify(arg.timezones)}"
     with-seconds="${arg.withSeconds}">
   </ods-timepicker>
   <style>
@@ -191,7 +191,7 @@ export const TimeZones: StoryObj = {
         defaultValue: { summary: 'ø' },
         type: { summary: [...ODS_TIMEZONES, ...ODS_TIMEZONES_PRESETS] },
       },
-      control: { type: 'select' },
+      control: { type: 'multi-select' },
       options: [...ODS_TIMEZONES, ...ODS_TIMEZONES_PRESETS],
     },
     withSeconds: {
@@ -262,6 +262,14 @@ export const Timezones: StoryObj = {
   tags: ['isHidden'],
   render: () => html`
 <ods-timepicker timezones="all"></ods-timepicker>
+  `,
+};
+
+export const TimezonesCustom: StoryObj = {
+  decorators: [(story) => html`<div style="padding-bottom: 200px; display: inline-flex; align-items: center;">${story()}</div>`],
+  tags: ['isHidden'],
+  render: () => html`
+<ods-timepicker timezones='["utc-4", "utc-2", "utc+2", "utc+4"]'></ods-timepicker>
   `,
 };
 


### PR DESCRIPTION
Bug in the parse of timezones who was modified by the `${arg.timezones}` like a `arg.timezones.toString()` for an array the `toString()` methods join the values with `,` so the arg was `UTC-2,UTC+2...`