### PR TITLE
Doc demo controls

### DIFF
--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -3,7 +3,6 @@ import type { StorybookConfig } from '@storybook/web-components-vite';
 const config: StorybookConfig = {
   addons: [
     '@storybook/addon-controls',
-    '@storybook/addon-a11y',
     '@storybook/addon-links',
     {
       name: '@storybook/addon-essentials',

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -15,7 +15,6 @@
     "react": "18.2.0"
   },
   "devDependencies": {
-    "@storybook/addon-a11y": "8.0.4",
     "@storybook/addon-essentials": "8.0.4",
     "@storybook/addon-links": "8.0.4",
     "@storybook/blocks": "8.0.4",

--- a/packages/storybook/stories/components/accordion/accordion.stories.ts
+++ b/packages/storybook/stories/components/accordion/accordion.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-accordion';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Accordion',

--- a/packages/storybook/stories/components/badge/badge.stories.ts
+++ b/packages/storybook/stories/components/badge/badge.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_ICON_NAMES, ODS_BADGE_COLOR, ODS_BADGE_COLORS, ODS_BADGE_SIZE, ODS_BADGE_SIZES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-badge';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Badge',

--- a/packages/storybook/stories/components/breadcrumb/breadcrumb.stories.ts
+++ b/packages/storybook/stories/components/breadcrumb/breadcrumb.stories.ts
@@ -1,8 +1,13 @@
+import { defineCustomElement as defineBreadcrumb } from '@ovhcloud/ods-components/dist/components/ods-breadcrumb';
+import { defineCustomElement as defineBreadcrumbItem } from '@ovhcloud/ods-components/dist/components/ods-breadcrumb-item';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineBreadcrumb();
+defineBreadcrumbItem();
 
 const meta: Meta = {
   title: 'ODS Components/Breadcrumb',

--- a/packages/storybook/stories/components/button/button.stories.ts
+++ b/packages/storybook/stories/components/button/button.stories.ts
@@ -1,4 +1,3 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import {
   ODS_BUTTON_COLOR,
   ODS_BUTTON_COLORS,
@@ -11,9 +10,13 @@ import {
   ODS_ICON_NAME,
   ODS_ICON_NAMES,
 } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-button';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Button',

--- a/packages/storybook/stories/components/card/card.stories.ts
+++ b/packages/storybook/stories/components/card/card.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_CARD_COLOR, ODS_CARD_COLORS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-card';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Card',

--- a/packages/storybook/stories/components/checkbox/checkbox.stories.ts
+++ b/packages/storybook/stories/components/checkbox/checkbox.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-checkbox';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Checkbox',

--- a/packages/storybook/stories/components/clipboard/clipboard.stories.ts
+++ b/packages/storybook/stories/components/clipboard/clipboard.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-clipboard';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Clipboard',

--- a/packages/storybook/stories/components/code/code.stories.ts
+++ b/packages/storybook/stories/components/code/code.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-code';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Code',

--- a/packages/storybook/stories/components/datepicker/datepicker.stories.ts
+++ b/packages/storybook/stories/components/datepicker/datepicker.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_DATEPICKER_LOCALE, ODS_DATEPICKER_LOCALES, formatDate } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-datepicker';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Datepicker',

--- a/packages/storybook/stories/components/divider/divider.stories.ts
+++ b/packages/storybook/stories/components/divider/divider.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_DIVIDER_COLOR, ODS_DIVIDER_COLORS, ODS_DIVIDER_SPACING, ODS_DIVIDER_SPACINGS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-divider';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Divider',

--- a/packages/storybook/stories/components/drawer/drawer.stories.ts
+++ b/packages/storybook/stories/components/drawer/drawer.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_DRAWER_POSITION, ODS_DRAWER_POSITIONS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-drawer';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Drawer',

--- a/packages/storybook/stories/components/file-upload/file-upload.stories.ts
+++ b/packages/storybook/stories/components/file-upload/file-upload.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-file-upload';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/File Upload',

--- a/packages/storybook/stories/components/form-field/form-field.stories.ts
+++ b/packages/storybook/stories/components/form-field/form-field.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-form-field';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Form Field',

--- a/packages/storybook/stories/components/icon/icon.stories.ts
+++ b/packages/storybook/stories/components/icon/icon.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_ICON_NAME, ODS_ICON_NAMES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-icon';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 type IconNameKey = keyof typeof ODS_ICON_NAME;
 

--- a/packages/storybook/stories/components/input/input.stories.ts
+++ b/packages/storybook/stories/components/input/input.stories.ts
@@ -1,10 +1,13 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_INPUT_TYPE, ODS_INPUT_TYPES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-input';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { html, nothing } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Input',

--- a/packages/storybook/stories/components/link/link.stories.ts
+++ b/packages/storybook/stories/components/link/link.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
-import { html } from 'lit-html';
 import { ODS_ICON_NAMES, ODS_LINK_COLOR, ODS_LINK_COLORS, ODS_LINK_ICON_ALIGNMENT, ODS_LINK_ICON_ALIGNMENTS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-link';
+import { type Meta, type StoryObj } from '@storybook/web-components';
+import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Link',

--- a/packages/storybook/stories/components/medium/medium.stories.ts
+++ b/packages/storybook/stories/components/medium/medium.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-medium';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Medium',

--- a/packages/storybook/stories/components/message/message.stories.ts
+++ b/packages/storybook/stories/components/message/message.stories.ts
@@ -1,14 +1,17 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import {
   ODS_MESSAGE_COLOR,
   ODS_MESSAGE_COLORS,
   ODS_MESSAGE_VARIANT,
   ODS_MESSAGE_VARIANTS,
 } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-message';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Message',

--- a/packages/storybook/stories/components/modal/modal.stories.ts
+++ b/packages/storybook/stories/components/modal/modal.stories.ts
@@ -1,10 +1,13 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_MODAL_COLOR, ODS_MODAL_COLORS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-modal';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
 import { withResetRoot } from '../../../src/hooks/withResetRoot';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Modal',

--- a/packages/storybook/stories/components/pagination/pagination.stories.ts
+++ b/packages/storybook/stories/components/pagination/pagination.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_PAGINATION_PER_PAGE, ODS_PAGINATION_PER_PAGE_OPTIONS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-pagination';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Pagination',

--- a/packages/storybook/stories/components/password/password.stories.ts
+++ b/packages/storybook/stories/components/password/password.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-password';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Password',

--- a/packages/storybook/stories/components/phone-number/phone-number.stories.ts
+++ b/packages/storybook/stories/components/phone-number/phone-number.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_PHONE_NUMBER_COUNTRY_ISO_CODES, ODS_PHONE_NUMBER_LOCALES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-phone-number';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Phone Number',

--- a/packages/storybook/stories/components/popover/popover.stories.ts
+++ b/packages/storybook/stories/components/popover/popover.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_POPOVER_POSITION, ODS_POPOVER_POSITIONS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-popover';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Popover',

--- a/packages/storybook/stories/components/progress-bar/progress-bar.stories.ts
+++ b/packages/storybook/stories/components/progress-bar/progress-bar.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-progress-bar';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Progress Bar',

--- a/packages/storybook/stories/components/quantity/quantity.stories.ts
+++ b/packages/storybook/stories/components/quantity/quantity.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-quantity';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Quantity',

--- a/packages/storybook/stories/components/radio/radio.stories.ts
+++ b/packages/storybook/stories/components/radio/radio.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-radio';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   component: 'ods-radio',

--- a/packages/storybook/stories/components/range/range.stories.ts
+++ b/packages/storybook/stories/components/range/range.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-range';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   component: 'ods-range',

--- a/packages/storybook/stories/components/select/select.stories.ts
+++ b/packages/storybook/stories/components/select/select.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-select';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Select',

--- a/packages/storybook/stories/components/skeleton/skeleton.stories.ts
+++ b/packages/storybook/stories/components/skeleton/skeleton.stories.ts
@@ -1,7 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-skeleton';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Skeleton',

--- a/packages/storybook/stories/components/spinner/spinner.stories.ts
+++ b/packages/storybook/stories/components/spinner/spinner.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_SPINNER_COLOR, ODS_SPINNER_COLORS, ODS_SPINNER_SIZE, ODS_SPINNER_SIZES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-spinner';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Spinner',

--- a/packages/storybook/stories/components/switch/switch.stories.ts
+++ b/packages/storybook/stories/components/switch/switch.stories.ts
@@ -1,9 +1,14 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_SWITCH_SIZE, ODS_SWITCH_SIZES } from '@ovhcloud/ods-components';
+import { defineCustomElement as defineSwitch } from '@ovhcloud/ods-components/dist/components/ods-switch';
+import { defineCustomElement as defineSwitchItem } from '@ovhcloud/ods-components/dist/components/ods-switch-item';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineSwitch();
+defineSwitchItem();
 
 const meta: Meta = {
   component: 'ods-switch',

--- a/packages/storybook/stories/components/table/table.stories.ts
+++ b/packages/storybook/stories/components/table/table.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_TABLE_SIZE, ODS_TABLE_SIZES, ODS_TABLE_VARIANT, ODS_TABLE_VARIANTS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-table';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Table',

--- a/packages/storybook/stories/components/tabs/tabs.stories.ts
+++ b/packages/storybook/stories/components/tabs/tabs.stories.ts
@@ -1,8 +1,13 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement as defineTab } from '@ovhcloud/ods-components/dist/components/ods-tab';
+import { defineCustomElement as defineTabs } from '@ovhcloud/ods-components/dist/components/ods-tabs';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineTab();
+defineTabs();
 
 const meta: Meta = {
   title: 'ODS Components/Tabs',

--- a/packages/storybook/stories/components/tag/tag.stories.ts
+++ b/packages/storybook/stories/components/tag/tag.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_ICON_NAMES, ODS_TAG_COLOR, ODS_TAG_COLORS, ODS_TAG_SIZE, ODS_TAG_SIZES } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-tag';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Tag',

--- a/packages/storybook/stories/components/text/text.stories.ts
+++ b/packages/storybook/stories/components/text/text.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_TEXT_PRESET, ODS_TEXT_PRESETS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-text';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Text',

--- a/packages/storybook/stories/components/textarea/textarea.stories.ts
+++ b/packages/storybook/stories/components/textarea/textarea.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-textarea';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Textarea',

--- a/packages/storybook/stories/components/timepicker/timepicker.stories.ts
+++ b/packages/storybook/stories/components/timepicker/timepicker.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-timepicker';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   component: 'ods-timepicker',

--- a/packages/storybook/stories/components/toggle/toggle.stories.ts
+++ b/packages/storybook/stories/components/toggle/toggle.stories.ts
@@ -1,8 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-toggle';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { ValidityStateTemplate } from '../../../src/components/validityState/validityState';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Form elements/Toggle',

--- a/packages/storybook/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/storybook/stories/components/tooltip/tooltip.stories.ts
@@ -1,9 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
 import { ODS_TOOLTIP_POSITION, ODS_TOOLTIP_POSITIONS } from '@ovhcloud/ods-components';
+import { defineCustomElement } from '@ovhcloud/ods-components/dist/components/ods-tooltip';
+import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { CONTROL_CATEGORY } from '../../../src/constants/controls';
 import { orderControls } from '../../../src/helpers/controls';
+
+defineCustomElement();
 
 const meta: Meta = {
   title: 'ODS Components/Tooltip',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4404,7 +4404,6 @@ __metadata:
   resolution: "@ovhcloud/ods-storybook@workspace:packages/storybook"
   dependencies:
     "@ovhcloud/ods-components": 18.5.0
-    "@storybook/addon-a11y": 8.0.4
     "@storybook/addon-essentials": 8.0.4
     "@storybook/addon-links": 8.0.4
     "@storybook/blocks": 8.0.4
@@ -4728,16 +4727,6 @@ __metadata:
   peerDependencies:
     "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
   checksum: bcee6b0603d13d305be458205b3774213064e01a691c7fd3616ccf810b6fefa4d22be1324410b359e298a4eec15859fce03b44a0c09ece4f545c4b56a0ef9115
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-a11y@npm:8.0.4":
-  version: 8.0.4
-  resolution: "@storybook/addon-a11y@npm:8.0.4"
-  dependencies:
-    "@storybook/addon-highlight": 8.0.4
-    axe-core: ^4.2.0
-  checksum: c4f26264c9e11873487b1881de1f935c00d69e8c96a76fab0195bfcdec4bbf08d4a0313648038355d108776b72b8b94bb159636706e061cbe942390396ff8868
   languageName: node
   linkType: hard
 
@@ -7596,13 +7585,6 @@ __metadata:
   version: 4.7.0
   resolution: "axe-core@npm:4.7.0"
   checksum: f086bcab42be1761ba2b0b127dec350087f4c3a853bba8dd58f69d898cefaac31a1561da23146f6f3c07954c76171d1f2ce460e555e052d2b02cd79af628fa4a
-  languageName: node
-  linkType: hard
-
-"axe-core@npm:^4.2.0":
-  version: 4.10.2
-  resolution: "axe-core@npm:4.10.2"
-  checksum: 2b9b1c93ea73ea9f206604e4e17bd771d2d835f077bde54517d73028b8865c69b209460e73d5b109968cbdb39ab3d28943efa5695189bd79e16421ce1706719e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- remove the a11y tab on Demo pages as it was giving wrong information (as Demo are custom made and not valid use case)
- put back components define call in stories to fix "Open in canvs" toolbar action (https://github.com/ovh/design-system/issues/689)