### PR TITLE
fix(switch): use separate command to run e2e tests on CI

### DIFF
--- a/packages/ods/src/components/switch/package.json
+++ b/packages/ods/src/components/switch/package.json
@@ -12,7 +12,8 @@
     "lint:ts": "eslint '{src,tests}/**/*.{js,ts,tsx}'",
     "start": "stencil build --dev --watch --serve",
     "test:e2e": "stencil test --e2e --config stencil.config.ts",
-    "test:e2e:ci": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
+    "test:e2e:ci": "echo \"FIXME e2e suites randomly fails on CI when run amongst other components e2e suites\"",
+    "test:e2e:switch": "tsc --noEmit && stencil test --e2e --ci --runInBand --config stencil.config.ts",
     "test:spec": "stencil test --spec --config stencil.config.ts --coverage",
     "test:spec:ci": "tsc --noEmit && stencil test --config stencil.config.ts  --spec --ci"
   }


### PR DESCRIPTION
Small hack to separate switch test suites from the global one as it fails randomly when run with the rest.
CI pipeline has been updated to run `test:e2e:switch` after `test:e2e:ci`