### PR TITLE
fix(config): allow lazy loading for bundle like vite

### DIFF
--- a/packages/ods/src/config/stencil.ts
+++ b/packages/ods/src/config/stencil.ts
@@ -25,6 +25,9 @@ function getStencilConfig({ args, componentCorePackage, devScript, jestOption = 
     devServer: {
       startupTimeout: 30000,
     },
+    extras: {
+      enableImportInjection: true,
+    },
     namespace,
     outputTargets: [
       {


### PR DESCRIPTION
On the vanilla playground I can't make the application work with a production build. Because the component can't be lazy load by Vite.

Test on react playground, vanilla playground (with npm link on build) and on the example apps

Stencil docs: https://stenciljs.com/docs/config-extras#enableimportinjection