### PR TITLE
fix(accordion): allow trigger text to be selected

### DIFF
--- a/packages/ods-react/src/components/accordion/src/components/accordion-trigger/accordionTrigger.module.scss
+++ b/packages/ods-react/src/components/accordion/src/components/accordion-trigger/accordionTrigger.module.scss
@@ -15,6 +15,7 @@
     color: inherit;
     font-family: inherit;
     font-size: inherit;
+    user-select: text;
 
     &:disabled {
       cursor: inherit;


### PR DESCRIPTION
Behavior is a bit different on Safari as it allows selection of button content only if the selection drag starts from an actual text element (for example, it you select the accordion content and the trigger)