### PR TITLE
feat(phone-number): set locale fallback to english

### DIFF
--- a/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
+++ b/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
@@ -79,7 +79,7 @@ function getTranslatedCountries(locale: OdsPhoneNumberLocale): { isoCode: string
     case ODS_PHONE_NUMBER_LOCALE.pt:
       return countriesTranslationPt;
     default:
-      return countriesTranslationFr;
+      return countriesTranslationEn;
   }
 }
 

--- a/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
+++ b/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
@@ -48,7 +48,7 @@ function getCurrentLocale(locale?: OdsPhoneNumberLocale): OdsPhoneNumberLocale {
 
   return getBrowserIsoCodes<ODS_PHONE_NUMBER_LOCALE>().find((browserIsoCode) => {
     return ODS_PHONE_NUMBER_LOCALES.indexOf(browserIsoCode) >= 0;
-  }) || ODS_PHONE_NUMBER_LOCALE.fr;
+  }) || ODS_PHONE_NUMBER_LOCALE.en;
 }
 
 function getNationalPhoneNumberExample(isoCode: OdsPhoneNumberCountryIsoCode | undefined, phoneUtils: PhoneNumberUtil): string {

--- a/packages/ods/src/components/phone-number/tests/controller/ods-phone-number.spec.ts
+++ b/packages/ods/src/components/phone-number/tests/controller/ods-phone-number.spec.ts
@@ -161,7 +161,7 @@ describe('ods-phone-number controller', () => {
       const defaultMap = getTranslatedCountryMap('zw', mockPhoneUtils);
 
       expect(defaultMap.size).toBe(countriesTranslationFr.length);
-      expect(defaultMap.values().next().value.name).toBe('Andorre');
+      expect(defaultMap.values().next().value.name).toBe('Andorra');
       expect(mockPhoneUtils.getExampleNumber).toHaveBeenCalledTimes(countriesTranslationFr.length);
       expect(getCountryCodeSpy).toHaveBeenCalledTimes(countriesTranslationFr.length);
     });

--- a/packages/ods/src/components/phone-number/tests/controller/ods-phone-number.spec.ts
+++ b/packages/ods/src/components/phone-number/tests/controller/ods-phone-number.spec.ts
@@ -103,7 +103,7 @@ describe('ods-phone-number controller', () => {
       global.navigator = { language: 'zh-gan' };
 
       // @ts-ignore for test purpose
-      expect(getCurrentLocale('zw')).toBe('fr');
+      expect(getCurrentLocale('zw')).toBe('en');
     });
   });
 

--- a/packages/storybook/stories/components/phone-number/documentation.mdx
+++ b/packages/storybook/stories/components/phone-number/documentation.mdx
@@ -79,7 +79,7 @@ The locale (i.e. country list translation in <StorybookLink kind="ODS Components
 
 If the given property is not defined or recognized, the component attempts to use the browser's locale settings.
 
-If the browser's locale is also not recognized, the component defaults to French (FR).
+If the browser's locale is also not recognized, the component defaults to English (EN).
 
 <Heading label="ISO code" level={ 3 } />
 


### PR DESCRIPTION
To check the fallback to 'en' you'll need to have:
* no locale or wrong locale
* AND browser's locale not recognized (not managed by ODS)