### PR TITLE
feat(select): add fitControlWidth prop

### DIFF
--- a/packages/ods-react/src/components/select/src/components/select/Select.tsx
+++ b/packages/ods-react/src/components/select/src/components/select/Select.tsx
@@ -11,6 +11,7 @@ interface SelectValueChangeDetail {
 interface SelectProp extends ComponentPropsWithRef<'div'> {
   defaultValue?: string | string[],
   disabled?: boolean,
+  fitControlWidth?: boolean,
   items: SelectItem[],
   invalid?: boolean,
   multiple?: SelectMultipleMode,
@@ -26,6 +27,7 @@ const Select: FC<SelectProp> = forwardRef(({
   className,
   defaultValue,
   disabled = false,
+  fitControlWidth = true,
   items = [],
   invalid,
   multiple = false,
@@ -71,7 +73,7 @@ const Select: FC<SelectProp> = forwardRef(({
         onValueChange={ onValueChange }
         positioning={{
           gutter: -1,
-          sameWidth: true,
+          sameWidth: fitControlWidth,
         }}
         readOnly={ readOnly }
         ref={ ref }

--- a/packages/ods-react/src/components/select/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/select/src/dev.stories.tsx
@@ -174,6 +174,23 @@ export const Default = () => (
   </Select>
 );
 
+export const DifferentWidth = () => (
+  <Select
+    fitControlWidth={ false }
+    items={[
+      { label: 'Dog', value:'dog' },
+      { label: 'Cat', value:'cat' },
+      { label: 'Hamster', value:'hamster' },
+      { label: 'Parrot', value:'parrot' },
+      { label: 'Spider', value:'spider' },
+      { label: 'Goldfish', value:'goldfish' },
+    ]}>
+    <SelectLabel>Label</SelectLabel>
+    <SelectControl />
+    <SelectContent />
+  </Select>
+);
+
 export const Disabled = () => (
   <Select
     disabled

--- a/packages/storybook/stories/components/select/select.stories.tsx
+++ b/packages/storybook/stories/components/select/select.stories.tsx
@@ -22,6 +22,7 @@ export const Demo: StoryObj = {
   render: (arg: DemoArg) => (
     <Select
       disabled={ arg.disabled }
+      fitControlWidth={ arg.fitControlWidth }
       invalid={ arg.invalid }
       items={[
         { label: 'Dog', value:'dog' },
@@ -42,6 +43,12 @@ export const Demo: StoryObj = {
   ),
   argTypes: orderControls({
     disabled: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+      },
+      control: { type: 'boolean' },
+    },
+    fitControlWidth: {
       table: {
         category: CONTROL_CATEGORY.general,
       },


### PR DESCRIPTION
Useful for example for the phone-number flag select, where the control is smaller than the content.