### PR TITLE
Fix overlay in fixed context

### DIFF
--- a/packages/examples/react-webpack/src/app/App.tsx
+++ b/packages/examples/react-webpack/src/app/App.tsx
@@ -1,8 +1,8 @@
 import React, { type ReactElement } from 'react';
 // import { Gallery } from './components/gallery/Gallery';
 // import { FormFormik } from './components/formFormik/FormFormik';
-import { FormNative } from './components/formNative/FormNative';
-// import { TestModal } from './components/testModal/TestModal';
+// import { FormNative } from './components/formNative/FormNative';
+import { TestModal } from './components/testModal/TestModal';
 import styles from './app.scss';
 
 function App(): ReactElement {
@@ -10,8 +10,8 @@ function App(): ReactElement {
     <div className={ styles.app }>
       {/* <Gallery /> */}
       {/*<FormFormik />*/}
-      <FormNative />
-      {/*<TestModal />*/}
+      {/*<FormNative />*/}
+      <TestModal />
     </div>
   );
 }

--- a/packages/examples/react-webpack/src/app/components/testModal/TestModal.tsx
+++ b/packages/examples/react-webpack/src/app/components/testModal/TestModal.tsx
@@ -1,4 +1,5 @@
-import { OdsButton, OdsModal } from '@ovhcloud/ods-components/react';
+import { ODS_ICON_NAME, ODS_INPUT_TYPE, ODS_TEXT_PRESET } from '@ovhcloud/ods-components';
+import { OdsButton, OdsFormField, OdsIcon, OdsInput, OdsModal, OdsText, OdsTooltip } from '@ovhcloud/ods-components/react';
 import React, { type ReactElement, useState } from 'react';
 
 function TestModal(): ReactElement {
@@ -19,7 +20,26 @@ function TestModal(): ReactElement {
 
       <OdsModal isOpen={ isModalOpen }
                 onOdsClose={ onCloseModal }>
-        Modal body
+        <OdsFormField>
+          <label htmlFor="label" slot="label">
+            Test *
+            <OdsIcon id="tooltip-trigger"
+                     name={ ODS_ICON_NAME.circleQuestion }>
+            </OdsIcon>
+
+            <OdsTooltip role="tooltip"
+                        strategy="fixed"
+                        triggerId="tooltip-trigger">
+              <OdsText preset={ ODS_TEXT_PRESET.paragraph }>
+                TestTooltip
+              </OdsText>
+            </OdsTooltip>
+          </label>
+          <OdsInput type={ODS_INPUT_TYPE.text}
+                    id="label"
+                    name="label">
+          </OdsInput>
+        </OdsFormField>
       </OdsModal>
     </div>
   );

--- a/packages/examples/vanilla-webpack/src/index.html
+++ b/packages/examples/vanilla-webpack/src/index.html
@@ -7,6 +7,17 @@
 </head>
 
 <body>
+  <ods-modal is-open>
+    <ods-icon id="tooltip-trigger"
+              name="circle-question">
+    </ods-icon>
+
+    <ods-tooltip strategy="fixed"
+                 trigger-id="tooltip-trigger">
+      TestTooltip
+    </ods-tooltip>
+  </ods-modal>
+
   <form>
     <ods-input name="text"></ods-input>
 

--- a/packages/ods/package.json
+++ b/packages/ods/package.json
@@ -26,7 +26,7 @@
     "test:spec:ci": "jest --config jest.config.ts"
   },
   "dependencies": {
-    "@floating-ui/dom": "1.6.3",
+    "@floating-ui/dom": "1.6.11",
     "@stencil/core": "4.16.0",
     "google-libphonenumber": "3.2.35",
     "tom-select": "2.3.1",

--- a/packages/ods/src/components/modal/src/components/ods-modal/ods-modal.tsx
+++ b/packages/ods/src/components/modal/src/components/ods-modal/ods-modal.tsx
@@ -124,7 +124,9 @@ export class OdsModal {
           </div>
 
           <div class='ods-modal__dialog__content'>
-            <slot></slot>
+            <div>
+              <slot></slot>
+            </div>
 
             <div class='ods-modal__dialog__content__actions'>
               <slot name='actions'></slot>

--- a/packages/ods/src/components/modal/src/components/ods-modal/ods-modal.tsx
+++ b/packages/ods/src/components/modal/src/components/ods-modal/ods-modal.tsx
@@ -111,8 +111,6 @@ export class OdsModal {
           ref={ (el) => this.modalDialog = el as HTMLDialogElement }
           onClick={ (event) => this.handleBackdropClick(event) }
           part='dialog'>
-          <div class='ods-modal__backdrop'></div>
-
           <div class={ `ods-modal__dialog__header ods-modal__dialog__header--${this.color}` }>
             {
               this.isDismissible &&

--- a/packages/ods/src/components/popover/custom-elements-manifest.config.mjs
+++ b/packages/ods/src/components/popover/custom-elements-manifest.config.mjs
@@ -9,6 +9,7 @@ export default {
   plugins: [cemEnumPlugin({
     rename: {
       ODS_OVERLAY_POSITION: 'ODS_POPOVER_POSITION',
+      ODS_OVERLAY_STRATEGY: 'ODS_POPOVER_STRATEGY',
     },
   })],
   stencil: true,

--- a/packages/ods/src/components/popover/src/components/ods-popover/ods-popover.scss
+++ b/packages/ods/src/components/popover/src/components/ods-popover/ods-popover.scss
@@ -4,9 +4,16 @@
   @include overlay.ods-tooltip();
 
   display: none;
-  position: absolute;
   top: 0;
   left: 0;
+}
+
+:host(.ods-popover--absolute) {
+  position: absolute;
+}
+
+:host(.ods-popover--fixed) {
+  position: fixed;
 }
 
 .ods-popover {

--- a/packages/ods/src/components/popover/src/components/ods-popover/ods-popover.tsx
+++ b/packages/ods/src/components/popover/src/components/ods-popover/ods-popover.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Event, type EventEmitter, type FunctionalComponent,
 import { isTargetInElement } from '../../../../../utils/dom';
 import { findTriggerElement, hideOverlay, showOverlay } from '../../../../../utils/overlay';
 import { ODS_POPOVER_POSITION, type OdsPopoverPosition } from '../../constants/popover-position';
+import { ODS_POPOVER_STRATEGY, type OdsPopoverStrategy } from '../../constants/popover-strategy';
 
 @Component({
   shadow: true,
@@ -20,6 +21,7 @@ export class OdsPopover {
 
   @Prop({ reflect: true }) public position: OdsPopoverPosition = ODS_POPOVER_POSITION.top;
   @Prop({ reflect: true }) public shadowDomTriggerId?: string;
+  @Prop({ reflect: true }) public strategy: OdsPopoverStrategy = ODS_POPOVER_STRATEGY.absolute;
   @Prop({ reflect: true }) public triggerId!: string;
   @Prop({ reflect: true }) public withArrow: boolean = false;
 
@@ -70,6 +72,7 @@ export class OdsPopover {
     }, {
       offset: 8,
       shift: { padding: 5 },
+      strategy: this.strategy,
     });
 
     this.isOpen = true;
@@ -104,7 +107,7 @@ export class OdsPopover {
 
   render(): FunctionalComponent {
     return (
-      <Host class="ods-popover">
+      <Host class={ `ods-popover ods-popover--${this.strategy}` }>
         <slot></slot>
 
         <div

--- a/packages/ods/src/components/popover/src/constants/popover-strategy.ts
+++ b/packages/ods/src/components/popover/src/constants/popover-strategy.ts
@@ -1,0 +1,7 @@
+import { ODS_OVERLAY_STRATEGIES, ODS_OVERLAY_STRATEGY, type OdsOverlayStrategy } from '../../../../utils/overlay';
+
+export {
+  ODS_OVERLAY_STRATEGIES as ODS_POPOVER_STRATEGIES,
+  ODS_OVERLAY_STRATEGY as ODS_POPOVER_STRATEGY,
+  type OdsOverlayStrategy as OdsPopoverStrategy,
+};

--- a/packages/ods/src/components/popover/src/globals.ts
+++ b/packages/ods/src/components/popover/src/globals.ts
@@ -7,3 +7,4 @@
  */
 import '../../button/src';
 import '../../input/src';
+import '../../modal/src';

--- a/packages/ods/src/components/popover/src/index.html
+++ b/packages/ods/src/components/popover/src/index.html
@@ -11,6 +11,18 @@
 </head>
 
 <body>
+<!--  <ods-modal is-open>-->
+<!--    <button id="default">-->
+<!--      Click me-->
+<!--    </button>-->
+
+<!--    <ods-popover position="right"-->
+<!--                 strategy="fixed"-->
+<!--                 trigger-id="default">-->
+<!--      Simple popover-->
+<!--    </ods-popover>-->
+<!--  </ods-modal>-->
+
   <p>
     Using button trigger
   </p>

--- a/packages/ods/src/components/popover/src/index.ts
+++ b/packages/ods/src/components/popover/src/index.ts
@@ -1,2 +1,3 @@
 export { OdsPopover } from './components/ods-popover/ods-popover';
 export { type OdsPopoverPosition, ODS_POPOVER_POSITION, ODS_POPOVER_POSITIONS } from './constants/popover-position';
+export { type OdsPopoverStrategy, ODS_POPOVER_STRATEGIES, ODS_POPOVER_STRATEGY } from './constants/popover-strategy';

--- a/packages/ods/src/components/popover/tests/rendering/ods-popover.spec.ts
+++ b/packages/ods/src/components/popover/tests/rendering/ods-popover.spec.ts
@@ -1,5 +1,5 @@
 import { type SpecPage, newSpecPage } from '@stencil/core/testing';
-import { ODS_POPOVER_POSITION, OdsPopover } from '../../src';
+import { ODS_POPOVER_POSITION, ODS_POPOVER_STRATEGY, OdsPopover } from '../../src';
 
 describe('ods-popover rendering', () => {
   let page: SpecPage;
@@ -31,6 +31,22 @@ describe('ods-popover rendering', () => {
       await setup('<ods-popover></ods-popover>');
 
       expect(root?.getAttribute('position')).toBe(ODS_POPOVER_POSITION.top);
+    });
+  });
+
+  describe('strategy', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-popover strategy="${dummyValue}"></ods-popover>`);
+
+      expect(root?.getAttribute('strategy')).toBe(dummyValue);
+    });
+
+    it('should render with expected default value', async() => {
+      await setup('<ods-popover></ods-popover>');
+
+      expect(root?.getAttribute('strategy')).toBe(ODS_POPOVER_STRATEGY.absolute);
     });
   });
 

--- a/packages/ods/src/components/tooltip/custom-elements-manifest.config.mjs
+++ b/packages/ods/src/components/tooltip/custom-elements-manifest.config.mjs
@@ -9,6 +9,7 @@ export default {
   plugins: [cemEnumPlugin({
     rename: {
       ODS_OVERLAY_POSITION: 'ODS_TOOLTIP_POSITION',
+      ODS_OVERLAY_STRATEGY: 'ODS_TOOLTIP_STRATEGY',
     },
   })],
   stencil: true,

--- a/packages/ods/src/components/tooltip/src/components/ods-tooltip/ods-tooltip.scss
+++ b/packages/ods/src/components/tooltip/src/components/ods-tooltip/ods-tooltip.scss
@@ -4,9 +4,16 @@
   @include overlay.ods-tooltip();
 
   display: none;
-  position: absolute;
   top: 0;
   left: 0;
+}
+
+:host(.ods-tooltip--absolute) {
+  position: absolute;
+}
+
+:host(.ods-tooltip--fixed) {
+  position: fixed;
 }
 
 .ods-tooltip {

--- a/packages/ods/src/components/tooltip/src/components/ods-tooltip/ods-tooltip.tsx
+++ b/packages/ods/src/components/tooltip/src/components/ods-tooltip/ods-tooltip.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, type EventEmitter, type FunctionalComponent, Host, Method, Prop, h } from '@stencil/core';
 import { findTriggerElement, hideOverlay, showOverlay } from '../../../../../utils/overlay';
 import { ODS_TOOLTIP_POSITION, type OdsTooltipPosition } from '../../constants/tooltip-position';
+import { ODS_TOOLTIP_STRATEGY, type OdsTooltipStrategy } from '../../constants/tooltip-strategy';
 
 @Component({
   shadow: true,
@@ -18,6 +19,7 @@ export class OdsTooltip {
 
   @Prop({ reflect: true }) public position: OdsTooltipPosition = ODS_TOOLTIP_POSITION.top;
   @Prop({ reflect: true }) public shadowDomTriggerId?: string;
+  @Prop({ reflect: true }) public strategy: OdsTooltipStrategy = ODS_TOOLTIP_STRATEGY.absolute;
   @Prop({ reflect: true }) public triggerId!: string;
   @Prop({ reflect: true }) public withArrow: boolean = false;
 
@@ -40,6 +42,7 @@ export class OdsTooltip {
     }, {
       offset: 8,
       shift: { padding: 5 },
+      strategy: this.strategy,
     });
 
     this.odsShow.emit();
@@ -63,7 +66,7 @@ export class OdsTooltip {
 
   render(): FunctionalComponent {
     return (
-      <Host class="ods-tooltip">
+      <Host class={ `ods-tooltip ods-tooltip--${this.strategy}` }>
         <slot></slot>
 
         <div

--- a/packages/ods/src/components/tooltip/src/constants/tooltip-strategy.ts
+++ b/packages/ods/src/components/tooltip/src/constants/tooltip-strategy.ts
@@ -1,0 +1,7 @@
+import { ODS_OVERLAY_STRATEGIES, ODS_OVERLAY_STRATEGY, type OdsOverlayStrategy } from '../../../../utils/overlay';
+
+export {
+  ODS_OVERLAY_STRATEGIES as ODS_TOOLTIP_STRATEGIES,
+  ODS_OVERLAY_STRATEGY as ODS_TOOLTIP_STRATEGY,
+  type OdsOverlayStrategy as OdsTooltipStrategy,
+};

--- a/packages/ods/src/components/tooltip/src/globals.ts
+++ b/packages/ods/src/components/tooltip/src/globals.ts
@@ -5,3 +5,4 @@
  * ex:
  *   import '../../text/src';
  */
+import '../../modal/src';

--- a/packages/ods/src/components/tooltip/src/index.html
+++ b/packages/ods/src/components/tooltip/src/index.html
@@ -82,6 +82,22 @@
 </head>
 
 <body>
+<!--  <ods-modal is-open>-->
+<!--    <span class="trigger"-->
+<!--          id="top-start">-->
+<!--      top-start-->
+<!--    </span>-->
+
+<!--    <ods-tooltip position="top-start"-->
+<!--                 strategy="fixed"-->
+<!--                 trigger-id="top-start"-->
+<!--                 with-arrow>-->
+<!--      <p class="custom-tooltip">-->
+<!--        Top-start tooltip-->
+<!--      </p>-->
+<!--    </ods-tooltip>-->
+<!--  </ods-modal>-->
+
   <span class="trigger top-start"
         id="top-start">
     top-start

--- a/packages/ods/src/components/tooltip/src/index.ts
+++ b/packages/ods/src/components/tooltip/src/index.ts
@@ -1,2 +1,3 @@
 export { OdsTooltip } from './components/ods-tooltip/ods-tooltip';
 export { type OdsTooltipPosition, ODS_TOOLTIP_POSITION, ODS_TOOLTIP_POSITIONS } from './constants/tooltip-position';
+export { type OdsTooltipStrategy, ODS_TOOLTIP_STRATEGIES, ODS_TOOLTIP_STRATEGY } from './constants/tooltip-strategy';

--- a/packages/ods/src/components/tooltip/tests/rendering/ods-tooltip.spec.ts
+++ b/packages/ods/src/components/tooltip/tests/rendering/ods-tooltip.spec.ts
@@ -1,5 +1,5 @@
 import { type SpecPage, newSpecPage } from '@stencil/core/testing';
-import { ODS_TOOLTIP_POSITION, OdsTooltip } from '../../src';
+import { ODS_TOOLTIP_POSITION, ODS_TOOLTIP_STRATEGY, OdsTooltip } from '../../src';
 
 describe('ods-tooltip rendering', () => {
   let page: SpecPage;
@@ -31,6 +31,22 @@ describe('ods-tooltip rendering', () => {
       await setup('<ods-tooltip></ods-tooltip>');
 
       expect(root?.getAttribute('position')).toBe(ODS_TOOLTIP_POSITION.top);
+    });
+  });
+
+  describe('strategy', () => {
+    it('should be reflected', async() => {
+      const dummyValue = 'dummy value';
+
+      await setup(`<ods-tooltip strategy="${dummyValue}"></ods-tooltip>`);
+
+      expect(root?.getAttribute('strategy')).toBe(dummyValue);
+    });
+
+    it('should render with expected default value', async() => {
+      await setup('<ods-tooltip></ods-tooltip>');
+
+      expect(root?.getAttribute('strategy')).toBe(ODS_TOOLTIP_STRATEGY.absolute);
     });
   });
 

--- a/packages/ods/src/utils/overlay.ts
+++ b/packages/ods/src/utils/overlay.ts
@@ -1,15 +1,5 @@
 import { type ComputePositionReturn, type OffsetOptions, type ShiftOptions, arrow, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
 
-type DomElement = {
-  arrow?: HTMLElement,
-  popper: HTMLElement,
-  trigger: HTMLElement | null | undefined,
-}
-type MiddlewareOption = {
-  offset?: OffsetOptions,
-  shift?: ShiftOptions,
-}
-
 enum ODS_OVERLAY_POSITION {
   bottom = 'bottom',
   bottomEnd = 'bottom-end',
@@ -25,9 +15,28 @@ enum ODS_OVERLAY_POSITION {
   topStart = 'top-start',
 }
 
+enum ODS_OVERLAY_STRATEGY {
+  absolute = 'absolute',
+  fixed = 'fixed',
+}
+
 type OdsOverlayPosition = `${ODS_OVERLAY_POSITION}`;
+type OdsOverlayStrategy = `${ODS_OVERLAY_STRATEGY}`;
+
+type DomElement = {
+  arrow?: HTMLElement,
+  popper: HTMLElement,
+  trigger: HTMLElement | null | undefined,
+}
+
+type MiddlewareOption = {
+  offset?: OffsetOptions,
+  shift?: ShiftOptions,
+  strategy?: OdsOverlayStrategy,
+}
 
 const ODS_OVERLAY_POSITIONS = Object.freeze(Object.values(ODS_OVERLAY_POSITION));
+const ODS_OVERLAY_STRATEGIES = Object.freeze(Object.values(ODS_OVERLAY_STRATEGY));
 
 function findTriggerElement(triggerId: string, shadowDomTriggerId?: string): HTMLElement | undefined {
   const hostElement = document.querySelector<HTMLElement>(`#${triggerId}`);
@@ -69,6 +78,7 @@ async function getElementPosition(position: OdsOverlayPosition, domElement: DomE
   return computePosition(domElement.trigger, domElement.popper, {
     middleware: middlewares,
     placement: position,
+    strategy: option?.strategy || ODS_OVERLAY_STRATEGY.absolute,
   });
 }
 
@@ -129,5 +139,8 @@ export {
   ODS_OVERLAY_POSITION,
   ODS_OVERLAY_POSITIONS,
   type OdsOverlayPosition,
+  ODS_OVERLAY_STRATEGIES,
+  ODS_OVERLAY_STRATEGY,
+  type OdsOverlayStrategy,
   showOverlay,
 };

--- a/packages/ods/tests/utils/overlay.spec.ts
+++ b/packages/ods/tests/utils/overlay.spec.ts
@@ -8,7 +8,7 @@ jest.mock('@floating-ui/dom', () => ({
 }));
 
 import { arrow, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
-import { findTriggerElement, getElementPosition, hideOverlay, showOverlay } from '../../src/utils/overlay';
+import { ODS_OVERLAY_STRATEGY, findTriggerElement, getElementPosition, hideOverlay, showOverlay } from '../../src/utils/overlay';
 
 describe('utils overlay', () => {
   beforeEach(jest.clearAllMocks);
@@ -71,7 +71,7 @@ describe('utils overlay', () => {
       }).rejects.toThrow();
     });
 
-    it('should call computePosition with expected arguments', async() => {
+    it('should call computePosition with default arguments', async() => {
       const dummyDomElement = {
         popper: document.createElement('div'),
         trigger: document.createElement('div'),
@@ -80,6 +80,12 @@ describe('utils overlay', () => {
 
       await getElementPosition(dummyPosition, dummyDomElement);
 
+      expect(flip).toHaveBeenCalledTimes(1);
+      expect(flip).toHaveBeenCalledWith();
+      expect(offset).toHaveBeenCalledTimes(1);
+      expect(offset).toHaveBeenCalledWith(0);
+      expect(shift).toHaveBeenCalledTimes(1);
+      expect(shift).toHaveBeenCalledWith(undefined);
       expect(computePosition).toHaveBeenCalledTimes(1);
       expect(computePosition).toHaveBeenCalledWith(dummyDomElement.trigger, dummyDomElement.popper, {
         middleware: [
@@ -88,6 +94,39 @@ describe('utils overlay', () => {
           'shift middleware',
         ],
         placement: dummyPosition,
+        strategy: ODS_OVERLAY_STRATEGY.absolute,
+      });
+    });
+
+    it('should call computePosition with given options', async() => {
+      const dummyDomElement = {
+        popper: document.createElement('div'),
+        trigger: document.createElement('div'),
+      };
+      const dummyOption = {
+        offset: 42,
+        shift: { mainAxis: false },
+        strategy: ODS_OVERLAY_STRATEGY.fixed,
+      };
+      const dummyPosition = 'top';
+
+      await getElementPosition(dummyPosition, dummyDomElement, dummyOption);
+
+      expect(flip).toHaveBeenCalledTimes(1);
+      expect(flip).toHaveBeenCalledWith();
+      expect(offset).toHaveBeenCalledTimes(1);
+      expect(offset).toHaveBeenCalledWith(dummyOption.offset);
+      expect(shift).toHaveBeenCalledTimes(1);
+      expect(shift).toHaveBeenCalledWith(dummyOption.shift);
+      expect(computePosition).toHaveBeenCalledTimes(1);
+      expect(computePosition).toHaveBeenCalledWith(dummyDomElement.trigger, dummyDomElement.popper, {
+        middleware: [
+          'flip middleware',
+          'offset middleware',
+          'shift middleware',
+        ],
+        placement: dummyPosition,
+        strategy: dummyOption.strategy,
       });
     });
   });
@@ -172,6 +211,7 @@ describe('utils overlay', () => {
             'shift middleware',
           ],
           placement: dummyPosition,
+          strategy: ODS_OVERLAY_STRATEGY.absolute,
         });
         expect(flip).toHaveBeenCalled();
         expect(offset).toHaveBeenCalledWith(dummyOption.offset);
@@ -219,6 +259,7 @@ describe('utils overlay', () => {
             'arrow middleware',
           ],
           placement: dummyPosition,
+          strategy: ODS_OVERLAY_STRATEGY.absolute,
         });
         expect(arrow).toHaveBeenCalledWith({ element: dummyArrow });
         expect(flip).toHaveBeenCalled();

--- a/packages/storybook/stories/components/popover/popover.stories.ts
+++ b/packages/storybook/stories/components/popover/popover.stories.ts
@@ -108,6 +108,35 @@ export const Default: StoryObj = {
   `,
 };
 
+export const FixedContext: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-button id="modal-button"
+            label="Open Modal">
+</ods-button>
+<ods-modal id="modal-popover">
+  <ods-button id="modal-popover-trigger"
+              label="Open Popover">
+  </ods-button>
+  <ods-popover strategy="fixed"
+               trigger-id="modal-popover-trigger">
+    Some popover content
+  </ods-popover>
+</ods-modal>
+
+<script>
+  (() => {
+    const modalButton = document.querySelector('#modal-button');
+    const modalElement = document.querySelector('#modal-popover');
+
+    modalButton.addEventListener('click', () => {
+      modalElement.open();
+    });
+  })();
+</script>
+  `,
+};
+
 export const Overview: StoryObj = {
   tags: ['isHidden'],
   parameters: {

--- a/packages/storybook/stories/components/popover/technical-information.mdx
+++ b/packages/storybook/stories/components/popover/technical-information.mdx
@@ -81,3 +81,12 @@ The correct way would be:
 <Heading label="Popover as Action Menu" level={ 3 } />
 
 <Canvas of={ PopoverStories.Menu } sourceState="shown" />
+
+<Heading label="In an ods-modal" level={ 3 } />
+
+If the component container is defining a position context, the popover may not appear at the right place, or partially clipped.
+
+In that case, you can change the component `strategy` prop to `fixed`, this way it will position itself based on the
+nearest containing block (usually the viewport).
+
+<Canvas of={ PopoverStories.FixedContext } sourceState="shown" />

--- a/packages/storybook/stories/components/tooltip/technical-information.mdx
+++ b/packages/storybook/stories/components/tooltip/technical-information.mdx
@@ -32,3 +32,12 @@ Custom CSS:
 <Heading label="With an arrow tip" level={ 3 } />
 
 <Canvas of={ TooltipStories.ArrowTip } sourceState="shown" />
+
+<Heading label="In an ods-modal" level={ 3 } />
+
+If the component container is defining a position context, the tooltip may not appear at the right place, or partially clipped.
+
+In that case, you can change the component `strategy` prop to `fixed`, this way it will position itself based on the
+nearest containing block (usually the viewport).
+
+<Canvas of={ TooltipStories.FixedContext } sourceState="shown" />

--- a/packages/storybook/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/storybook/stories/components/tooltip/tooltip.stories.ts
@@ -123,3 +123,32 @@ export const CustomCSS: StoryObj = {
 </style>
   `,
 };
+
+export const FixedContext: StoryObj = {
+  tags: ['isHidden'],
+  render: () => html`
+<ods-button id="modal-button"
+            label="Open Modal">
+</ods-button>
+<ods-modal id="modal-tooltip">
+  <ods-icon id="modal-tooltip-trigger"
+            name="circle-question">
+  </ods-icon>
+  <ods-tooltip strategy="fixed"
+               trigger-id="modal-tooltip-trigger">
+    Some tooltip content
+  </ods-tooltip>
+</ods-modal>
+
+<script>
+  (() => {
+    const modalButton = document.querySelector('#modal-button');
+    const modalElement = document.querySelector('#modal-tooltip');
+
+    modalButton.addEventListener('click', () => {
+      modalElement.open();
+    });
+  })();
+</script>
+  `,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,29 +2584,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
+"@floating-ui/core@npm:^1.6.0":
+  version: 1.6.8
+  resolution: "@floating-ui/core@npm:1.6.8"
   dependencies:
-    "@floating-ui/utils": ^0.2.1
-  checksum: 2e25c53b0c124c5c9577972f8ae21d081f2f7895e6695836a53074463e8c65b47722744d6d2b5a993164936da006a268bcfe87fe68fd24dc235b1cb86bed3127
+    "@floating-ui/utils": ^0.2.8
+  checksum: 82faa6ea9d57e466779324e51308d6d49c098fb9d184a08d9bb7f4fad83f08cc070fc491f8d56f0cad44a16215fb43f9f829524288413e6c33afcb17303698de
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:1.6.3":
-  version: 1.6.3
-  resolution: "@floating-ui/dom@npm:1.6.3"
+"@floating-ui/dom@npm:1.6.11":
+  version: 1.6.11
+  resolution: "@floating-ui/dom@npm:1.6.11"
   dependencies:
-    "@floating-ui/core": ^1.0.0
-    "@floating-ui/utils": ^0.2.0
-  checksum: 81cbb18ece3afc37992f436e469e7fabab2e433248e46fff4302d12493a175b0c64310f8a971e6e1eda7218df28ace6b70237b0f3c22fe12a21bba05b5579555
+    "@floating-ui/core": ^1.6.0
+    "@floating-ui/utils": ^0.2.8
+  checksum: d6413759abd06a541edfad829c45313f930310fe76a3322e74a00eb655e283db33fe3e65b5265c4072eb54db7447e11225acd355a9a02cabd1d1b0d5fc8fc21d
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: 9ed4380653c7c217cd6f66ae51f20fdce433730dbc77f95b5abfb5a808f5fdb029c6ae249b4e0490a816f2453aa6e586d9a873cd157fdba4690f65628efc6e06
+"@floating-ui/utils@npm:^0.2.8":
+  version: 0.2.8
+  resolution: "@floating-ui/utils@npm:0.2.8"
+  checksum: deb98bba017c4e073c7ad5740d4dec33a4d3e0942d412e677ac0504f3dade15a68fc6fd164d43c93c0bb0bcc5dc5015c1f4080dfb1a6161140fe660624f7c875
   languageName: node
   linkType: hard
 
@@ -4341,7 +4341,7 @@ __metadata:
   resolution: "@ovhcloud/ods-components@workspace:packages/ods"
   dependencies:
     "@custom-elements-manifest/analyzer": 0.10.3
-    "@floating-ui/dom": 1.6.3
+    "@floating-ui/dom": 1.6.11
     "@jest/types": 29.6.3
     "@stencil-community/postcss": 2.2.0
     "@stencil/core": 4.16.0


### PR DESCRIPTION
- add a strategy prop to tooltip & popover
This fixes overlay not positioned correctly when set in an ods-modal

- wrap the modal content slot
This prevents slotted elements to be impacted by the flex container style. This was an issue for example when setting just an icon with a tooltip in the slot, the icon will be rendered on the right, but its width will actually be 100% (due to parent flex), so the tooltip will be positioned in the middle of the modal instead of top of the icon.