### PR TITLE
fix(accordion): update summary style

### DIFF
--- a/packages/ods/src/components/accordion/src/components/ods-accordion/ods-accordion.scss
+++ b/packages/ods/src/components/accordion/src/components/ods-accordion/ods-accordion.scss
@@ -1,6 +1,8 @@
 @use '../../../../../style/focus';
 @use '../../../../../style/state';
 
+$ods-accordion-padding: 24px;
+
 .ods-accordion {
   &__wrapper {
     transition: .3s border-color ease-out;
@@ -35,9 +37,10 @@
 
       display: flex;
       position: relative;
+      column-gap: $ods-accordion-padding;
       align-items: center;
       justify-content: space-between;
-      padding: 24px;
+      padding: $ods-accordion-padding;
       list-style: none;
 
       &::-webkit-details-marker {
@@ -45,7 +48,7 @@
       }
 
       &--is-open {
-        padding-bottom: 24px;
+        padding-bottom: $ods-accordion-padding;
       }
 
       &--is-disabled {
@@ -65,10 +68,14 @@
         color: var(--ods-color-primary-500);
         font-size: 0.875rem;
       }
+
+      &__slot {
+        width: 100%;
+      }
     }
 
     &__content {
-      padding: 0 24px 24px;
+      padding: 0 $ods-accordion-padding $ods-accordion-padding;
     }
   }
 }

--- a/packages/ods/src/components/accordion/src/index.html
+++ b/packages/ods/src/components/accordion/src/index.html
@@ -13,7 +13,10 @@
 <body>
   <p>Default</p>
   <ods-accordion>
-    <ods-text preset="span" slot="summary">Hello, world!</ods-text>
+    <div slot="summary" style="display: grid; grid-template-columns: 1fr max-content; column-gap: 8px;">
+      <span>Hello, world!</span>
+      <button>Dummy button</button>
+    </div>
 
     <ods-text preset="span">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -21,7 +24,6 @@
   </ods-accordion>
 
   <ods-accordion>
-    <!-- <ods-text slot="summary" preset="heading-6">Hello, world!</ods-text> -->
     <ods-text preset="span">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </ods-text>
@@ -51,20 +53,11 @@
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
   </details>
 
-  <div style="width: 1px; height: 5000px;"></div>
-
+  <div style="height: 5000px;"></div>
 
   <style>
     ods-text {
       font-family: 'Source Sans Pro', sans-serif;
-    }
-
-    .label {
-      color: #0050d7;
-    }
-
-    .label::part(text) {
-      margin: 0;
     }
   </style>
 </body>


### PR DESCRIPTION
Stretch the summary slot wrapper to allow custom display, for example a display grid before:
<img width="1018" alt="Capture d’écran 2024-08-27 à 10 54 46" src="https://github.com/user-attachments/assets/2ae986be-db57-4ab1-8eed-d52a5928f9a5">

after:
<img width="1019" alt="Capture d’écran 2024-08-27 à 10 54 29" src="https://github.com/user-attachments/assets/28734279-11bc-477b-9e0a-d7d61ad2393c">
