### PR TITLE
fix(font-face): variable weight declaration

### DIFF
--- a/packages/themes/src/helpers/_fonts.scss
+++ b/packages/themes/src/helpers/_fonts.scss
@@ -12,6 +12,7 @@
   @font-face {
     font-family: 'Source Code Pro';
     font-stretch: normal;
+    font-weight: 200 900;
     font-style: normal;
     font-display: fallback;
     src: $src format('woff2');
@@ -22,6 +23,7 @@
   @font-face {
     font-family: 'Source Code Pro';
     font-stretch: normal;
+    font-weight: 200 900;
     font-style: italic;
     font-display: fallback;
     src: $src format('woff2');
@@ -32,6 +34,7 @@
   @font-face {
     font-family: 'Source Sans Pro';
     font-stretch: normal;
+    font-weight: 200 900;
     font-style: normal;
     font-display: fallback;
     src: $src format('woff2');
@@ -42,6 +45,7 @@
   @font-face {
     font-family: 'Source Sans Pro';
     font-stretch: normal;
+    font-weight: 200 900;
     font-style: italic;
     font-display: fallback;
     src: $src format('woff2');


### PR DESCRIPTION
Safari is not able to guess the variable aspect of a font without an explicit declaration of a range.

<img width="378" height="204" alt="image" src="https://github.com/user-attachments/assets/ea8ad603-5914-4819-afed-4fe073d0d2d6" />


Hence the browser trying to (badly) simulate weight