### PR TITLE
fix(breadcrumb): set line-height on breadcrumb

### DIFF
--- a/packages/storybook/assets/css/preview.css
+++ b/packages/storybook/assets/css/preview.css
@@ -5,7 +5,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-overflow-scrolling: touch;
-  line-height: 24px;
   color: #2e3438;
 }
 


### PR DESCRIPTION
We need to set this line-height on Breadcrumb component so, we avoid component style to be overridden by generic style (Storybook)