### PR TITLE
fix(build): ensure lib new version is added to the bundled documentation

### DIFF
--- a/packages/storybook/scripts/generate-version-list.js
+++ b/packages/storybook/scripts/generate-version-list.js
@@ -14,8 +14,13 @@ async function getVersions() {
       return [];
     }
 
-    return (Object.keys(data.versions) || [])
+    // In case of new release, new version is not yet in the registry list, so we add it manually
+    const versions = (Object.keys(data.versions) || []).concat([currentVersion]);
+
+    return versions
       .filter((version) => EXCLUDED_VERSIONS.indexOf(version) < 0)
+      // But when starting locally, this could end up with current version being added twice, so we ensure uniqueness
+      .filter((version, index, array) => array.indexOf(version) === index)
       .sort()
       .reverse()
       .filter((version) => version === currentVersion || !/-alpha\.\d+$/gi.test(version));


### PR DESCRIPTION
When releasing, version list was incomplete and we were forced to fix gh-pages branch each time (ex: https://github.com/ovh/design-system/commit/0f6eb2b1884ea26f16027f82ad1356fd3f9e8819)
This should add correctly the new version to the bundle published on npm.