### PR TITLE
refactor(spinner): use span instead of div

### DIFF
--- a/packages/ods-react/src/components/button/src/components/button/Button.tsx
+++ b/packages/ods-react/src/components/button/src/components/button/Button.tsx
@@ -37,11 +37,11 @@ const Button: FC<ButtonProp> = forwardRef(({
       type={ props.type || 'button' }>
       {
         isLoading &&
-        <div className={ style['button__spinner'] }>
+        <span className={ style['button__spinner'] }>
           <Spinner
             color={ SPINNER_COLOR.neutral }
             size={ size === BUTTON_SIZE.xs ? SPINNER_SIZE.xs : SPINNER_SIZE.sm } />
-        </div>
+        </span>
       }
 
       { children }

--- a/packages/ods-react/src/components/spinner/src/components/spinner/Spinner.tsx
+++ b/packages/ods-react/src/components/spinner/src/components/spinner/Spinner.tsx
@@ -4,7 +4,7 @@ import { SPINNER_COLOR, type SpinnerColor } from '../../constants/spinner-color'
 import { SPINNER_SIZE, type SpinnerSize } from '../../constants/spinner-size';
 import style from './spinner.module.scss';
 
-interface SpinnerProp extends ComponentPropsWithRef<'div'> {
+interface SpinnerProp extends ComponentPropsWithRef<'span'> {
   color?: SpinnerColor,
   size?: SpinnerSize,
 }
@@ -16,7 +16,7 @@ const Spinner: FC<SpinnerProp> = forwardRef(({
   ...props
 }, ref): JSX.Element => {
   return (
-    <div
+    <span
       className={ classNames(
         style['spinner'],
         style[`spinner--${color}`],
@@ -27,6 +27,7 @@ const Spinner: FC<SpinnerProp> = forwardRef(({
       role="progressbar"
       { ...props }>
       <svg
+        className={ style['spinner__svg'] }
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg">
         <rect
@@ -52,7 +53,7 @@ const Spinner: FC<SpinnerProp> = forwardRef(({
             transform="translate(238.694 104.932)" />
         </g>
       </svg>
-    </div>
+    </span>
   );
 });
 

--- a/packages/ods-react/src/components/spinner/src/components/spinner/spinner.module.scss
+++ b/packages/ods-react/src/components/spinner/src/components/spinner/spinner.module.scss
@@ -46,7 +46,7 @@ $spinner-size-lg: 80px;
       fill: var(--ods-color-primary-000);
     }
 
-    > svg {
+    &__svg {
       height: 100%;
       animation: rotate 0.8s infinite linear;
     }


### PR DESCRIPTION
Fix semantic issue when used inside `button`