### PR TITLE
Fix timezone doc

### DIFF
--- a/packages/examples/react-webpack/src/app/App.tsx
+++ b/packages/examples/react-webpack/src/app/App.tsx
@@ -1,7 +1,7 @@
 import React, { type ReactElement } from 'react';
 // import { Gallery } from './components/gallery/Gallery';
-import { FormFormik } from './components/formFormik/FormFormik';
-// import { FormNative } from './components/formNative/FormNative';
+// import { FormFormik } from './components/formFormik/FormFormik';
+import { FormNative } from './components/formNative/FormNative';
 // import { TestModal } from './components/testModal/TestModal';
 import styles from './app.scss';
 
@@ -9,8 +9,8 @@ function App(): ReactElement {
   return (
     <div className={ styles.app }>
       {/* <Gallery /> */}
-      <FormFormik />
-      {/*<FormNative />*/}
+      {/*<FormFormik />*/}
+      <FormNative />
       {/*<TestModal />*/}
     </div>
   );

--- a/packages/examples/react-webpack/src/app/App.tsx
+++ b/packages/examples/react-webpack/src/app/App.tsx
@@ -1,17 +1,17 @@
 import React, { type ReactElement } from 'react';
 // import { Gallery } from './components/gallery/Gallery';
-// import { FormFormik } from './components/formFormik/FormFormik';
+import { FormFormik } from './components/formFormik/FormFormik';
 // import { FormNative } from './components/formNative/FormNative';
-import { TestModal } from './components/testModal/TestModal';
+// import { TestModal } from './components/testModal/TestModal';
 import styles from './app.scss';
 
 function App(): ReactElement {
   return (
     <div className={ styles.app }>
       {/* <Gallery /> */}
-      {/*<FormFormik />*/}
+      <FormFormik />
       {/*<FormNative />*/}
-      <TestModal />
+      {/*<TestModal />*/}
     </div>
   );
 }

--- a/packages/examples/react-webpack/src/app/components/formNative/FormNative.tsx
+++ b/packages/examples/react-webpack/src/app/components/formNative/FormNative.tsx
@@ -252,11 +252,10 @@ function FormNative(): ReactElement {
         ref={ textareaRef }
       />
 
-      {/* KO value not in formData when no default */}
-      {/* KO value in formData not updated when default */}
+      {/* OK */}
       <OdsTimepicker
         // defaultValue="12:34"
-        hasError={ error.timepicker }
+        hasError={ error.timepicker } onOdsChange={(e) => console.log(e)}
         isRequired={ true }
         name="timepicker"
         ref={ timepickerRef }

--- a/packages/examples/react-webpack/src/app/components/formNative/FormNative.tsx
+++ b/packages/examples/react-webpack/src/app/components/formNative/FormNative.tsx
@@ -255,7 +255,7 @@ function FormNative(): ReactElement {
       {/* OK */}
       <OdsTimepicker
         // defaultValue="12:34"
-        hasError={ error.timepicker } onOdsChange={(e) => console.log(e)}
+        hasError={ error.timepicker }
         isRequired={ true }
         name="timepicker"
         ref={ timepickerRef }

--- a/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.scss
+++ b/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.scss
@@ -2,3 +2,9 @@
   display: inline-flex;
   column-gap: 8px;
 }
+
+.ods-timepicker {
+  &__timezones {
+    min-width: 89px;
+  }
+}

--- a/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.tsx
+++ b/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.tsx
@@ -122,14 +122,13 @@ export class OdsTimepicker {
     return (
       <Host class="ods-timepicker">
         <ods-input
-          class="ods-timepicker__time"
           ariaLabel={ this.ariaLabel }
           ariaLabelledby={ this.ariaLabelledby }
           defaultValue={ this.defaultValue }
           exportparts="input"
-          is-disabled={ this.isDisabled }
-          is-readonly={ this.isReadonly }
-          has-error={ this.hasError }
+          isDisabled={ this.isDisabled }
+          isReadonly={ this.isReadonly }
+          hasError={ this.hasError }
           onOdsChange={ (event: OdsInputChangeEvent) => this.onOdsChange(event, false) }
           onOdsClear={ (event: CustomEvent<void>) => event.stopPropagation() }
           onOdsReset={ (event: CustomEvent<void>) => event.stopPropagation() }
@@ -137,19 +136,17 @@ export class OdsTimepicker {
           ref={ (el?: HTMLElement): OdsInput => this.odsInput = el as OdsInput & HTMLElement }
           step={ this.withSeconds ? 1 : undefined }
           type={ ODS_INPUT_TYPE.time }
-          value={ this.value }
-        >
+          value={ this.value }>
         </ods-input>
         {
           this.hasTimezones &&
           <ods-select
             class="ods-timepicker__timezones"
-            default-value={ this.defaultCurrentTimezone }
-            dropdown-width="auto"
+            defaultValue={ this.defaultCurrentTimezone }
             part="select"
-            has-error={ this.hasError }
-            is-disabled={ this.isDisabled }
-            is-readonly={ this.isReadonly }
+            hasError={ this.hasError }
+            isDisabled={ this.isDisabled }
+            isReadonly={ this.isReadonly }
             onOdsChange={ (event: OdsSelectChangeEvent) => this.onOdsChange(event, true) }
             onOdsClear={ (event: CustomEvent<void>) => event.stopPropagation() }
             onOdsReset={ (event: CustomEvent<void>) => event.stopPropagation() }

--- a/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.tsx
+++ b/packages/ods/src/components/timepicker/src/components/ods-timepicker/ods-timepicker.tsx
@@ -106,6 +106,7 @@ export class OdsTimepicker {
     } else {
       this.previousValue = event.detail.previousValue as string;
       this.value = event.detail.value as string;
+      setFormValue(this.internals, this.value);
     }
 
     this.odsChange.emit({

--- a/packages/ods/src/components/timepicker/src/constant/timezone-preset.ts
+++ b/packages/ods/src/components/timepicker/src/constant/timezone-preset.ts
@@ -1,5 +1,5 @@
 enum ODS_TIMEZONES_PRESET {
-  All = 'all'
+  all = 'all'
 }
 
 type OdsTimezonePreset =`${ODS_TIMEZONES_PRESET}`;

--- a/packages/ods/src/components/timepicker/src/controller/ods-timepicker.ts
+++ b/packages/ods/src/components/timepicker/src/controller/ods-timepicker.ts
@@ -25,19 +25,21 @@ function formatValue(value?: string, withSeconds?: boolean): string {
   return '';
 }
 
-function getCurrentTimezone(currentTimezone?: OdsTimezone): OdsTimezone | undefined {
+function getCurrentTimezone(currentTimezone: OdsTimezone | undefined, timezones: OdsTimezone[]): OdsTimezone | undefined {
   if (!currentTimezone) {
     const browserTimezone = new Date().getTimezoneOffset() / 60 * -1;
     const parsedTimezone = browserTimezone >= 0 ? `+${browserTimezone}` : browserTimezone.toString();
-    return ODS_TIMEZONES.find((timezone) => timezone.indexOf(parsedTimezone) > -1);
+
+    return timezones.find((timezone) => timezone.indexOf(parsedTimezone) > -1);
   }
   return currentTimezone;
 }
 
 function parseTimezones(timezones?: OdsTimezone[] | ODS_TIMEZONES_PRESET | string): OdsTimezone[] {
-  if (!timezones || timezones === ODS_TIMEZONES_PRESET.All) {
+  if (timezones === ODS_TIMEZONES_PRESET.all) {
     return ODS_TIMEZONES as OdsTimezone[];
   }
+
   if (typeof timezones === 'string') {
     try {
       const parsedTimezones = JSON.parse(timezones);
@@ -49,7 +51,8 @@ function parseTimezones(timezones?: OdsTimezone[] | ODS_TIMEZONES_PRESET | strin
       return [];
     }
   }
-  return timezones;
+
+  return [];
 }
 
 function setFormValue(internals: ElementInternals, value: string | null): void {

--- a/packages/ods/src/components/timepicker/src/index.html
+++ b/packages/ods/src/components/timepicker/src/index.html
@@ -61,23 +61,23 @@
   <p>Readonly</p>
   <ods-timepicker is-readonly></ods-timepicker>
 
-  <p>with current Timezone</p>
-  <ods-timepicker current-timezone='UTC+4'></ods-timepicker>
+  <p>Disabled  Timezone</p>
+  <ods-timepicker timezones="all" is-disabled></ods-timepicker>
 
-  <p>Disabled with current Timezone</p>
-  <ods-timepicker current-timezone='UTC+4' is-disabled></ods-timepicker>
+  <p>Readonly with Timezone</p>
+  <ods-timepicker timezones="all" is-readonly></ods-timepicker>
 
-  <p>Readonly with current Timezone</p>
-  <ods-timepicker current-timezone='UTC+4' is-readonly></ods-timepicker>
+  <p>Error with Timezones</p>
+  <ods-timepicker timezones="all" has-error></ods-timepicker>
 
-  <p>Error with current Timezone</p>
-  <ods-timepicker current-timezone='UTC+4' has-error></ods-timepicker>
-
-  <p>with Timezones</p>
+  <p>With wrong Timezones</p>
   <ods-timepicker timezones='["utc-2", "utc+2", "utc+30"]'></ods-timepicker>
 
-  <p>Disabled with timezones</p>
-  <ods-timepicker is-disabled timezones='all'></ods-timepicker>
+  <p>With Timezones and current timezone</p>
+  <ods-timepicker current-timezone="UTC+4" timezones="all"></ods-timepicker>
+
+  <p>With Timezones and wrong current timezone</p>
+  <ods-timepicker current-timezone="UTC+44" timezones="all"></ods-timepicker>
 
   <p>Form</p>
   <form id="timepicker-form" target="_self">
@@ -89,7 +89,6 @@
 
   <script>
     const form = document.getElementById('timepicker-form');
-    const resetFormButton = document.getElementById('form-reset-button');
     const submitFormButton = document.getElementById('form-submit-button');
 
     submitFormButton.addEventListener('click', () => {

--- a/packages/ods/src/components/timepicker/tests/behavior/ods-timepicker.e2e.ts
+++ b/packages/ods/src/components/timepicker/tests/behavior/ods-timepicker.e2e.ts
@@ -110,4 +110,20 @@ describe('ods-timepicker behavior', () => {
       });
     });
   });
+
+  describe('form', () => {
+    it('should get form data when submit button is triggered', async() => {
+      await setup(`<form method="get">
+        <ods-timepicker name="odsTimepicker" value="12:42"></ods-timepicker>
+        <button type="submit">Submit</button>
+      </form>`);
+      const submitButton = await page.find('button[type="submit"]');
+
+      await submitButton.click();
+      await page.waitForNetworkIdle();
+
+      const url = new URL(page.url());
+      expect(url.searchParams.get('odsTimepicker')).toBe('12:42');
+    });
+  });
 });

--- a/packages/ods/src/components/timepicker/tests/behavior/ods-timepicker.e2e.ts
+++ b/packages/ods/src/components/timepicker/tests/behavior/ods-timepicker.e2e.ts
@@ -71,30 +71,20 @@ describe('ods-timepicker behavior', () => {
   });
 
   describe('watchers', () => {
-    describe('on timezones / current timezone change', () => {
+    describe('on timezones change', () => {
       it('should display select on timezones change', async() => {
         const timezonesValue = 'all';
         await setup('<ods-timepicker></ods-timepicker>');
+
         expect(select).toBeNull();
 
         await el.setProperty('timezones', timezonesValue);
         await page.waitForChanges();
 
         expect(await el.getProperty('timezones')).toBe(timezonesValue);
+
         await findSelect();
-        expect(select).not.toBeNull();
-      });
 
-      it('should display select on currentTimezone change', async() => {
-        const currentTimezoneValue = 'utc+1';
-        await setup('<ods-timepicker></ods-timepicker>');
-        expect(select).toBeNull();
-
-        await el.setProperty('currentTimezone', currentTimezoneValue);
-        await page.waitForChanges();
-
-        expect(await el.getProperty('currentTimezone')).toBe(currentTimezoneValue);
-        await findSelect();
         expect(select).not.toBeNull();
       });
     });

--- a/packages/ods/src/components/timepicker/tests/controller/ods-timepicker.spec.ts
+++ b/packages/ods/src/components/timepicker/tests/controller/ods-timepicker.spec.ts
@@ -1,4 +1,4 @@
-import { ODS_TIMEZONE, ODS_TIMEZONES, ODS_TIMEZONES_PRESET } from '../../src';
+import { ODS_TIMEZONE, ODS_TIMEZONES, ODS_TIMEZONES_PRESET, type OdsTimezone } from '../../src';
 import { formatValue, getCurrentTimezone, parseTimezones } from '../../src/controller/ods-timepicker';
 
 describe('ods-timepicker controller', () => {
@@ -40,20 +40,23 @@ describe('ods-timepicker controller', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       global.Date = jest.fn(() => dateMock as any) as any;
 
-      expect(getCurrentTimezone()).toBe(ODS_TIMEZONE.UTC5);
+      expect(getCurrentTimezone(undefined, ODS_TIMEZONES as OdsTimezone[])).toBe(ODS_TIMEZONE.UTC5);
     });
 
     it('should return currentTimezone when provided', () => {
       const currentTimezoneMock = 'UTC+1';
-      expect(getCurrentTimezone(currentTimezoneMock)).toBe(currentTimezoneMock);
-    });
 
+      expect(getCurrentTimezone(currentTimezoneMock, ODS_TIMEZONES as OdsTimezone[])).toBe(currentTimezoneMock);
+    });
   });
 
   describe('parseTimezones', () => {
-    it('should return all timezones when input is undefined or ODS_TIMEZONES_PRESET.All', () => {
-      expect(parseTimezones()).toEqual(ODS_TIMEZONES);
-      expect(parseTimezones(ODS_TIMEZONES_PRESET.All)).toEqual(ODS_TIMEZONES);
+    it('should return an empty array if no arg', () => {
+      expect(parseTimezones()).toEqual([]);
+    });
+
+    it('should return all timezones when ODS_TIMEZONES_PRESET.all', () => {
+      expect(parseTimezones(ODS_TIMEZONES_PRESET.all)).toEqual(ODS_TIMEZONES);
     });
 
     it('should parse a valid JSON string of timezones', () => {

--- a/packages/ods/src/components/timepicker/tests/rendering/ods-timepicker.e2e.ts
+++ b/packages/ods/src/components/timepicker/tests/rendering/ods-timepicker.e2e.ts
@@ -18,8 +18,8 @@ describe('ods-timepicker rendering', () => {
     }
 
     el = await page.find('ods-timepicker');
-    input = await page.find('ods-timepicker >>> .ods-timepicker__time');
-    select = await page.find('ods-timepicker >>> .ods-timepicker__timezones');
+    input = await page.find('ods-timepicker >>> ods-input');
+    select = await page.find('ods-timepicker >>> ods-select');
   }
 
   it('should render the web component', async() => {

--- a/packages/ods/src/components/timepicker/tests/rendering/ods-timepicker.e2e.ts
+++ b/packages/ods/src/components/timepicker/tests/rendering/ods-timepicker.e2e.ts
@@ -43,11 +43,11 @@ describe('ods-timepicker rendering', () => {
     expect(select).not.toBeNull();
   });
 
-  it('should render the web component with select because of currentTimezone', async() => {
+  it('should not render the web component with select because of currentTimezone if not timezones are set', async() => {
     await setup('<ods-timepicker current-timezone="UTC+1"></ods-timepicker>');
 
     expect(el.shadowRoot).not.toBeNull();
-    expect(select).not.toBeNull();
+    expect(select).toBeNull();
   });
 
   describe('part', () => {

--- a/packages/storybook/stories/components/phone-number/phone-number.stories.ts
+++ b/packages/storybook/stories/components/phone-number/phone-number.stories.ts
@@ -13,8 +13,8 @@ export default meta;
 export const Demo: StoryObj = {
   render: (arg) => html`
     <ods-phone-number class="my-phone-number"
-                      ariaLabel="${arg.ariaLabel}"
-                      ariaLabelledby="${arg.ariaLabelledby}"
+                      aria-label="${arg.ariaLabel}"
+                      aria-labelledby="${arg.ariaLabelledby}"
                       countries="${arg.countries ? 'all' : null}"
                       has-error="${arg.hasError}"
                       is-clearable="${arg.isClearable}"

--- a/packages/storybook/stories/components/timepicker/technical-information.mdx
+++ b/packages/storybook/stories/components/timepicker/technical-information.mdx
@@ -44,6 +44,10 @@ Custom timepicker CSS:
 
 <Canvas of={ TimepickerStories.Timezones } sourceState='shown' />
 
+### Timezones Custom
+
+<Canvas of={ TimepickerStories.TimezonesCustom } sourceState='shown' />
+
 ### WithSeconds
 
 <Canvas of={ TimepickerStories.WithSeconds } sourceState='shown' />

--- a/packages/storybook/stories/components/timepicker/timepicker.stories.ts
+++ b/packages/storybook/stories/components/timepicker/timepicker.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { ODS_TIMEZONES, ODS_TIMEZONES_PRESETS } from '@ovhcloud/ods-components';
+import { ODS_TIMEZONES } from '@ovhcloud/ods-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY, orderControls } from '../../control';
 
@@ -13,12 +13,13 @@ export default meta;
 export const Demo: StoryObj = {
   render: (arg) => html`
   <ods-timepicker class="my-timepicker-demo"
-    aria-label="${arg.ariaLabel}"
-    aria-labelledby="${arg.ariaLabelledby}"
-    has-error="${arg.hasError}"
-    is-disabled="${arg.isDisabled}"
-    is-readonly="${arg.isReadonly}"
-    with-seconds="${arg.withSeconds}">
+                  aria-label="${arg.ariaLabel}"
+                  aria-labelledby="${arg.ariaLabelledby}"
+                  current-timezone="${arg.currentTimezone}"
+                  has-error="${arg.hasError}"
+                  is-disabled="${arg.isDisabled}"
+                  is-readonly="${arg.isReadonly}"
+                  with-seconds="${arg.withSeconds}">
   </ods-timepicker>
   <style>
     .my-timepicker-demo::part(input) {
@@ -42,6 +43,15 @@ export const Demo: StoryObj = {
         type: { summary: 'string' },
       },
       control: 'text',
+    },
+    currentTimezone: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+        defaultValue: { summary: 'ø' },
+        type: { summary: ODS_TIMEZONES },
+      },
+      control: { type: 'select' },
+      options: ODS_TIMEZONES,
     },
     customCss: {
       table: {
@@ -76,6 +86,15 @@ export const Demo: StoryObj = {
       },
       control: 'boolean',
     },
+    // timezones: {
+    //   table: {
+    //     category: CONTROL_CATEGORY.general,
+    //     defaultValue: { summary: 'ø' },
+    //     type: { summary: 'string' },
+    //   },
+    //   control: { type: 'boolean' },
+    //   description: 'Toggle this to demo the "all" preset. To fine-tune the list of timezones, check the prop documentation.',
+    // },
     withSeconds: {
       table: {
         category: CONTROL_CATEGORY.general,
@@ -89,128 +108,13 @@ export const Demo: StoryObj = {
     hasError: false,
     isDisabled: false,
     isReadonly: false,
-    withSeconds: false,
-  },
-};
-
-export const TimeZones: StoryObj = {
-  render: (arg) => html`
-  <ods-timepicker class="my-timepicker-demo-timezones"
-    aria-label="${arg.ariaLabel}"
-    aria-labelledby="${arg.ariaLabelledby}"
-    current-timezone="${arg.currentTimezone}"
-    has-error="${arg.hasError}"
-    is-disabled="${arg.isDisabled}"
-    is-readonly="${arg.isReadonly}"
-    timezones="${arg.timezones}"
-    with-seconds="${arg.withSeconds}">
-  </ods-timepicker>
-  <style>
-    .my-timepicker-demo-timezones::part(input) {
-      ${arg.customCssInput}
-    }
-    .my-timepicker-demo-timezones::part(select) {
-      ${arg.customCssSelect}
-    }
-  </style>
-  `,
-  argTypes: orderControls({
-    ariaLabel: {
-      table: {
-        category: CONTROL_CATEGORY.accessibility,
-        defaultValue: { summary: 'ø' },
-        type: { summary: 'string' },
-      },
-      control: 'text',
-    },
-    ariaLabelledby: {
-      table: {
-        category: CONTROL_CATEGORY.accessibility,
-        defaultValue: { summary: 'ø' },
-        type: { summary: 'string' },
-      },
-      control: 'text',
-    },
-    currentTimezone: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: 'ø' },
-        type: { summary: ODS_TIMEZONES },
-      },
-      control: { type: 'select' },
-      options: ODS_TIMEZONES,
-    },
-    customCssInput: {
-      table: {
-        category: CONTROL_CATEGORY.design,
-        defaultValue: { summary: 'ø' },
-        type: { summary: 'string' },
-      },
-      control: 'text',
-      description: 'Set a custom style properties. Example: "width: 300px;"',
-    },
-    customCssSelect: {
-      table: {
-        category: CONTROL_CATEGORY.design,
-        defaultValue: { summary: 'ø' },
-        type: { summary: 'string' },
-      },
-      control: 'text',
-      description: 'Set a custom style properties. Example: "width: 300px;"',
-    },
-    hasError: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
-    isDisabled: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
-    isReadonly: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
-    timezones: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: 'ø' },
-        type: { summary: [...ODS_TIMEZONES, ...ODS_TIMEZONES_PRESETS] },
-      },
-      control: { type: 'select' },
-      options: [...ODS_TIMEZONES, ...ODS_TIMEZONES_PRESETS],
-    },
-    withSeconds: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
-  }),
-  args: {
-    hasError: false,
-    isDisabled: false,
-    isReadonly: false,
-    timezones: 'all',
+    // timezones: false,
     withSeconds: false,
   },
 };
 
 export const CustomCSS: StoryObj = {
-  decorators: [(story) => html`<div style="padding-bottom: 200px; display: inline-flex; align-items: center;">${story()}</div>`],
+  decorators: [(story) => html`<div style="height: 230px;">${story()}</div>`],
   tags: ['isHidden'],
   render: () => html`
   <ods-timepicker timezones="all" class="my-timepicker-custom-css"></ods-timepicker>
@@ -265,10 +169,18 @@ export const Readonly: StoryObj = {
 };
 
 export const Timezones: StoryObj = {
-  decorators: [(story) => html`<div style="padding-bottom: 200px; display: inline-flex; align-items: center;">${story()}</div>`],
+  decorators: [(story) => html`<div style="height: 230px;">${story()}</div>`],
   tags: ['isHidden'],
   render: () => html`
 <ods-timepicker timezones="all"></ods-timepicker>
+  `,
+};
+
+export const TimezonesCustom: StoryObj = {
+  decorators: [(story) => html`<div style="height: 150px;">${story()}</div>`],
+  tags: ['isHidden'],
+  render: () => html`
+<ods-timepicker timezones='["utc-4", "utc-2", "utc+2", "utc+4"]'></ods-timepicker>
   `,
 };
 

--- a/packages/storybook/stories/components/timepicker/timepicker.stories.ts
+++ b/packages/storybook/stories/components/timepicker/timepicker.stories.ts
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { ODS_TIMEZONES } from '@ovhcloud/ods-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY, orderControls } from '../../control';
 
@@ -15,10 +14,10 @@ export const Demo: StoryObj = {
   <ods-timepicker class="my-timepicker-demo"
                   aria-label="${arg.ariaLabel}"
                   aria-labelledby="${arg.ariaLabelledby}"
-                  current-timezone="${arg.currentTimezone}"
                   has-error="${arg.hasError}"
                   is-disabled="${arg.isDisabled}"
                   is-readonly="${arg.isReadonly}"
+                  timezones="${arg.timezones ? 'all' : null}"
                   with-seconds="${arg.withSeconds}">
   </ods-timepicker>
   <style>
@@ -43,15 +42,6 @@ export const Demo: StoryObj = {
         type: { summary: 'string' },
       },
       control: 'text',
-    },
-    currentTimezone: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: 'ø' },
-        type: { summary: ODS_TIMEZONES },
-      },
-      control: { type: 'select' },
-      options: ODS_TIMEZONES,
     },
     customCss: {
       table: {
@@ -86,15 +76,15 @@ export const Demo: StoryObj = {
       },
       control: 'boolean',
     },
-    // timezones: {
-    //   table: {
-    //     category: CONTROL_CATEGORY.general,
-    //     defaultValue: { summary: 'ø' },
-    //     type: { summary: 'string' },
-    //   },
-    //   control: { type: 'boolean' },
-    //   description: 'Toggle this to demo the "all" preset. To fine-tune the list of timezones, check the prop documentation.',
-    // },
+    timezones: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+        defaultValue: { summary: 'ø' },
+        type: { summary: 'string' },
+      },
+      control: { type: 'boolean' },
+      description: 'Toggle this to demo the "all" preset. To fine-tune the list of timezones, check the prop documentation.',
+    },
     withSeconds: {
       table: {
         category: CONTROL_CATEGORY.general,
@@ -108,7 +98,7 @@ export const Demo: StoryObj = {
     hasError: false,
     isDisabled: false,
     isReadonly: false,
-    // timezones: false,
+    timezones: false,
     withSeconds: false,
   },
 };


### PR DESCRIPTION
- prevent displaying the timezone select if only the `currentTimezone` prop is set
- remove the Demo Timezone page, replaced by a toggle control on Demo page