### PR TITLE
fix(link): enforce baseline on empty text

### DIFF
--- a/packages/ods-react/src/components/link/src/components/link/Link.tsx
+++ b/packages/ods-react/src/components/link/src/components/link/Link.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import { type ComponentPropsWithRef, type ElementType, type ForwardedRef, type JSX, type MouseEvent, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type ElementType, type ForwardedRef, type JSX, type MouseEvent, forwardRef, useMemo } from 'react';
+import { getElementText } from '../../../../../utils/element';
 import { LINK_COLOR, type LinkColor } from '../../constant/link-color';
 import style from './link.module.scss';
 
@@ -17,6 +18,11 @@ const Link = forwardRef(function Link<T extends ElementType>({
   ...props
 }: LinkProp<T> & Omit<ComponentPropsWithRef<T>, keyof LinkProp<T>>, ref: ForwardedRef<HTMLAnchorElement>): JSX.Element {
   const Component = as || 'a';
+  const { children, ...linkProps } = props;
+
+  const hasNoText = useMemo(() => {
+    return getElementText(children) === '';
+  }, [children]);
 
   function onClick(event: MouseEvent): void {
     if (disabled) {
@@ -31,12 +37,17 @@ const Link = forwardRef(function Link<T extends ElementType>({
         style['link'],
         style[`link--${color}`],
         { [style['link--disabled']]: disabled },
+        { [style['link--no-text']]: hasNoText },
         className,
       )}
       ref={ ref }
-      { ...props }
+      { ...linkProps }
       onClick={ onClick }
-      tabIndex={ disabled ? -1 : props.tabIndex } />
+      tabIndex={ disabled ? -1 : linkProps.tabIndex }>
+      {/* If there is no text content, we add a zero-width space to simulate the correct baseline */}
+      { hasNoText && <span>&#8203;</span> }
+      { props.children }
+    </Component>
   );
 });
 

--- a/packages/ods-react/src/components/link/src/components/link/link.module.scss
+++ b/packages/ods-react/src/components/link/src/components/link/link.module.scss
@@ -7,6 +7,10 @@
 
     @include link.ods-link();
 
+    &--no-text {
+      gap: 0;
+    }
+
     &--primary {
       @include link.ods-link-color('primary');
 

--- a/packages/ods-react/src/components/link/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/link/src/dev.stories.tsx
@@ -41,11 +41,19 @@ export const Disabled = () => (
 );
 
 export const IconOnly = () => (
-  <Link
-    href="http://google.com"
-    target="_blank">
-    <Icon name={ ICON_NAME.home } />
-  </Link>
+  <>
+    <Link
+      href="http://google.com"
+      target="_blank">
+      <Icon name={ ICON_NAME.home } />
+    </Link>
+    <br />
+    <Link
+      href="http://google.com"
+      target="_blank">
+      <Icon name={ ICON_NAME.arrowCrossed } />
+    </Link>
+  </>
 );
 
 export const Icons = () => (
@@ -54,6 +62,12 @@ export const Icons = () => (
       href="http://google.com"
       target="_blank">
       <Icon name={ ICON_NAME.arrowLeft } /> My link
+    </Link>
+    <br />
+    <Link
+      href="http://google.com"
+      target="_blank">
+      <Icon name={ ICON_NAME.home } /> My link
     </Link>
     <br />
     <Link

--- a/packages/ods-react/src/utils/element.ts
+++ b/packages/ods-react/src/utils/element.ts
@@ -1,9 +1,47 @@
 import { Children, type ReactElement, type ReactNode, isValidElement } from 'react';
 
-function getValidChildren(children: ReactNode): ReactElement[] {
-  return Children.toArray(children).filter(isValidElement);
+function elementToString(element: ReactNode): string {
+  if (typeof element === 'undefined' || element === null || typeof element === 'boolean') {
+    return '';
+  }
+
+  if (JSON.stringify(element) === '{}') {
+    return '';
+  }
+
+  return element.toString();
+}
+
+// Inspired by https://github.com/fernandopasik/react-children-utilities/blob/main/src/lib/onlyText.ts
+function getElementText(element: ReactNode | ReactNode[]): string {
+  if (!(element instanceof Array) && !isValidElement(element)) {
+    return elementToString(element);
+  }
+
+  return Children.toArray(element).reduce<string>((text, child: ReactNode) => {
+    let newText = '';
+
+    if (hasChildren(child)) {
+      newText = getElementText((child as ReactElement<{ children: ReactNode | ReactNode[] }>).props.children);
+    } else if (isValidElement(child)) {
+      newText = '';
+    } else {
+      newText = elementToString(child);
+    }
+
+    return text.concat(newText);
+  }, '');
+}
+
+function getValidChildren(element: ReactNode): ReactElement[] {
+  return Children.toArray(element).filter(isValidElement);
+}
+
+function hasChildren(element: ReactNode): boolean {
+  return isValidElement(element) && !!element.props.children;
 }
 
 export {
+  getElementText,
   getValidChildren,
 };


### PR DESCRIPTION
This prevents the issue of having the link underline displayed without spacing at the bottom of an icon (when the icon is alone), like:
```
<Link ...>
  <Icon name="home" />
</LInk>
```
