### PR TITLE
Form validity phone number

### DIFF
--- a/packages/ods/src/components/input/src/components/ods-input/ods-input.tsx
+++ b/packages/ods/src/components/input/src/components/ods-input/ods-input.tsx
@@ -17,8 +17,8 @@ const VALUE_DEFAULT_VALUE = null;
   tag: 'ods-input',
 })
 export class OdsInput {
-  private observer?: MutationObserver;
   private inputEl?: HTMLInputElement;
+  private observer?: MutationObserver;
   private shouldUpdateIsInvalidState: boolean = false;
 
   @Element() el!: HTMLElement;
@@ -107,6 +107,18 @@ export class OdsInput {
     // Element internal validityState is not yet updated, so we set the flag
     // to update our internal state when it will be up-to-date
     this.shouldUpdateIsInvalidState = true;
+  }
+
+  @Method()
+  public async setCustomValidity(message: string): Promise<void> {
+    if (message) {
+      this.internals.setValidity({ customError: true }, message);
+    } else {
+      if (this.internals.validity.valid) {
+        // This would override all flags, even if some are still set to true
+        this.internals.setValidity({ customError: false });
+      }
+    }
   }
 
   @Method()

--- a/packages/ods/src/components/input/src/index.html
+++ b/packages/ods/src/components/input/src/index.html
@@ -92,15 +92,16 @@
                name="firstName">
     </ods-input>
 
-    <label for="input-form-last-name">Last name:</label>
-    <ods-input id="input-form-last-name"
-               is-required
-               name="lastName">
-    </ods-input>
+<!--    <label for="input-form-last-name">Last name:</label>-->
+<!--    <ods-input id="input-form-last-name"-->
+<!--               is-required-->
+<!--               name="lastName">-->
+<!--    </ods-input>-->
 
 <!--    <input type="text" name="natif-input" required>-->
 
-<!--    <button id="input-form-check-validity-button" type="button">Check validity</button>-->
+    <button id="input-form-toggle-custom-error-button" type="button">Toggle custom error</button>
+    <button id="input-form-check-validity-button" type="button">Check validity</button>
 <!--    <button id="input-form-clear-button" type="button">Clear</button>-->
 <!--    <button id="input-form-reset-button" type="button">Reset</button>-->
 <!--    <button type="reset">Global Form Reset</button>-->
@@ -109,14 +110,19 @@
   <script>
     const formElement = document.querySelector('#input-form');
     const inputFormFirstName = document.querySelector('#input-form-first-name');
-    // const inputCheckValidityFormButton = document.querySelector('#input-form-check-validity-button');
+    const inputToggleCustomErrorButton = document.querySelector('#input-form-toggle-custom-error-button');
+    const inputCheckValidityFormButton = document.querySelector('#input-form-check-validity-button');
     // const inputClearFormButton = document.querySelector('#input-form-clear-button');
     // const inputResetFormButton = document.querySelector('#input-form-reset-button');
     const inputSubmitFormButton = document.querySelector('#input-form-submit-button');
 
-    // inputCheckValidityFormButton.addEventListener('click', async() => {
-    //   console.log('Check validity: ', await inputFormInput.checkValidity());
-    // });
+    inputToggleCustomErrorButton.addEventListener('click', async() => {
+      await inputFormFirstName.setCustomValidity('NOP')
+    });
+
+    inputCheckValidityFormButton.addEventListener('click', async() => {
+      console.log('Check validity: ', await inputFormFirstName.getValidity());
+    });
     //
     // inputClearFormButton.addEventListener('click', async() => {
     //   await inputFormInput.clear();
@@ -136,7 +142,9 @@
   </script>
 
   <p>Methods</p>
-  <ods-input id="input-methods" is-required default-value="rest">
+  <ods-input id="input-methods"
+             is-required
+             default-value="rest">
   </ods-input>
   <button id="clear-button">clear</button>
   <button id="reset-button">reset</button>
@@ -152,20 +160,17 @@
     const resetButton = document.getElementById('reset-button');
     const getValidityButton = document.getElementById('get-validity-button');
     const toggleMaskButton = document.getElementById('toggle-mask-button');
+
     clearButton.addEventListener('click', () => input.clear());
+
     resetButton.addEventListener('click', () => input.reset());
+
     getValidityButton.addEventListener('click', async () => {
       const validity = await input.getValidity();
       console.log('validity', validity);
     });
+
     toggleMaskButton.addEventListener('click', () => input.toggleMask());
-    const form = document.getElementById('input-form');
-    const resetFormButton = document.getElementById('form-reset-button');
-    const submitFormButton = document.getElementById('form-submit-button');
-    submitFormButton.addEventListener('click', () => {
-      const formData = new FormData(form);
-      console.log('formData', formData);
-    });
   </script>
 
 <!--  <p>With label</p>-->

--- a/packages/ods/src/components/phone-number/src/components/ods-phone-number/ods-phone-number.tsx
+++ b/packages/ods/src/components/phone-number/src/components/ods-phone-number/ods-phone-number.tsx
@@ -46,6 +46,7 @@ export class OdsPhoneNumber {
   @Prop({ reflect: true }) public ariaLabel: HTMLElement['ariaLabel'] = null;
   @Prop({ reflect: true }) public ariaLabelledby?: string;
   @Prop({ reflect: true }) public countries?: OdsPhoneNumberCountryIsoCode[] | OdsPhoneNumberCountryPreset | string;
+  @Prop({ reflect: true }) public customValidityMessage: string = 'Phone number is incorrect';
   @Prop({ reflect: true }) public defaultValue?: string;
   @Prop({ mutable: true, reflect: true }) public hasError: boolean = false;
   @Prop({ reflect: true }) public isClearable: boolean = false;
@@ -180,8 +181,7 @@ export class OdsPhoneNumber {
     this.value = event.detail.value as string ?? null;
 
     if (!isValidPhoneNumber(this.value, this.isoCode, this.phoneUtils)) {
-      // TODO add Prop to customize message
-      await this.inputElement?.setCustomValidity('Phone number format KO');
+      await this.inputElement?.setCustomValidity(this.customValidityMessage);
     } else {
       await this.inputElement?.setCustomValidity('');
     }

--- a/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
+++ b/packages/ods/src/components/phone-number/src/controller/ods-phone-number.ts
@@ -1,6 +1,6 @@
 import type { OdsInput } from '../../../input/src';
 import { type PhoneNumber, PhoneNumberFormat, type PhoneNumberUtil } from 'google-libphonenumber';
-import { setInternalsValidityFromValidityState } from '../../../../utils/dom';
+import { setInternalsValidityFromOdsComponent } from '../../../../utils/dom';
 import { ODS_PHONE_NUMBER_COUNTRY_ISO_CODE, ODS_PHONE_NUMBER_COUNTRY_ISO_CODES, type OdsPhoneNumberCountryIsoCode } from '../constants/phone-number-country-iso-code';
 import { ODS_PHONE_NUMBER_COUNTRY_PRESET, type OdsPhoneNumberCountryPreset } from '../constants/phone-number-country-preset';
 import { ODS_PHONE_NUMBER_LOCALE, ODS_PHONE_NUMBER_LOCALES, type OdsPhoneNumberLocale } from '../constants/phone-number-locale';
@@ -91,26 +91,6 @@ function getTranslatedCountryMap(locale: OdsPhoneNumberLocale, phoneUtils: Phone
   }, new Map());
 }
 
-function getValidityState(hasError: boolean, validityState?: ValidityState): ValidityState {
-  return {
-    badInput: validityState?.badInput || hasError,
-    customError: validityState?.customError || false,
-    patternMismatch: validityState?.patternMismatch || false,
-    rangeOverflow: validityState?.rangeOverflow || false,
-    rangeUnderflow: validityState?.rangeUnderflow || false,
-    stepMismatch: validityState?.stepMismatch || false,
-    tooLong: validityState?.tooLong || false,
-    tooShort: validityState?.tooShort || false,
-    typeMismatch: validityState?.typeMismatch || false,
-    valid: validityState?.valid === false ? validityState?.valid : !hasError,
-    valueMissing: validityState?.valueMissing || false,
-  };
-}
-
-function getValidityMessage(hasError: boolean): string {
-  return hasError && 'Wrong phone number format' || '';
-}
-
 function isValidPhoneNumber(phoneNumber: string | null, isoCode: OdsPhoneNumberCountryIsoCode | undefined, phoneUtils: PhoneNumberUtil): boolean {
   if (!phoneNumber || !isoCode) {
     return true;
@@ -156,12 +136,11 @@ function parsePhoneNumber(phoneNumber: string | null, isoCode: OdsPhoneNumberCou
   }
 }
 
-// eslint-disable-next-line max-params
-async function updateInternals(internals: ElementInternals, value: string | null, validityState: ValidityState, inputEl?: HTMLElement & OdsInput, validityMessage?: string): Promise<void> {
+async function updateInternals(internals: ElementInternals, value: string | null, inputEl?: HTMLElement & OdsInput): Promise<void> {
   internals.setFormValue(value?.toString() ?? '');
 
   if (inputEl) {
-    await setInternalsValidityFromValidityState(inputEl, internals, validityState, validityMessage);
+    await setInternalsValidityFromOdsComponent(inputEl, internals);
   }
 }
 
@@ -187,8 +166,6 @@ export {
   getCurrentLocale,
   getNationalPhoneNumberExample,
   getTranslatedCountryMap,
-  getValidityMessage,
-  getValidityState,
   isValidPhoneNumber,
   parseCountries,
   parsePhoneNumber,

--- a/packages/ods/src/components/phone-number/src/index.html
+++ b/packages/ods/src/components/phone-number/src/index.html
@@ -78,21 +78,47 @@
 
   <p>Form</p>
   <form id="opn-input-form">
-    <ods-phone-number name="input-form"
-                      value="+18444629181"
-                      is-required>
+    <ods-phone-number id="opn-element"
+                      iso-code="fr"
+                      is-required
+                      name="input-form"
+                      >
     </ods-phone-number>
+    <button id="opn-toggle-is-required-button" type="button">Toggle is required</button>
+    <button id="opn-reset-phone-number-button" type="button">Reset phone-number</button>
     <button id="opn-input-form-reset-button" type="reset">Reset</button>
     <button id="opn-input-form-submit-button" type="submit">Submit</button>
   </form>
   <script>
+    const opnElement = document.querySelector('#opn-element');
     const opnInputForm = document.querySelector('#opn-input-form');
     const opnInputSubmitFormButton = document.querySelector('#opn-input-form-submit-button');
+    const opnResetPhoneNumberButton = document.querySelector('#opn-reset-phone-number-button');
+    const opnToggleIsRequiredButton = document.querySelector('#opn-toggle-is-required-button');
 
-    opnInputSubmitFormButton.addEventListener('click', () => {
+    opnInputSubmitFormButton.addEventListener('click', async() => {
+      // e.preventDefault(); // comment to test native validation messages
       const formData = new FormData(opnInputForm);
       console.log('formData', formData);
+      console.log(await opnElement?.getValidity())
     });
+
+    opnResetPhoneNumberButton.addEventListener('click', async() => {
+      await opnElement.reset();
+    })
+
+    opnToggleIsRequiredButton.addEventListener('click', async() => {
+      if (opnElement.hasAttribute('is-required')) {
+        opnElement.removeAttribute('is-required');
+      } else {
+        opnElement.setAttribute('is-required', 'true');
+      }
+    });
+
+    // opnElement.addEventListener('odsChange', async(e) => {
+    //   console.log('on change', e.detail.value);
+    //   console.log(await opnElement.getValidity());
+    // });
   </script>
 
   <!--<p>Countries update</p>

--- a/packages/ods/src/components/phone-number/tests/behaviour/ods-phone-number.e2e.ts
+++ b/packages/ods/src/components/phone-number/tests/behaviour/ods-phone-number.e2e.ts
@@ -134,10 +134,9 @@ describe('ods-phone-number behaviour', () => {
       it('should emit an odsChange event', async() => {
         await setup('<ods-phone-number name="ods-phone-number" iso-code="fr"></ods-phone-number>');
         const odsChangeSpy = await page.spyOnEvent('odsChange');
-
         const newValue = '0987654321';
-        await page.keyboard.press('Tab');
-        await page.keyboard.type(newValue, { delay: 100 });
+
+        await el.type(newValue, { delay: 100 });
         await page.waitForChanges();
 
         expect(await el.getProperty('value')).toBe(newValue);
@@ -146,19 +145,7 @@ describe('ods-phone-number behaviour', () => {
           isoCode: 'fr',
           name: 'ods-phone-number',
           previousValue: newValue.slice(0, -1),
-          validity: {
-            badInput: false,
-            customError: false,
-            patternMismatch: false,
-            rangeOverflow: false,
-            rangeUnderflow: false,
-            stepMismatch: false,
-            tooLong: false,
-            tooShort: false,
-            typeMismatch: false,
-            valid: true,
-            valueMissing: false,
-          },
+          validity: {},
           value: `+33${newValue.substring(1)}`,
         });
       });

--- a/packages/ods/src/components/phone-number/tests/rendering/ods-phone-number.spec.ts
+++ b/packages/ods/src/components/phone-number/tests/rendering/ods-phone-number.spec.ts
@@ -65,6 +65,22 @@ describe('ods-phone-number rendering', () => {
     });
   });
 
+  describe('customValidityMessage', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-phone-number custom-validity-message="${dummyValue}"></ods-phone-number>`);
+
+      expect(root?.getAttribute('custom-validity-message')).toBe(dummyValue);
+    });
+
+    it('should render with expected default value', async() => {
+      await setup('<ods-phone-number></ods-phone-number>');
+
+      expect(root?.getAttribute('custom-validity-message')).toBe('Phone number is incorrect');
+    });
+  });
+
   describe('defaultValue', () => {
     it('should be reflected', async() => {
       const dummyValue = 'dummy value';

--- a/packages/ods/src/components/phone-number/tests/validity/ods-phone-number.e2e.ts
+++ b/packages/ods/src/components/phone-number/tests/validity/ods-phone-number.e2e.ts
@@ -47,13 +47,13 @@ describe('ods-phone-number validity', () => {
 
     describe('with no value but default-value defined', () => {
       it('should return validity true if not required', async() => {
-        await setup('<ods-phone-number default-value="+18444629181"></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr"></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
       });
 
       it('should return validity true if required', async() => {
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
       });
@@ -61,13 +61,13 @@ describe('ods-phone-number validity', () => {
 
     describe('with defined value', () => {
       it('should return validity true if not required', async() => {
-        await setup('<ods-phone-number value="+18444629181"></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr"></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
       });
 
       it('should return validity true if required', async() => {
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
       });
@@ -80,10 +80,10 @@ describe('ods-phone-number validity', () => {
         await setup('<ods-phone-number></ods-phone-number>');
         expect(await el.callMethod('checkValidity')).toBe(true);
 
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('checkValidity')).toBe(true);
 
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('checkValidity')).toBe(true);
       });
 
@@ -101,7 +101,7 @@ describe('ods-phone-number validity', () => {
 
     describe('clear', () => {
       it('should update the validity state accordingly, given value', async() => {
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
 
@@ -112,7 +112,7 @@ describe('ods-phone-number validity', () => {
       });
 
       it('should update the validity state accordingly, given default-value', async() => {
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
 
         expect(await el.callMethod('checkValidity')).toBe(true);
 
@@ -128,10 +128,10 @@ describe('ods-phone-number validity', () => {
         await setup('<ods-phone-number></ods-phone-number>');
         expect(await el.callMethod('getValidationMessage')).toBe('');
 
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('getValidationMessage')).toBe('');
 
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('getValidationMessage')).toBe('');
       });
 
@@ -165,10 +165,10 @@ describe('ods-phone-number validity', () => {
         await setup('<ods-phone-number></ods-phone-number>');
         expect(await getValidityProp('valid')).toBe(true);
 
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await getValidityProp('valid')).toBe(true);
 
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await getValidityProp('valid')).toBe(true);
       });
 
@@ -192,10 +192,10 @@ describe('ods-phone-number validity', () => {
         await setup('<ods-phone-number></ods-phone-number>');
         expect(await el.callMethod('reportValidity')).toBe(true);
 
-        await setup('<ods-phone-number value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('reportValidity')).toBe(true);
 
-        await setup('<ods-phone-number default-value="+18444629181" is-required></ods-phone-number>');
+        await setup('<ods-phone-number default-value="+33612345678" iso-code="fr" is-required></ods-phone-number>');
         expect(await el.callMethod('reportValidity')).toBe(true);
       });
 
@@ -292,6 +292,26 @@ describe('ods-phone-number validity', () => {
 
       expect(await el.callMethod('checkValidity')).toBe(true);
       expect(formValidity).toBe(true);
+    });
+  });
+
+  describe('watchers', () => {
+    describe('is-required', () => {
+      it('should update validity when is-required change', async() => {
+        await setup('<ods-phone-number></ods-phone-number>');
+
+        expect(await el.callMethod('checkValidity')).toBe(true);
+
+        await el.setAttribute('is-required', 'true');
+        await page.waitForChanges();
+
+        expect(await el.callMethod('checkValidity')).toBe(false);
+
+        await el.removeAttribute('is-required');
+        await page.waitForChanges();
+
+        expect(await el.callMethod('checkValidity')).toBe(true);
+      });
     });
   });
 });

--- a/packages/ods/src/utils/dom.ts
+++ b/packages/ods/src/utils/dom.ts
@@ -36,12 +36,6 @@ function setInternalsValidityFromHtmlElement(formElement: HTMLInputElement | HTM
   return setInternalsValidity(formElement, internals, formElement.validity, formElement.validationMessage);
 }
 
-async function setInternalsValidityFromValidityState(odsFormElement: OdsFormElement, internals: ElementInternals, validity: ValidityState, validityMessage: string = ''): Promise<void> {
-  const validationMessage = await odsFormElement.getValidationMessage();
-
-  return setInternalsValidity(odsFormElement, internals, validity, validationMessage || validityMessage);
-}
-
 async function setInternalsValidityFromOdsComponent(odsFormElement: OdsFormElement, internals: ElementInternals): Promise<void> {
   const validityState = await odsFormElement.getValidity();
   const validationMessage = await odsFormElement.getValidationMessage();
@@ -61,6 +55,5 @@ export {
   isTargetInElement,
   setInternalsValidityFromHtmlElement,
   setInternalsValidityFromOdsComponent,
-  setInternalsValidityFromValidityState,
   submitFormOnEnter,
 };

--- a/packages/ods/tests/utils/dom.spec.ts
+++ b/packages/ods/tests/utils/dom.spec.ts
@@ -1,4 +1,4 @@
-import { copyToClipboard, getRandomHTMLId, isTargetInElement, setInternalsValidityFromHtmlElement, setInternalsValidityFromOdsComponent, setInternalsValidityFromValidityState, submitFormOnEnter } from '../../src/utils/dom';
+import { copyToClipboard, getRandomHTMLId, isTargetInElement, setInternalsValidityFromHtmlElement, setInternalsValidityFromOdsComponent, submitFormOnEnter } from '../../src/utils/dom';
 
 describe('utils dom', () => {
   beforeEach(jest.clearAllMocks);
@@ -132,99 +132,6 @@ describe('utils dom', () => {
       Object.entries(mockValidityState).forEach(([key, value]) => {
         expect(mockInternals.setValidity).toHaveBeenCalledWith({ [key]: value }, mockFormElement.validationMessage, mockFormElement);
       });
-    });
-  });
-
-  describe('setInternalsValidityFromValidityState', () => {
-    const mockInternals = {
-      setValidity: jest.fn(),
-    } as unknown as ElementInternals;
-
-    it('should set the validity to empty if valid', async() => {
-      const mockOdsFormElement = {
-        getValidationMessage: jest.fn().mockImplementation(() => Promise.resolve('')),
-        getValidity: jest.fn().mockImplementation(() => Promise.resolve({ valid: true })),
-      } as unknown as HTMLElement & {
-        getValidationMessage: () => Promise<string>,
-        getValidity: () => Promise<ValidityState>,
-      };
-
-      const validityState: ValidityState = {
-        badInput: false,
-        customError: false,
-        patternMismatch: false,
-        rangeOverflow: false,
-        rangeUnderflow: false,
-        stepMismatch: false,
-        tooLong: false,
-        tooShort: false,
-        typeMismatch: false,
-        valid: true,
-        valueMissing: false,
-      };
-
-      await setInternalsValidityFromValidityState(mockOdsFormElement, mockInternals, validityState);
-
-      expect(mockInternals.setValidity).toHaveBeenCalledTimes(1);
-      expect(mockInternals.setValidity).toHaveBeenCalledWith({});
-    });
-
-    it('should set the same validity flags as the form element if invalid', async() => {
-      const validityState: ValidityState = {
-        badInput: false,
-        customError: false,
-        patternMismatch: false,
-        rangeOverflow: false,
-        rangeUnderflow: false,
-        stepMismatch: false,
-        tooLong: false,
-        tooShort: false,
-        typeMismatch: false,
-        valid: false,
-        valueMissing: true,
-      };
-      const dummyValidationMessage = 'dummy validation message';
-      const mockOdsFormElement = {
-        getValidationMessage: jest.fn().mockImplementation(() => Promise.resolve(dummyValidationMessage)),
-        getValidity: jest.fn().mockImplementation(() => Promise.resolve({ valid: true })),
-      } as unknown as HTMLElement & {
-        getValidationMessage: () => Promise<string>,
-        getValidity: () => Promise<ValidityState>,
-      };
-
-      await setInternalsValidityFromValidityState(mockOdsFormElement, mockInternals, validityState);
-
-      expect(mockInternals.setValidity).toHaveBeenCalledTimes(1);
-      expect(mockInternals.setValidity).toHaveBeenCalledWith({ 'valueMissing': true }, dummyValidationMessage, mockOdsFormElement);
-    });
-
-    it('should set the same validity flags as the form element if invalid with custom message error', async() => {
-      const validityState: ValidityState = {
-        badInput: false,
-        customError: false,
-        patternMismatch: false,
-        rangeOverflow: false,
-        rangeUnderflow: false,
-        stepMismatch: false,
-        tooLong: false,
-        tooShort: false,
-        typeMismatch: false,
-        valid: false,
-        valueMissing: true,
-      };
-      const dummyValidationMessage = 'dummy validation message';
-      const mockOdsFormElement = {
-        getValidationMessage: jest.fn().mockImplementation(() => Promise.resolve('')),
-        getValidity: jest.fn().mockImplementation(() => Promise.resolve({ valid: true })),
-      } as unknown as HTMLElement & {
-        getValidationMessage: () => Promise<string>,
-        getValidity: () => Promise<ValidityState>,
-      };
-
-      await setInternalsValidityFromValidityState(mockOdsFormElement, mockInternals, validityState, dummyValidationMessage);
-
-      expect(mockInternals.setValidity).toHaveBeenCalledTimes(1);
-      expect(mockInternals.setValidity).toHaveBeenCalledWith({ 'valueMissing': true }, dummyValidationMessage, mockOdsFormElement);
     });
   });
 

--- a/packages/storybook/stories/components/phone-number/phone-number.stories.ts
+++ b/packages/storybook/stories/components/phone-number/phone-number.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_PHONE_NUMBER_COUNTRY_ISO_CODES, ODS_PHONE_NUMBER_LOCALES } from '@ovhcloud/ods-components';
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
 
@@ -46,7 +46,7 @@ export const Demo: StoryObj = {
                       is-required="${arg.isRequired}"
                       iso-code="${arg.isoCode}"
                       locale="${arg.locale}"
-                      pattern="${arg.pattern}">
+                      pattern="${arg.pattern || nothing}">
     </ods-phone-number>
     ${ arg.validityState ? validityStateTemplate : '' }
     <style>

--- a/packages/storybook/stories/components/textarea/textarea.stories.ts
+++ b/packages/storybook/stories/components/textarea/textarea.stories.ts
@@ -135,14 +135,6 @@ export const Demo: StoryObj = {
       },
       control: 'boolean',
     },
-    isResizable: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-        defaultValue: { summary: false },
-        type: { summary: 'boolean' },
-      },
-      control: 'boolean',
-    },
     placeholder: {
       table: {
         category: CONTROL_CATEGORY.general,


### PR DESCRIPTION
- rewrite phone-number to use setCustomValidity instead of managing our own validityState object
- remove all observer/watcher on value, as odsChange event are received on every value change
- add a `customValidityMessage` prop to allow user to translated native form popup message