### PR TITLE
fix(quantity): error state & double deletions for emptying input

### DIFF
--- a/packages/ods/src/components/quantity/src/components/ods-quantity/ods-quantity.tsx
+++ b/packages/ods/src/components/quantity/src/components/ods-quantity/ods-quantity.tsx
@@ -115,7 +115,6 @@ export class OdsQuantity {
     }
     const step = this.step || 1;
     this.value = this.value !== null ? Number(this.value) - step : 0;
-    this.shouldUpdateIsInvalidState = true;
   }
 
   private async increment(): Promise<void> {
@@ -124,15 +123,15 @@ export class OdsQuantity {
     }
     const step = this.step || 1;
     this.value = this.value !== null ? Number(this.value) + step : 0;
-    this.shouldUpdateIsInvalidState = true;
   }
 
-  private onOdsBlur(): void {
+  private async onOdsBlur(): Promise<void> {
+    await this.odsInput?.checkValidity();
     this.isInvalid = !this.internals.validity.valid;
   }
 
   private async onOdsChange(event: OdsInputChangeEvent): Promise<void> {
-    if (event.detail.value === null) {
+    if (event.detail.value === null || event.detail.value === '') {
       this.value = null;
     } else {
       this.value = Number(event.detail.value) ?? null;
@@ -143,7 +142,7 @@ export class OdsQuantity {
     // In case the value gets updated from an other source than a blur event
     // we may have to perform an internal validity state update
     if (this.shouldUpdateIsInvalidState) {
-      await this.odsInput?.reportValidity();
+      await this.odsInput?.checkValidity();
       this.isInvalid = !this.internals.validity.valid;
     }
   }
@@ -170,6 +169,7 @@ export class OdsQuantity {
           isDisabled={ isMinusButtonDisabled(this.isDisabled, this.isReadonly, this.value, this.min) }
           icon={ ODS_ICON_NAME.minus }
           label=""
+          onBlur={ () => this.onOdsBlur() }
           onClick={ () => this.decrement() }
           size={ ODS_BUTTON_SIZE.sm }
           variant={ ODS_BUTTON_VARIANT.outline }>
@@ -206,6 +206,7 @@ export class OdsQuantity {
           isDisabled={ isPlusButtonDisabled(this.isDisabled, this.isReadonly, this.value, this.max) }
           icon={ ODS_ICON_NAME.plus }
           label=""
+          onBlur={ () => this.onOdsBlur() }
           onClick={ () => this.increment() }
           size={ ODS_BUTTON_SIZE.sm }
           variant={ ODS_BUTTON_VARIANT.outline }>

--- a/packages/ods/src/components/quantity/tests/navigation/ods-quantity.e2e.ts
+++ b/packages/ods/src/components/quantity/tests/navigation/ods-quantity.e2e.ts
@@ -1,6 +1,8 @@
-import { type E2EPage, newE2EPage } from '@stencil/core/testing';
+import { type E2EElement, type E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('ods-quantity navigation', () => {
+  let el: E2EElement;
+  let input: E2EElement;
   let page: E2EPage;
 
   async function isFocused(): Promise<boolean> {
@@ -21,6 +23,9 @@ describe('ods-quantity navigation', () => {
 
     await page.setContent(content);
     await page.evaluate(() => document.body.style.setProperty('margin', '0px'));
+
+    el = await page.find('ods-quantity');
+    input = await page.find('ods-quantity >>> .ods-quantity__input');
   }
 
   describe('focus', () => {
@@ -75,6 +80,20 @@ describe('ods-quantity navigation', () => {
       const lastFocusedElement = await odsQuantityFocusedElementTagName();
       expect(lastFocusedElement).not.toBe('ODS-BUTTON');
       expect(lastFocusedElement).not.toBe('ODS-INPUT');
+    });
+  });
+
+  describe('deletions', () => {
+    it('should emptying input in one delete', async() => {
+      await setup('<ods-quantity value="1"></ods-quantity>');
+
+      expect(await el.getProperty('value')).toBe(1);
+
+      await input.focus();
+      await page.keyboard.press('Backspace');
+      await page.waitForChanges();
+
+      expect(await el.getProperty('value')).toBeNull();
     });
   });
 });

--- a/packages/ods/src/components/quantity/tests/rendering/ods-quantity.e2e.ts
+++ b/packages/ods/src/components/quantity/tests/rendering/ods-quantity.e2e.ts
@@ -155,5 +155,25 @@ describe('ods-quantity rendering', () => {
 
       expect(await isInErrorState()).toBe(false);
     });
+
+    it('should update error state on plus button', async() => {
+      await setup(`<form method="get">
+        <ods-quantity is-required name="odsQuantity"></ods-quantity>
+      </form>`);
+      expect(await isInErrorState()).toBe(false);
+
+      await page.evaluate(() => {
+        document.querySelector<HTMLFormElement>('form')?.requestSubmit();
+      });
+      await page.waitForChanges();
+      expect(await isInErrorState()).toBe(true);
+
+      await buttonAdd.click();
+      expect(await isInErrorState()).toBe(true);
+
+      await input.focus(); // Blur
+
+      expect(await isInErrorState()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Update error state on blur with the increment & decrement button
One deletions is required for emptying the input instead of 2