### PR TITLE
fix(doc): prevent heading spacing with hidden elements

### DIFF
--- a/packages/storybook/src/components/heading/heading.module.css
+++ b/packages/storybook/src/components/heading/heading.module.css
@@ -6,7 +6,6 @@
 .heading-6 {
   display: flex;
   flex-flow: row;
-  column-gap: .5rem;
   align-items: center;
   margin-bottom: 0;
   color: var(--ods-color-primary-800);

--- a/packages/storybook/src/components/technicalSpecification/classModule.module.css
+++ b/packages/storybook/src/components/technicalSpecification/classModule.module.css
@@ -17,6 +17,7 @@
 
 .class-module__event-title-link,
 .class-module__method-title-link {
+  margin-left: .5rem;
   font-size: 12px;
 }
 


### PR DESCRIPTION
Latest changes did mess up with alignement.
<img width="882" alt="Capture d’écran 2025-01-20 à 11 01 07" src="https://github.com/user-attachments/assets/0e9dd0d9-fa88-4a9f-a97f-64d952151e85" />

This fix back to:
<img width="807" alt="Capture d’écran 2025-01-20 à 11 00 36" src="https://github.com/user-attachments/assets/f636f56b-c5b8-4146-a9e2-636857ed59e6" />

