### PR TITLE
Overlay component improvements

### DIFF
--- a/packages/ods-react/src/components/code/src/components/code/Code.tsx
+++ b/packages/ods-react/src/components/code/src/components/code/Code.tsx
@@ -21,7 +21,13 @@ interface CodeProp extends ComponentPropsWithRef<'div'> {
    * Configuration of a specific code highlighter (see beneath for more details).
    */
   highlighter?: {
+    /**
+     * The programming language displayed.
+     */
     language: LanguageRegistration[],
+    /**
+     * The theme to apply to the code.
+     */
     theme: ThemeRegistrationAny,
   },
   /**

--- a/packages/ods-react/src/components/combobox/src/components/combobox-content/ComboboxContent.tsx
+++ b/packages/ods-react/src/components/combobox/src/components/combobox-content/ComboboxContent.tsx
@@ -28,6 +28,7 @@ const ComboboxContent: FC<ComboboxContentProp> = forwardRef(({
     isOpen,
     invalid,
     noResultLabel,
+    overlayConfig,
     setContentId,
     setContentPosition,
   } = useCombobox();
@@ -45,11 +46,14 @@ const ComboboxContent: FC<ComboboxContentProp> = forwardRef(({
   return (
     <Popover
       autoFocus={ false }
-      gutter={ -1 }
       onPositionChange={ handlePositionChange }
       open={ isOpen }
-      position={ POPOVER_POSITION.bottom }
-      sameWidth={ true }
+      overlayConfig={{
+        gutter: -1,
+        position: POPOVER_POSITION.bottom,
+        sameWidth: true,
+        ...overlayConfig,
+      }}
       triggerId={ controlId }>
       <PopoverContent
         className={ classNames(

--- a/packages/ods-react/src/components/combobox/src/components/combobox/Combobox.tsx
+++ b/packages/ods-react/src/components/combobox/src/components/combobox/Combobox.tsx
@@ -10,6 +10,7 @@ const Combobox: FC<ComboboxProp> = forwardRef(({
   className,
   customFilter,
   customOptionRenderer,
+  defaultOpen,
   defaultValue,
   disabled,
   highlightResults = false,
@@ -22,7 +23,10 @@ const Combobox: FC<ComboboxProp> = forwardRef(({
   newElementLabel = 'Add ',
   noResultLabel = 'No results found',
   onInputValueChange,
+  onOpenChange,
   onValueChange,
+  open,
+  overlayConfig,
   readOnly,
   required,
   value,
@@ -36,6 +40,7 @@ const Combobox: FC<ComboboxProp> = forwardRef(({
       allowCustomValue={ allowCustomValue }
       customFilter={ customFilter }
       customOptionRenderer={ customOptionRenderer }
+      defaultOpen={ defaultOpen }
       defaultValue={ defaultValue }
       disabled={ disabled }
       highlightResults={ highlightResults }
@@ -48,7 +53,10 @@ const Combobox: FC<ComboboxProp> = forwardRef(({
       newElementLabel={ newElementLabel }
       noResultLabel={ noResultLabel }
       onInputValueChange={ onInputValueChange }
+      onOpenChange={ onOpenChange }
       onValueChange={ onValueChange }
+      open={ open }
+      overlayConfig={ overlayConfig }
       readOnly={ readOnly }
       required={ required }
       value={ value }>

--- a/packages/ods-react/src/components/combobox/src/contexts/useCombobox.tsx
+++ b/packages/ods-react/src/components/combobox/src/contexts/useCombobox.tsx
@@ -10,6 +10,10 @@ interface ComboboxInputValueChangeDetails {
   inputValue: string;
 }
 
+interface ComboboxOpenChangeDetail {
+  open: boolean,
+}
+
 interface ComboboxValueChangeDetails {
   value: string[];
 }
@@ -46,6 +50,10 @@ type ComboboxRootProp = Omit<ComponentPropsWithRef<'div'>, 'defaultValue' | 'onS
    * Custom render for each option item.
    */
   customOptionRenderer?: (item: ComboboxItem) => JSX.Element,
+  /**
+   * The initial open state of the combobox. Use when you don't need to control the open state of the combobox.
+   */
+  defaultOpen?: boolean,
   /**
    * The initial selected value(s). Use when you don't need to control the selected value(s) of the combobox.
    */
@@ -95,9 +103,30 @@ type ComboboxRootProp = Omit<ComponentPropsWithRef<'div'>, 'defaultValue' | 'onS
    */
   onInputValueChange?: (value: ComboboxInputValueChangeDetails) => void,
   /**
+   * Callback fired when the select open state changes.
+   */
+  onOpenChange?: (detail: ComboboxOpenChangeDetail) => void
+  /**
    * Callback fired when the value(s) changes.
    */
   onValueChange?: (value: ComboboxValueChangeDetails) => void,
+  /**
+   * The controlled open state of the combobox.
+   */
+  open?: boolean,
+  /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+    /**
+     * Whether to make the floating element same width as the reference element.
+     */
+    sameWidth?: boolean,
+  },
   /**
    * Whether the component is readonly.
    */
@@ -146,13 +175,16 @@ const ComboboxProvider = ({
   allowCustomValue,
   children,
   customFilter,
+  defaultOpen,
   defaultValue,
   disabled,
   items,
   multiple = false,
   newElementLabel,
   onInputValueChange,
+  onOpenChange,
   onValueChange,
+  open,
   readOnly,
   value,
   ...props
@@ -174,7 +206,7 @@ const ComboboxProvider = ({
   const [filteredItems, setFilteredItems] = useState(items);
   const [highlightedOptionValue, setHighlightedOptionValue] = useState('');
   const [inputValue, _setInputValue] = useState(defaultInputValue);
-  const [isOpen, _setIsOpen] = useState(false);
+  const [isOpen, _setIsOpen] = useState((defaultOpen ?? open) ?? false);
   const [selection, _setSelection] = useState<ComboboxOptionItem[]>(defaultSelection);
 
   const optionValues = useMemo(() => {
@@ -214,6 +246,12 @@ const ComboboxProvider = ({
       setHighlightedOptionValue('');
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (typeof open === 'boolean') {
+      _setIsOpen(open);
+    }
+  }, [open]);
 
   useEffect(() => {
     const matchingItems = getDefaultSelection(items, value);
@@ -322,10 +360,20 @@ const ComboboxProvider = ({
   }
 
   function setIsOpen(state: SetStateAction<boolean>): void {
+    let newState;
+
     if (disabled || readOnly) {
-      _setIsOpen(false);
+      newState = false;
     } else {
-      _setIsOpen(state);
+      newState = typeof state === 'function' ? state(isOpen) : state;
+    }
+
+    if (typeof open !== 'boolean') {
+      _setIsOpen(newState);
+    }
+
+    if (onOpenChange) {
+      onOpenChange({ open: newState });
     }
   }
 
@@ -388,6 +436,7 @@ export {
   type ComboboxGroupItem,
   type ComboboxInputValueChangeDetails,
   type ComboboxItem,
+  type ComboboxOpenChangeDetail,
   type ComboboxOptionItem,
   ComboboxProvider,
   type ComboboxRootProp,

--- a/packages/ods-react/src/components/combobox/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/combobox/src/dev.stories.tsx
@@ -238,6 +238,15 @@ export const DefaultValue = () => (
   </Combobox>
 );
 
+export const DifferentWidth = () => (
+  <Combobox
+    items={ items }
+    overlayConfig={{ sameWidth: false }}>
+    <ComboboxControl />
+    <ComboboxContent />
+  </Combobox>
+);
+
 export const Disabled = () => (
   <>
     <Combobox
@@ -496,6 +505,31 @@ export const NoCustom = () => (
     <ComboboxContent />
   </Combobox>
 );
+
+export const Opened = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <>
+      <Combobox
+        defaultOpen={ true }
+        items={ items }>
+        <ComboboxControl />
+        <ComboboxContent />
+      </Combobox>
+
+      <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+
+      <Combobox
+        items={ items }
+        onOpenChange={ ({ open }) => setIsOpen(open) }
+        open={ isOpen }>
+        <ComboboxControl />
+        <ComboboxContent />
+      </Combobox>
+    </>
+  );
+}
 
 export const Placeholder = () => (
   <Combobox items={ items }>

--- a/packages/ods-react/src/components/combobox/src/index.ts
+++ b/packages/ods-react/src/components/combobox/src/index.ts
@@ -14,6 +14,7 @@ export {
   type ComboboxInputValueChangeDetails,
   type ComboboxGroupItem,
   type ComboboxItem,
+  type ComboboxOpenChangeDetail,
   type ComboboxOptionItem,
   type ComboboxValueChangeDetails,
 } from './contexts/useCombobox';

--- a/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
+++ b/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
@@ -26,6 +26,7 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
   min,
   minView,
   name,
+  onOpenChange,
   onValueChange,
   open,
   placeholder,
@@ -89,6 +90,7 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
         min={ convertedMin }
         minView={ minView }
         name={ name }
+        onOpenChange={ onOpenChange }
         onValueChange={ onChange }
         open={ open }
         outsideDaySelectable={ true }

--- a/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
+++ b/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
@@ -29,6 +29,7 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
   onOpenChange,
   onValueChange,
   open,
+  overlayConfig,
   placeholder,
   positionerStyle,
   readOnly,
@@ -96,6 +97,7 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
         outsideDaySelectable={ true }
         placeholder={ placeholder }
         positioning={{
+          flip: overlayConfig?.flip,
           gutter: 4,
           placement: 'bottom-start',
         }}

--- a/packages/ods-react/src/components/datepicker/src/contexts/useDatepicker.tsx
+++ b/packages/ods-react/src/components/datepicker/src/contexts/useDatepicker.tsx
@@ -9,6 +9,10 @@ interface DatepickerFormatterArg {
   locale: string,
 }
 
+interface DatepickerOpenChangeDetail {
+  open: boolean,
+}
+
 interface DatepickerValueChangeDetail {
   value: Date | null,
   valueAsString: string | null,
@@ -75,6 +79,10 @@ interface DatepickerRootProp {
    * The name of the form element. Useful for form submission.
    */
   name?: string,
+  /**
+   * Callback fired when the datepicker open state changes.
+   */
+  onOpenChange?: (detail: DatepickerOpenChangeDetail) => void
   /**
    * Callback fired when the value changes.
    */
@@ -145,6 +153,7 @@ function useDatepicker(): DatepickerContextType {
 export {
   type DatepickerContextType,
   type DatepickerFormatterArg,
+  type DatepickerOpenChangeDetail,
   DatepickerProvider,
   type DatepickerRootProp,
   type DatepickerValueChangeDetail,

--- a/packages/ods-react/src/components/datepicker/src/contexts/useDatepicker.tsx
+++ b/packages/ods-react/src/components/datepicker/src/contexts/useDatepicker.tsx
@@ -92,6 +92,15 @@ interface DatepickerRootProp {
    */
   open?: boolean,
   /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+  }
+  /**
    * The placeholder text to display in the input.
    */
   placeholder?: string,

--- a/packages/ods-react/src/components/datepicker/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/datepicker/src/dev.stories.tsx
@@ -295,6 +295,28 @@ export const MinView = () => (
   </div>
 );
 
+export const Opened = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <>
+      <Datepicker defaultOpen={ true }>
+        <DatepickerControl placeholder="Default open" />
+
+        <DatepickerContent />
+      </Datepicker>
+
+      <Datepicker
+        onOpenChange={ ({ open }) => setIsOpen(open) }
+        open={ isOpen }>
+        <DatepickerControl placeholder="Controlled open" />
+
+        <DatepickerContent />
+      </Datepicker>
+    </>
+  );
+};
+
 export const Placeholder = () => (
   <Datepicker placeholder="Pick a date">
     <DatepickerControl />

--- a/packages/ods-react/src/components/datepicker/src/index.ts
+++ b/packages/ods-react/src/components/datepicker/src/index.ts
@@ -12,4 +12,4 @@ export { DatepickerContent, DatepickerControl };
 export type { DatepickerProp, DatepickerContentProp, DatepickerControlProp };
 export { DATEPICKER_DAY, DATEPICKER_DAYS, type DatepickerDay } from './constants/datepicker-day';
 export { DATEPICKER_VIEW, DATEPICKER_VIEWS, type DatepickerView } from './constants/datepicker-view';
-export { type DatepickerFormatterArg, type DatepickerValueChangeDetail } from './contexts/useDatepicker';
+export { type DatepickerFormatterArg, type DatepickerOpenChangeDetail, type DatepickerValueChangeDetail } from './contexts/useDatepicker';

--- a/packages/ods-react/src/components/input/src/contexts/useInput.tsx
+++ b/packages/ods-react/src/components/input/src/contexts/useInput.tsx
@@ -27,10 +27,17 @@ interface InputRootProp {
    */
   locale?: Locale,
   /**
-   * Whether the masked display is active and its initial state.
+   * Masked display options.
    */
   maskOption?: {
+    /**
+     * Whether the masked display is active.
+     */
     enable: boolean,
+    /**
+     * @type=INPUT_MASK_STATE
+     * Initial state of the mask.
+     */
     initialState?: InputMaskState,
   },
   /**

--- a/packages/ods-react/src/components/menu/src/components/menu/Menu.tsx
+++ b/packages/ods-react/src/components/menu/src/components/menu/Menu.tsx
@@ -9,6 +9,7 @@ const Menu: FC<PropsWithChildren<MenuProp>> = ({
   onOpenChange,
   onPositionChange,
   open,
+  overlayConfig,
   position,
   positionerStyle,
   triggerId,
@@ -22,7 +23,10 @@ const Menu: FC<PropsWithChildren<MenuProp>> = ({
         onOpenChange={ onOpenChange }
         open={ open }
         positioning={{
-          placement: position,
+          flip: overlayConfig?.flip,
+          gutter: overlayConfig?.gutter,
+          placement: overlayConfig?.position ?? position,
+          sameWidth: overlayConfig?.sameWidth,
         }}
         { ...props }>
         { children }

--- a/packages/ods-react/src/components/menu/src/contexts/useMenu.tsx
+++ b/packages/ods-react/src/components/menu/src/contexts/useMenu.tsx
@@ -26,8 +26,31 @@ interface MenuRootProp {
    */
   open?: boolean,
   /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+    /**
+     * The main axis offset or gap between the reference and floating elements.
+     */
+    gutter?: number;
+    /**
+     * @type=MENU_POSITION
+     * The menu position around the trigger.
+     */
+    position?: MenuPosition,
+    /**
+     * Whether to make the floating element same width as the reference element.
+     */
+    sameWidth?: boolean,
+  }
+  /**
+   * @deprecated
    * @type=MENU_POSITION
-   * The menu position around the trigger.
+   * Moved to overlayConfig.
    */
   position?: MenuPosition,
   /**

--- a/packages/ods-react/src/components/menu/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/menu/src/dev.stories.tsx
@@ -247,6 +247,32 @@ export const DisabledNested = (): JSX.Element => (
   </Menu>
 );
 
+export const Gutter = () => (
+  <Menu overlayConfig={{ gutter: 0 }}>
+    <MenuTrigger>
+      Show menu
+    </MenuTrigger>
+    <MenuContent>
+      <MenuItem value="menu">
+        Menu
+      </MenuItem>
+    </MenuContent>
+  </Menu>
+);
+
+export const SameWidth = () => (
+  <Menu overlayConfig={{ sameWidth: true }}>
+    <MenuTrigger>
+      Show popover with this width
+    </MenuTrigger>
+    <MenuContent>
+      <MenuItem value="menu">
+        Menu
+      </MenuItem>
+    </MenuContent>
+  </Menu>
+);
+
 export const ViewsExample = (): JSX.Element => (
   <Menu>
     <MenuTrigger asChild>

--- a/packages/ods-react/src/components/phone-number/src/components/phone-number-country-list/PhoneNumberCountryList.tsx
+++ b/packages/ods-react/src/components/phone-number/src/components/phone-number-country-list/PhoneNumberCountryList.tsx
@@ -75,13 +75,13 @@ const PhoneNumberCountryList: FC<PhoneNumberCountryListProp> = forwardRef(({
       className={ classNames(style['phone-number-country-list'], className) }
       data-ods="phone-number-country-list"
       disabled={ disabled }
-      fitControlWidth={ false }
       invalid={ hasError || invalid }
       items={ countryItems }
       readOnly={ readOnly }
       required={ required }
       ref={ ref }
       onValueChange={ onValueChange }
+      overlayConfig={{ sameWidth: false }}
       value={ [isoCode || FALLBACK_ISO_CODE] }
       { ...props }>
       <SelectControl

--- a/packages/ods-react/src/components/popover/src/components/popover/Popover.tsx
+++ b/packages/ods-react/src/components/popover/src/components/popover/Popover.tsx
@@ -11,6 +11,7 @@ const PopoverRoot: FC<PropsWithChildren<PopoverProp>> = ({
   gutter,
   onOpenChange,
   open,
+  overlayConfig,
   position = POPOVER_POSITION.top,
   sameWidth,
   triggerId,
@@ -28,9 +29,10 @@ const PopoverRoot: FC<PropsWithChildren<PopoverProp>> = ({
       onOpenChange={ onOpenChange }
       open={ open }
       positioning={{
-        gutter: gutter,
-        placement: position,
-        sameWidth: sameWidth,
+        flip: overlayConfig?.flip,
+        gutter: overlayConfig?.gutter ?? gutter,
+        placement: overlayConfig?.position || position,
+        sameWidth: overlayConfig?.sameWidth || sameWidth,
       }}
       { ...props }>
       { children }

--- a/packages/ods-react/src/components/popover/src/components/popover/Popover.tsx
+++ b/packages/ods-react/src/components/popover/src/components/popover/Popover.tsx
@@ -31,8 +31,8 @@ const PopoverRoot: FC<PropsWithChildren<PopoverProp>> = ({
       positioning={{
         flip: overlayConfig?.flip,
         gutter: overlayConfig?.gutter ?? gutter,
-        placement: overlayConfig?.position || position,
-        sameWidth: overlayConfig?.sameWidth || sameWidth,
+        placement: overlayConfig?.position ?? position,
+        sameWidth: overlayConfig?.sameWidth ?? sameWidth,
       }}
       { ...props }>
       { children }

--- a/packages/ods-react/src/components/popover/src/contexts/usePopover.tsx
+++ b/packages/ods-react/src/components/popover/src/contexts/usePopover.tsx
@@ -17,7 +17,8 @@ interface PopoverRootProp {
    */
   autoFocus?: boolean,
   /**
-   * The main axis offset or gap between the reference and floating elements
+   * @deprecated
+   * Moved to overlayConfig.
    */
   gutter?: number;
   /**
@@ -33,8 +34,31 @@ interface PopoverRootProp {
    */
   open?: boolean,
   /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+    /**
+     * The main axis offset or gap between the reference and floating elements.
+     */
+    gutter?: number;
+    /**
+     * @type=POPOVER_POSITION
+     * The popover position around the trigger.
+     */
+    position?: PopoverPosition,
+    /**
+     * Whether to make the floating element same width as the reference element.
+     */
+    sameWidth?: boolean,
+  }
+  /**
+   * @deprecated
    * @type=POPOVER_POSITION
-   * The popover position around the trigger.
+   * Moved to overlayConfig.
    */
   position?: PopoverPosition,
   /**
@@ -42,7 +66,8 @@ interface PopoverRootProp {
    */
   positionerStyle?: CSSProperties,
   /**
-   * Whether to make the floating element same width as the reference element.
+   * @deprecated
+   * Moved to overlayConfig.
    */
   sameWidth?: boolean,
   /**

--- a/packages/ods-react/src/components/popover/src/contexts/usePopover.tsx
+++ b/packages/ods-react/src/components/popover/src/contexts/usePopover.tsx
@@ -54,7 +54,7 @@ interface PopoverRootProp {
      * Whether to make the floating element same width as the reference element.
      */
     sameWidth?: boolean,
-  }
+  },
   /**
    * @deprecated
    * @type=POPOVER_POSITION

--- a/packages/ods-react/src/components/popover/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/popover/src/dev.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '.';
 import { Button } from '../../button/src';
+import { DIVIDER_SPACING, Divider } from '../../divider/src';
 import { Modal, ModalBody, ModalContent, type ModalOpenChangeDetail, ModalTrigger } from '../../modal/src';
 import style from './dev.module.css';
 
@@ -219,7 +220,7 @@ export const Grid = () => (
     gap: '20px',
     padding: '200px',
   } }>
-    <Popover position="top-start">
+    <Popover overlayConfig={{ position: 'top-start' }}>
       <PopoverTrigger>
         Top Left
       </PopoverTrigger>
@@ -228,7 +229,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="top">
+    <Popover overlayConfig={{ position: 'top' }}>
       <PopoverTrigger>
         Top
       </PopoverTrigger>
@@ -237,7 +238,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="top-end">
+    <Popover overlayConfig={{ position: 'top-end' }}>
       <PopoverTrigger>
         Top Right
       </PopoverTrigger>
@@ -246,7 +247,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="left">
+    <Popover overlayConfig={{ position: 'left' }}>
       <PopoverTrigger>
         Middle Left
       </PopoverTrigger>
@@ -257,7 +258,7 @@ export const Grid = () => (
 
     <div />
 
-    <Popover position="right">
+    <Popover overlayConfig={{ position: 'right' }}>
       <PopoverTrigger>
         Middle Right
       </PopoverTrigger>
@@ -266,7 +267,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="bottom-start">
+    <Popover overlayConfig={{ position: 'bottom-start' }}>
       <PopoverTrigger>
         Bottom Left
       </PopoverTrigger>
@@ -275,7 +276,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="bottom">
+    <Popover overlayConfig={{ position: 'bottom' }}>
       <PopoverTrigger>
         Bottom
       </PopoverTrigger>
@@ -284,7 +285,7 @@ export const Grid = () => (
       </PopoverContent>
     </Popover>
 
-    <Popover position="bottom-end">
+    <Popover overlayConfig={{ position: 'bottom-end' }}>
       <PopoverTrigger>
         Bottom Right
       </PopoverTrigger>
@@ -296,15 +297,29 @@ export const Grid = () => (
 );
 
 export const Gutter = () => (
-  <Popover gutter={ 0 }>
-    <PopoverTrigger>
-      Show popover
-    </PopoverTrigger>
+  <>
+    <Popover overlayConfig={{ gutter: 0 }}>
+      <PopoverTrigger>
+        Show popover
+      </PopoverTrigger>
 
-    <PopoverContent>
-      This is the popover content
-    </PopoverContent>
-  </Popover>
+      <PopoverContent>
+        This is the popover content
+      </PopoverContent>
+    </Popover>
+
+    <Divider spacing={ DIVIDER_SPACING._32 } />
+
+    <Popover gutter={ 0 }>
+      <PopoverTrigger>
+        [DEPRECATED] Show popover
+      </PopoverTrigger>
+
+      <PopoverContent>
+        This is the popover content
+      </PopoverContent>
+    </Popover>
+  </>
 );
 
 export const OnPositionChange = () => {
@@ -319,7 +334,7 @@ export const OnPositionChange = () => {
       <Popover
         onPositionChange={ ({ position }) => setCurrentPosition(position) }
         open
-        position='bottom'>
+        overlayConfig={{ position: 'bottom' }}>
         <PopoverTrigger>
           Show popover
         </PopoverTrigger>
@@ -332,12 +347,25 @@ export const OnPositionChange = () => {
 }
 
 export const SameWidth = () => (
-  <Popover sameWidth>
-    <PopoverTrigger>
-      Show popover with this width
-    </PopoverTrigger>
-    <PopoverContent>
-      Popover
-    </PopoverContent>
-  </Popover>
+  <>
+    <Popover overlayConfig={{ sameWidth: true }}>
+      <PopoverTrigger>
+        Show popover with this width
+      </PopoverTrigger>
+      <PopoverContent>
+        Popover
+      </PopoverContent>
+    </Popover>
+
+    <Divider spacing={ DIVIDER_SPACING._32 } />
+
+    <Popover sameWidth>
+      <PopoverTrigger>
+        [DEPRECATED] Show popover with this width
+      </PopoverTrigger>
+      <PopoverContent>
+        Popover
+      </PopoverContent>
+    </Popover>
+  </>
 );

--- a/packages/ods-react/src/components/select/src/components/select/Select.tsx
+++ b/packages/ods-react/src/components/select/src/components/select/Select.tsx
@@ -9,6 +9,7 @@ interface SelectProp extends SelectRootProp {}
 const Select: FC<SelectProp> = forwardRef(({
   children,
   className,
+  defaultOpen,
   defaultValue,
   disabled = false,
   fitControlWidth = true,
@@ -18,6 +19,7 @@ const Select: FC<SelectProp> = forwardRef(({
   multiple = false,
   name,
   onValueChange,
+  open,
   positionerStyle,
   readOnly = false,
   required,
@@ -56,6 +58,7 @@ const Select: FC<SelectProp> = forwardRef(({
         className={ className }
         collection={ collection }
         data-ods="select"
+        defaultOpen={ defaultOpen }
         defaultValue={ defaultValues }
         disabled={ disabled }
         id={ id || fieldContext?.id }
@@ -64,6 +67,7 @@ const Select: FC<SelectProp> = forwardRef(({
         multiple={ !!multiple }
         name={ name }
         onValueChange={ onValueChange }
+        open={ open }
         positioning={{
           gutter: -1,
           sameWidth: fitControlWidth,

--- a/packages/ods-react/src/components/select/src/components/select/Select.tsx
+++ b/packages/ods-react/src/components/select/src/components/select/Select.tsx
@@ -20,6 +20,7 @@ const Select: FC<SelectProp> = forwardRef(({
   name,
   onValueChange,
   open,
+  overlayConfig,
   positionerStyle,
   readOnly = false,
   required,
@@ -69,8 +70,9 @@ const Select: FC<SelectProp> = forwardRef(({
         onValueChange={ onValueChange }
         open={ open }
         positioning={{
+          flip: overlayConfig?.flip,
           gutter: -1,
-          sameWidth: fitControlWidth,
+          sameWidth: overlayConfig?.sameWidth ?? fitControlWidth,
         }}
         readOnly={ readOnly }
         ref={ ref }

--- a/packages/ods-react/src/components/select/src/components/select/Select.tsx
+++ b/packages/ods-react/src/components/select/src/components/select/Select.tsx
@@ -18,6 +18,7 @@ const Select: FC<SelectProp> = forwardRef(({
   items = [],
   multiple = false,
   name,
+  onOpenChange,
   onValueChange,
   open,
   overlayConfig,
@@ -67,6 +68,7 @@ const Select: FC<SelectProp> = forwardRef(({
         loopFocus={ true }
         multiple={ !!multiple }
         name={ name }
+        onOpenChange={ onOpenChange }
         onValueChange={ onValueChange }
         open={ open }
         positioning={{

--- a/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
+++ b/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
@@ -1,6 +1,10 @@
 import { type CSSProperties, type ComponentPropsWithRef, type JSX, type ReactNode, createContext } from 'react';
 import { useContext } from '../../../../utils/context';
 
+interface SelectOpenChangeDetail {
+  open: boolean,
+}
+
 interface SelectValueChangeDetail {
   items: SelectItem[],
   value: string[],
@@ -44,6 +48,10 @@ type SelectCustomOptionRendererArg<T extends CustomData = CustomData> = {
 
 interface SelectRootProp extends Omit<ComponentPropsWithRef<'div'>, 'onSelect'> {
   /**
+   * The initial open state of the select. Use when you don't need to control the open state of the select.
+   */
+  defaultOpen?: boolean,
+  /**
    * The initial selected value(s). Use when you don't need to control the selected value(s) of the select.
    */
   defaultValue?: string | string[],
@@ -72,9 +80,17 @@ interface SelectRootProp extends Omit<ComponentPropsWithRef<'div'>, 'onSelect'> 
    */
   name?: string,
   /**
+   * Callback fired when the select open state changes.
+   */
+  onOpenChange?: (detail: SelectOpenChangeDetail) => void
+  /**
    * Callback fired when the value(s) changes.
    */
   onValueChange?: (detail: SelectValueChangeDetail) => void,
+  /**
+   * The controlled open state of the select.
+   */
+  open?: boolean,
   /**
    * Custom style applied to the overlay positioner. Useful if you want to override the overlay z-index.
    */
@@ -133,6 +149,7 @@ export {
   type SelectGroupItem,
   type SelectItem,
   type SelectMultipleMode,
+  type SelectOpenChangeDetail,
   type SelectOptionItem,
   SelectProvider,
   type SelectRootProp,

--- a/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
+++ b/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
@@ -60,7 +60,8 @@ interface SelectRootProp extends Omit<ComponentPropsWithRef<'div'>, 'onSelect'> 
    */
   disabled?: boolean,
   /**
-   * Whether the dropdown width should stay the same as the input.
+   * @deprecated
+   * Use overlayConfig.sameWidth instead
    */
   fitControlWidth?: boolean,
   /**
@@ -91,6 +92,19 @@ interface SelectRootProp extends Omit<ComponentPropsWithRef<'div'>, 'onSelect'> 
    * The controlled open state of the select.
    */
   open?: boolean,
+  /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+    /**
+     * Whether to make the floating element same width as the reference element.
+     */
+    sameWidth?: boolean,
+  }
   /**
    * Custom style applied to the overlay positioner. Useful if you want to override the overlay z-index.
    */

--- a/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
+++ b/packages/ods-react/src/components/select/src/contexts/useSelect.tsx
@@ -104,7 +104,7 @@ interface SelectRootProp extends Omit<ComponentPropsWithRef<'div'>, 'onSelect'> 
      * Whether to make the floating element same width as the reference element.
      */
     sameWidth?: boolean,
-  }
+  },
   /**
    * Custom style applied to the overlay positioner. Useful if you want to override the overlay z-index.
    */

--- a/packages/ods-react/src/components/select/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/select/src/dev.stories.tsx
@@ -379,6 +379,45 @@ export const Multiple = () => (
   </>
 );
 
+export const Opened = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <>
+      <Select
+        defaultOpen={ true }
+        items={[
+          { label: 'Dog', value:'dog' },
+          { label: 'Cat', value:'cat' },
+          { label: 'Hamster', value:'hamster' },
+          { label: 'Parrot', value:'parrot' },
+          { label: 'Spider', value:'spider' },
+          { label: 'Goldfish', value:'goldfish' },
+        ]}>
+        <SelectControl placeholder="Default open" />
+        <SelectContent />
+      </Select>
+
+      <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+
+      <Select
+        items={[
+          { label: 'Dog', value:'dog' },
+          { label: 'Cat', value:'cat' },
+          { label: 'Hamster', value:'hamster' },
+          { label: 'Parrot', value:'parrot' },
+          { label: 'Spider', value:'spider' },
+          { label: 'Goldfish', value:'goldfish' },
+        ]}
+        onOpenChange={ ({ open }) => setIsOpen(open) }
+        open={ isOpen }>
+        <SelectControl placeholder="Controlled open" />
+        <SelectContent />
+      </Select>
+    </>
+  );
+}
+
 export const Placeholder = () => (
   <Select
     items={[

--- a/packages/ods-react/src/components/select/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/select/src/dev.stories.tsx
@@ -224,7 +224,6 @@ export const Default = () => (
 
 export const DifferentWidth = () => (
   <Select
-    fitControlWidth={ false }
     items={[
       { label: 'Dog', value:'dog' },
       { label: 'Cat', value:'cat' },
@@ -232,7 +231,8 @@ export const DifferentWidth = () => (
       { label: 'Parrot', value:'parrot' },
       { label: 'Spider', value:'spider' },
       { label: 'Goldfish', value:'goldfish' },
-    ]}>
+    ]}
+    overlayConfig={{ sameWidth: false }}>
     <SelectControl />
     <SelectContent />
   </Select>

--- a/packages/ods-react/src/components/select/src/index.ts
+++ b/packages/ods-react/src/components/select/src/index.ts
@@ -10,4 +10,14 @@ const Select = Object.assign(SelectRoot, {
 export { Select };
 export { SelectContent, SelectControl };
 export type { SelectProp, SelectContentProp, SelectControlProp };
-export { type SelectCustomGroupRendererArg, type SelectCustomItemRendererArg, type SelectCustomOptionRendererArg, type SelectGroupItem, type SelectItem, type SelectMultipleMode, type SelectOptionItem, type SelectValueChangeDetail } from './contexts/useSelect';
+export {
+  type SelectCustomGroupRendererArg,
+  type SelectCustomItemRendererArg,
+  type SelectCustomOptionRendererArg,
+  type SelectGroupItem,
+  type SelectItem,
+  type SelectMultipleMode,
+  type SelectOpenChangeDetail,
+  type SelectOptionItem,
+  type SelectValueChangeDetail,
+} from './contexts/useSelect';

--- a/packages/ods-react/src/components/tooltip/src/components/tooltip/Tooltip.tsx
+++ b/packages/ods-react/src/components/tooltip/src/components/tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ const TooltipRoot: FC<PropsWithChildren<TooltipProp>> = ({
   onOpenChange,
   open,
   openDelay = 0,
+  overlayConfig,
   position = TOOLTIP_POSITION.top,
   ...props
 }): JSX.Element => {
@@ -30,7 +31,10 @@ const TooltipRoot: FC<PropsWithChildren<TooltipProp>> = ({
       open={ open }
       openDelay={ openDelay }
       positioning={{
-        placement: position,
+        flip: overlayConfig?.flip,
+        gutter: overlayConfig?.gutter,
+        placement: overlayConfig?.position || position,
+        sameWidth: overlayConfig?.sameWidth,
       }}
       { ...props }>
       { children }

--- a/packages/ods-react/src/components/tooltip/src/contexts/useTooltip.tsx
+++ b/packages/ods-react/src/components/tooltip/src/contexts/useTooltip.tsx
@@ -24,6 +24,29 @@ interface TooltipRootProp {
    */
   openDelay?: number,
   /**
+   * The overlay configuration.
+   */
+  overlayConfig?: {
+    /**
+     * Whether to flip the position.
+     */
+    flip?: boolean,
+    /**
+     * The main axis offset or gap between the reference and floating elements.
+     */
+    gutter?: number;
+    /**
+     * @type=TOOLTIP_POSITION
+     * The tooltip position around the trigger.
+     */
+    position?: TooltipPosition,
+    /**
+     * Whether to make the floating element same width as the reference element.
+     */
+    sameWidth?: boolean,
+  }
+  /**
+   * @deprecated
    * @type=TOOLTIP_POSITION
    * The tooltip position around the trigger.
    */

--- a/packages/ods-react/src/components/tooltip/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tooltip/src/dev.stories.tsx
@@ -128,7 +128,7 @@ export const Grid = () => (
     gap: '20px',
     padding: '200px',
   }}>
-    <Tooltip position="top-start">
+    <Tooltip overlayConfig={{ position: 'top-start' }}>
       <TooltipTrigger>
         Top Left
       </TooltipTrigger>
@@ -137,7 +137,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="top">
+    <Tooltip overlayConfig={{ position: 'top' }}>
       <TooltipTrigger>
         Top
       </TooltipTrigger>
@@ -146,7 +146,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="top-end">
+    <Tooltip overlayConfig={{ position: 'top-end' }}>
       <TooltipTrigger>
         Top Right
       </TooltipTrigger>
@@ -155,7 +155,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="left">
+    <Tooltip overlayConfig={{ position: 'left' }}>
       <TooltipTrigger>
         Middle Left
       </TooltipTrigger>
@@ -166,7 +166,7 @@ export const Grid = () => (
 
     <div />
 
-    <Tooltip position="right">
+    <Tooltip overlayConfig={{ position: 'right' }}>
       <TooltipTrigger>
         Middle Right
       </TooltipTrigger>
@@ -175,7 +175,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="bottom-start">
+    <Tooltip overlayConfig={{ position: 'bottom-start' }}>
       <TooltipTrigger>
         Bottom Left
       </TooltipTrigger>
@@ -184,7 +184,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="bottom">
+    <Tooltip overlayConfig={{ position: 'bottom' }}>
       <TooltipTrigger>
         Bottom
       </TooltipTrigger>
@@ -193,7 +193,7 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
 
-    <Tooltip position="bottom-end">
+    <Tooltip overlayConfig={{ position: 'bottom-end' }}>
       <TooltipTrigger>
         Bottom Right
       </TooltipTrigger>
@@ -202,6 +202,30 @@ export const Grid = () => (
       </TooltipContent>
     </Tooltip>
   </div>
+);
+
+export const Gutter = () => (
+  <Tooltip overlayConfig={{ gutter: 0 }}>
+    <TooltipTrigger>
+      Show tooltip
+    </TooltipTrigger>
+
+    <TooltipContent>
+      This is the tooltip content
+    </TooltipContent>
+  </Tooltip>
+);
+
+export const SameWidth = () => (
+  <Tooltip overlayConfig={{ sameWidth: true }}>
+    <TooltipTrigger>
+      Show tooltip with this width
+    </TooltipTrigger>
+
+    <TooltipContent>
+      This is the tooltip content
+    </TooltipContent>
+  </Tooltip>
 );
 
 export const Accessibility = () => (

--- a/packages/storybook/src/components/technicalSpecification/ClassModule.tsx
+++ b/packages/storybook/src/components/technicalSpecification/ClassModule.tsx
@@ -26,37 +26,39 @@ type ClassModuleProp = {
 const COLUMNS = ['Property', 'Type', 'Required', 'Default value', 'Description'];
 
 const ClassModuleRow = ({ isChild, prop }: ClassModuleRowProp): JSX.Element => {
-  const tdClass = classNames({
-    [styles['class-module-row--has-child']]: !!prop.entries?.length || (isChild && isChild !== 'last'),
-  });
+  const tdClass = classNames(
+    styles['class-module-row'],
+    { [styles['class-module-row--has-child']]: !!prop.entries?.length || (isChild && isChild !== 'last') },
+  );
 
   return (
     <>
       <tr>
-        <td className={ classNames(
-          tdClass,
-          { [styles['class-module-row__key--child']]: !!isChild },
-        )}>
-          {
-            isChild &&
+        <td className={ tdClass }>
+          <div className={ styles['class-module-row__key'] }>
+            {
+              isChild &&
+              <span className={ classNames(
+                styles['class-module-row__key__border'],
+                { [styles['class-module-row__key__border--last']]: isChild === 'last' },
+              )} />
+            }
+
             <span className={ classNames(
-              styles['class-module-row__key__border'],
-              { [styles['class-module-row__key__border--last']]: isChild === 'last' },
-            )} />
-          }
-          <span className={ classNames(
-            { [styles['class-module-row__key__name--child']]: !!isChild },
-          )}>
-            { prop.name }
-          </span>
-          {
-            prop.deprecated &&
-            <Badge
-              color={ BADGE_COLOR.warning }
-              size={ BADGE_SIZE.sm }>
-              Deprecated
-            </Badge>
-          }
+              { [styles['class-module-row__key__name--child']]: !!isChild },
+            )}>
+              { prop.name }
+            </span>
+
+            {
+              prop.deprecated &&
+              <Badge
+                color={ BADGE_COLOR.warning }
+                size={ BADGE_SIZE.sm }>
+                Deprecated
+              </Badge>
+            }
+          </div>
         </td>
 
         <td className={ tdClass }>

--- a/packages/storybook/src/components/technicalSpecification/ClassModule.tsx
+++ b/packages/storybook/src/components/technicalSpecification/ClassModule.tsx
@@ -1,23 +1,100 @@
 import { BADGE_COLOR, BADGE_SIZE, ICON_NAME, TABLE_VARIANT, Badge, Icon } from '@ovhcloud/ods-react';
 import { CodeOrSourceMdx } from '@storybook/blocks';
-import React, { type JSX, useMemo } from 'react';
+import classNames from 'classnames';
+import React, { Fragment, type JSX, useMemo } from 'react';
 import { ExternalLink } from '../externalLink/ExternalLink';
 import { Table } from '../table/Table';
 import { Heading } from '../heading/Heading';
-import { type Component, removeTags } from '../../helpers/docgen';
+import { type Component, type ComponentProp, removeTags } from '../../helpers/docgen';
 import styles from './classModule.module.css';
 
+type ClassModuleRowProp = {
+  isChild?: boolean | 'last';
+  prop: ComponentProp;
+}
+
 type ClassModuleProp = {
-  component: Component,
+  component: Component;
   extraInfo?: Record<string, {
     extendAttribute: {
-      name: string,
-      url: string,
+      name: string;
+      url: string;
     }
-  }>,
+  }>;
 }
 
 const COLUMNS = ['Property', 'Type', 'Required', 'Default value', 'Description'];
+
+const ClassModuleRow = ({ isChild, prop }: ClassModuleRowProp): JSX.Element => {
+  const tdClass = classNames({
+    [styles['class-module-row--has-child']]: !!prop.entries?.length || (isChild && isChild !== 'last'),
+  });
+
+  return (
+    <>
+      <tr>
+        <td className={ classNames(
+          tdClass,
+          { [styles['class-module-row__key--child']]: !!isChild },
+        )}>
+          {
+            isChild &&
+            <span className={ classNames(
+              styles['class-module-row__key__border'],
+              { [styles['class-module-row__key__border--last']]: isChild === 'last' },
+            )} />
+          }
+          <span className={ classNames(
+            { [styles['class-module-row__key__name--child']]: !!isChild },
+          )}>
+            { prop.name }
+          </span>
+          {
+            prop.deprecated &&
+            <Badge
+              color={ BADGE_COLOR.warning }
+              size={ BADGE_SIZE.sm }>
+              Deprecated
+            </Badge>
+          }
+        </td>
+
+        <td className={ tdClass }>
+          <CodeOrSourceMdx>
+            { prop.type }
+          </CodeOrSourceMdx>
+        </td>
+
+        <td className={ classNames(
+          tdClass,
+          styles['class-module__properties__body__is-required']
+        )}>
+          {
+            prop.isOptional ? '-' :
+              <Icon aria-label="Required"
+                    className={ styles['class-module__properties__body__is-required--required'] }
+                    name={ ICON_NAME.check }
+                    role="img" />
+          }
+        </td>
+
+        <td className={ tdClass }>
+          <CodeOrSourceMdx>
+            {
+              prop.defaultValue === undefined ?
+                <div className={ styles['class-module__properties__body__default-value'] }>undefined</div> :
+                prop.defaultValue
+            }
+          </CodeOrSourceMdx>
+        </td>
+
+        <td className={ tdClass }>
+          { removeTags(prop.description) || '-' }
+        </td>
+      </tr>
+    </>
+  );
+};
 
 const ClassModule = ({ component, extraInfo }: ClassModuleProp): JSX.Element => {
   const extraAttributeInfo = useMemo(() => {
@@ -38,7 +115,9 @@ const ClassModule = ({ component, extraInfo }: ClassModuleProp): JSX.Element => 
 
   return (
     <>
-      <Heading label={ component.name } level={ 2 } />
+      <Heading
+        label={ component.name }
+        level={ 2 } />
 
       {
         (props.length <= 0 && !extraAttributeInfo) ?
@@ -74,49 +153,18 @@ const ClassModule = ({ component, extraInfo }: ClassModuleProp): JSX.Element => 
 
               {
                 props.map((prop, idx) => (
-                  <tr key={ idx }>
-                    <td>
-                      { prop.name }
-                      {
-                        prop.deprecated &&
-                        <Badge
-                          color={ BADGE_COLOR.warning }
-                          size={ BADGE_SIZE.sm }>
-                          Deprecated
-                        </Badge>
-                      }
-                    </td>
+                  <Fragment key={ idx }>
+                    <ClassModuleRow prop={ prop } />
 
-                    <td>
-                      <CodeOrSourceMdx>
-                        { prop.type }
-                      </CodeOrSourceMdx>
-                    </td>
-
-                    <td className={ styles['class-module__properties__body__is-required'] }>
-                      {
-                        prop.isOptional ? '-' :
-                          <Icon aria-label="Required"
-                                className={ styles['class-module__properties__body__is-required--required'] }
-                                name={ ICON_NAME.check }
-                                role="img" />
-                      }
-                    </td>
-
-                    <td>
-                      <CodeOrSourceMdx>
-                        {
-                          prop.defaultValue === undefined ?
-                            <div className={ styles['class-module__properties__body__default-value'] }>undefined</div> :
-                            prop.defaultValue
-                        }
-                      </CodeOrSourceMdx>
-                    </td>
-
-                    <td>
-                      { removeTags(prop.description) || '-' }
-                    </td>
-                  </tr>
+                    {
+                      (prop.entries || []).map((entry, i) => (
+                        <ClassModuleRow
+                          isChild={ i === ((prop.entries || []).length - 1) ? 'last' : true }
+                          key={ i }
+                          prop={ entry } />
+                      ))
+                    }
+                  </Fragment>
                 ))
               }
             </tbody>

--- a/packages/storybook/src/components/technicalSpecification/TechnicalSpecification.tsx
+++ b/packages/storybook/src/components/technicalSpecification/TechnicalSpecification.tsx
@@ -52,23 +52,26 @@ const TechnicalSpecification = ({ cssVariable, data, extraInfo, of }: Props): JS
     <div>
       {
         (components || []).map((component, idx) => (
-          <ClassModule key={ idx }
-                       component={ component }
-                       extraInfo={ extraInfo } />
+          <ClassModule
+            component={ component }
+            extraInfo={ extraInfo }
+            key={ idx } />
         ))
       }
 
       {
         enums.length > 0 &&
         <>
-          <Heading label="Enums"
-                   level={ 2 } />
+          <Heading
+            label="Enums"
+            level={ 2 } />
 
           {
             enums.map((enumObj, idx) => (
               <Fragment key={ idx }>
-                <Heading label={ enumObj.name }
-                         level={ 3 }>
+                <Heading
+                  label={ enumObj.name }
+                  level={ 3 }>
                   {
                     enumObj.deprecated &&
                     <Badge
@@ -91,14 +94,16 @@ const TechnicalSpecification = ({ cssVariable, data, extraInfo, of }: Props): JS
       {
         interfaces.length > 0 &&
         <>
-          <Heading label="Interfaces"
-                   level={ 2 } />
+          <Heading
+            label="Interfaces"
+            level={ 2 } />
 
           {
             interfaces.map((interfaceObj, idx) => (
               <Fragment key={ idx }>
-                <Heading label={ interfaceObj.name }
-                         level={ 3 } />
+                <Heading
+                  label={ interfaceObj.name }
+                  level={ 3 } />
 
                 <ul className={ styles['technical-specification__interfaces__keys'] }>
                   {
@@ -120,8 +125,9 @@ const TechnicalSpecification = ({ cssVariable, data, extraInfo, of }: Props): JS
       {
         unions.length > 0 &&
         <>
-          <Heading label="Unions"
-                   level={ 2 } />
+          <Heading
+            label="Unions"
+            level={ 2 } />
 
           <ul className={ styles['technical-specification__unions__keys'] }>
             {
@@ -140,8 +146,9 @@ const TechnicalSpecification = ({ cssVariable, data, extraInfo, of }: Props): JS
       {
         cssVariables.length > 0 &&
         <>
-          <Heading label="Css Variables"
-                   level={ 2 }>
+          <Heading
+            label="Css Variables"
+            level={ 2 }>
             <StorybookLink title={ HOME_TITLE.styleCustomization }>(see style customization)</StorybookLink>
           </Heading>
 

--- a/packages/storybook/src/components/technicalSpecification/classModule.module.css
+++ b/packages/storybook/src/components/technicalSpecification/classModule.module.css
@@ -16,3 +16,40 @@
 .class-module__properties__body__is-required--required {
   color: var(--ods-color-success-500);
 }
+
+.class-module-row--has-child {
+  border-bottom: none;
+}
+
+.class-module-row__key--child {
+  position: relative;
+}
+
+.class-module-row__key__name--child {
+  margin-left: calc(var(--ods-theme-padding-horizontal) * 5 - 1px);
+}
+
+.class-module-row__key__border {
+  position: absolute;
+  left: calc(var(--ods-theme-padding-horizontal) * 2);
+  top: 0;
+  bottom: 0;
+  margin: 0 var(--ods-theme-padding-horizontal);
+  border-left: solid 1px;
+}
+
+.class-module-row__key__border::after {
+  position: absolute;
+  top: 50%;
+  border-bottom: solid 1px;
+  width: calc(var(--ods-theme-padding-horizontal) * 2);
+  content: '';
+}
+
+.class-module-row__key__border--last {
+  bottom: 50%;
+}
+
+.class-module-row__key__border--last::after {
+  top: calc(100% - 1px);
+}

--- a/packages/storybook/src/components/technicalSpecification/classModule.module.css
+++ b/packages/storybook/src/components/technicalSpecification/classModule.module.css
@@ -17,12 +17,19 @@
   color: var(--ods-color-success-500);
 }
 
+.class-module-row {
+  position: relative;
+}
+
 .class-module-row--has-child {
   border-bottom: none;
 }
 
-.class-module-row__key--child {
-  position: relative;
+.class-module-row__key {
+  display: flex;
+  flex-flow: row;
+  column-gap: var(--ods-theme-column-gap);
+  align-items: center;
 }
 
 .class-module-row__key__name--child {

--- a/packages/storybook/src/helpers/docgen.ts
+++ b/packages/storybook/src/helpers/docgen.ts
@@ -9,17 +9,18 @@ enum TAG {
 }
 
 type ComponentProp = {
-  deprecated: boolean,
-  description: string,
-  defaultValue: string,
-  isOptional: boolean,
-  name: string,
-  type: string,
+  defaultValue: string;
+  deprecated: boolean;
+  description: string;
+  entries?: ComponentProp[];
+  isOptional: boolean;
+  name: string;
+  type: string;
 }
 
 type Component = {
-  name: string,
-  props: ComponentProp[],
+  name: string;
+  props: ComponentProp[];
 }
 
 const tagRegExp = /(@[\w-]+)=?([\w${} ']+)?/gi;
@@ -51,14 +52,17 @@ function getComponentProp(name: string, prop: PropDescriptor): ComponentProp | u
     return;
   }
 
+  const type = tagsMap.get(TAG.type) || (prop.tsType ? typeToString(prop.tsType) : '');
+
   return {
+    defaultValue: prop.defaultValue?.value?.toString() || tagsMap.get(TAG.defaultValue) || 'undefined',
     deprecated: tagsMap.has(TAG.deprecated),
     description: prop.description || '',
-    defaultValue: prop.defaultValue?.value?.toString() || tagsMap.get(TAG.defaultValue) || 'undefined',
+    entries: type === 'object' ? getPropEntries(prop) : [],
     isOptional: !prop.required,
     name: name,
-    type: tagsMap.get(TAG.type) || (prop.tsType ? typeToString(prop.tsType) : ''),
-  }
+    type: type,
+  };
 }
 
 function getComponentsInfo(docgens: Documentation[]): Component[] {
@@ -80,15 +84,36 @@ function getCustomProps(description = ''): ComponentProp[] {
       const [type, optional] = matches[1].split('|');
 
       return {
+        defaultValue: 'undefined',
         deprecated: false,
         description: matches[3].trim(),
-        defaultValue: 'undefined',
         isOptional: optional && optional.replace(/[{}]/g, '').trim() === 'optional',
         name: matches[2].trim(),
         type: type.replace(/[{}]/g, '').trim(),
       };
     })
     .filter((prop): prop is ComponentProp => !!prop);
+}
+
+function getPropEntries(prop: PropDescriptor): ComponentProp[] {
+  return (prop.tsType as ObjectSignatureType).signature.properties.map((property) => {
+    const tagsMap = extractTags(property.description || '');
+
+    if (tagsMap.has(TAG.internal)) {
+      return;
+    }
+
+    const type = tagsMap.get(TAG.type) || property.value.name;
+
+    return {
+      defaultValue: '-',
+      deprecated: tagsMap.has(TAG.deprecated),
+      description: property.description || '',
+      isOptional: !property.value.required,
+      name: property.key.toString(),
+      type: type,
+    }
+  }).filter(Boolean) as ComponentProp[];
 }
 
 function removeTags(str: string): string {
@@ -101,17 +126,7 @@ function typeToString(type: TypeDescriptor): string {
   }
 
   if ((type as ObjectSignatureType).type === 'object') {
-    const objectType = type as ObjectSignatureType;
-
-    if (objectType.name === 'signature' && objectType.signature.properties.length) {
-      const signatureProp = objectType.signature.properties.map((property) => {
-        return `${property.key}: ${typeToString(property.value)}`;
-      }).join(', ');
-
-      return `{ ${signatureProp} }`;
-    }
-
-    return objectType.raw;
+    return (type as ObjectSignatureType).type;
   }
 
   if (type.name === 'literal') {
@@ -135,6 +150,7 @@ function typeToString(type: TypeDescriptor): string {
 export {
   TAG,
   type Component,
+  type ComponentProp,
   extractTags,
   getComponentsInfo,
   removeTags,

--- a/packages/storybook/stories/components/combobox/combobox.stories.tsx
+++ b/packages/storybook/stories/components/combobox/combobox.stories.tsx
@@ -19,7 +19,7 @@ type DemoArg = Partial<ComboboxProp> & Partial<ComboboxControlProp> & {
 };
 
 const meta: Meta<ComboboxProp> = {
-  argTypes: excludeFromDemoControls(['customFilter', 'customOptionRenderer', 'defaultValue', 'i18n', 'items', 'locale', 'name', 'onInputValueChange', 'onValueChange', 'required', 'value']),
+  argTypes: excludeFromDemoControls(['customFilter', 'customOptionRenderer', 'defaultOpen', 'defaultValue', 'i18n', 'items', 'locale', 'name', 'onInputValueChange', 'onOpenChange', 'onValueChange', 'open', 'overlayConfig', 'required', 'value']),
   component: Combobox,
   subcomponents: { ComboboxContent, ComboboxControl },
   title: 'React Components/Combobox',

--- a/packages/storybook/stories/components/datepicker/datepicker.stories.tsx
+++ b/packages/storybook/stories/components/datepicker/datepicker.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<DatepickerProp>;
 type DemoArg = Partial<DatepickerProp> & Partial<DatepickerControlProp>;
 
 const meta: Meta<DatepickerProp> = {
-  argTypes: excludeFromDemoControls(['dateFormatter', 'defaultOpen', 'defaultValue', 'defaultView', 'disabledDates', 'disabledWeekDays', 'i18n', 'max', 'maxView', 'min', 'minView', 'name', 'onValueChange', 'open', 'required', 'value', 'view']),
+  argTypes: excludeFromDemoControls(['dateFormatter', 'defaultOpen', 'defaultValue', 'defaultView', 'disabledDates', 'disabledWeekDays', 'i18n', 'max', 'maxView', 'min', 'minView', 'name', 'onOpenChange', 'onValueChange', 'open', 'positionerStyle', 'required', 'value', 'view']),
   component: Datepicker,
   subcomponents: { DatepickerContent, DatepickerControl },
   title: 'React Components/Datepicker',

--- a/packages/storybook/stories/components/datepicker/datepicker.stories.tsx
+++ b/packages/storybook/stories/components/datepicker/datepicker.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<DatepickerProp>;
 type DemoArg = Partial<DatepickerProp> & Partial<DatepickerControlProp>;
 
 const meta: Meta<DatepickerProp> = {
-  argTypes: excludeFromDemoControls(['dateFormatter', 'defaultOpen', 'defaultValue', 'defaultView', 'disabledDates', 'disabledWeekDays', 'i18n', 'max', 'maxView', 'min', 'minView', 'name', 'onOpenChange', 'onValueChange', 'open', 'positionerStyle', 'required', 'value', 'view']),
+  argTypes: excludeFromDemoControls(['dateFormatter', 'defaultOpen', 'defaultValue', 'defaultView', 'disabledDates', 'disabledWeekDays', 'i18n', 'max', 'maxView', 'min', 'minView', 'name', 'onOpenChange', 'onValueChange', 'open', 'overlayConfig', 'positionerStyle', 'required', 'value', 'view']),
   component: Datepicker,
   subcomponents: { DatepickerContent, DatepickerControl },
   title: 'React Components/Datepicker',

--- a/packages/storybook/stories/components/menu/menu.stories.tsx
+++ b/packages/storybook/stories/components/menu/menu.stories.tsx
@@ -11,13 +11,15 @@ import { staticSourceRenderConfig } from '../../../src/helpers/source';
 
 type Story = StoryObj<MenuProp>;
 type DemoArg = {
-  position: MenuProp['position'],
+  gutter?: number,
+  position?: MENU_POSITION,
+  sameWidth?: boolean,
   triggerLabel: string,
   withArrow: boolean,
 };
 
 const meta: Meta<MenuProp> = {
-  argTypes: excludeFromDemoControls(['onOpenChange', 'onPositionChange', 'open', 'positionerStyle', 'triggerId']),
+  argTypes: excludeFromDemoControls(['onOpenChange', 'onPositionChange', 'open', 'overlayConfig', 'positionerStyle', 'triggerId']),
   component: Menu,
   subcomponents: {
     MenuContent,
@@ -35,6 +37,13 @@ export default meta;
 
 export const Demo: StoryObj = {
   argTypes: orderControls({
+    gutter: {
+      table: {
+        category: CONTROL_CATEGORY.design,
+        type: { summary: 'number' }
+      },
+      control: 'number',
+    },
     position: {
       control: 'select',
       options: MENU_POSITIONS,
@@ -42,6 +51,12 @@ export const Demo: StoryObj = {
         category: CONTROL_CATEGORY.general,
         type: { summary: 'MENU_POSITION' },
       },
+    },
+    sameWidth: {
+      table: {
+        category: CONTROL_CATEGORY.design,
+      },
+      control: { type: 'boolean' },
     },
     triggerLabel: {
       control: 'text',
@@ -63,13 +78,17 @@ export const Demo: StoryObj = {
     withArrow: false,
   },
   render: (arg: Partial<DemoArg>) => (
-    <Menu
-      position={ arg.position }>
+    <Menu overlayConfig={{
+      gutter: arg.gutter,
+      position: arg.position,
+      sameWidth: arg.sameWidth,
+    }}>
       <MenuTrigger asChild>
         <Button>
           { arg.triggerLabel }
         </Button>
       </MenuTrigger>
+
       <MenuContent withArrow={ arg.withArrow }>
         <MenuItem value="profile">Profile</MenuItem>
         <MenuItem value="settings">Settings</MenuItem>

--- a/packages/storybook/stories/components/popover/documentation.mdx
+++ b/packages/storybook/stories/components/popover/documentation.mdx
@@ -167,7 +167,7 @@ Update the content type on the **Popover Trigger**, which is set by default to `
 
 <Heading label="Using aria-popup for a Popover containing a Menu" level={ 3 } />
 
-<Canvas of={PopoverStories.AccessibilityWithMenu} sourceState='shown' />
+<Canvas of={ PopoverStories.AccessibilityWithMenu } sourceState="shown" />
 
 <Icon name={ ICON_NAME.circleCheck }
       style={{ color: 'var(--ods-color-success-500)' }} /> Screen readers will recognize that **Popover** contains a menu and menu items. It indicates that the element can trigger a popup and the nature of this popup.

--- a/packages/storybook/stories/components/popover/popover.stories.tsx
+++ b/packages/storybook/stories/components/popover/popover.stories.tsx
@@ -11,10 +11,13 @@ import { staticSourceRenderConfig } from '../../../src/helpers/source';
 type Story = StoryObj<PopoverProp>;
 type DemoArg = Partial<PopoverProp> & Partial<PopoverContentProp> & {
   content?: string,
+  gutter?: number,
+  position?: POPOVER_POSITION,
+  sameWidth?: boolean,
 };
 
 const meta: Meta<PopoverProp> = {
-  argTypes: excludeFromDemoControls(['autoFocus', 'onOpenChange', 'onPositionChange', 'open', 'triggerId']),
+  argTypes: excludeFromDemoControls(['autoFocus', 'onOpenChange', 'onPositionChange', 'open', 'overlayConfig', 'positionerStyle', 'triggerId']),
   component: Popover,
   subcomponents: { PopoverContent, PopoverTrigger },
   title: 'React Components/Popover',
@@ -27,10 +30,11 @@ export const Demo: StoryObj = {
     layout: 'centered',
   },
   render: (arg: DemoArg) => (
-    <Popover
-      gutter={ arg.gutter }
-      position={ arg.position }
-      sameWidth={ arg.sameWidth }>
+    <Popover overlayConfig={{
+      gutter: arg.gutter,
+      position: arg.position,
+      sameWidth: arg.sameWidth,
+    }}>
       <PopoverTrigger>
         Show popover
       </PopoverTrigger>
@@ -177,7 +181,7 @@ export const Grid: StoryObj = {
   tags: ['!dev'],
   render: ({}) => (
     <>
-      <Popover position="top-start">
+      <Popover overlayConfig={{ position: 'top-start' }}>
         <PopoverTrigger>
           Top Left
         </PopoverTrigger>
@@ -186,7 +190,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="top">
+      <Popover overlayConfig={{ position: 'top' }}>
         <PopoverTrigger>
           Top
         </PopoverTrigger>
@@ -195,7 +199,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="top-end">
+      <Popover overlayConfig={{ position: 'top-end' }}>
         <PopoverTrigger>
           Top Right
         </PopoverTrigger>
@@ -204,7 +208,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="left">
+      <Popover overlayConfig={{ position: 'left' }}>
         <PopoverTrigger>
           Middle Left
         </PopoverTrigger>
@@ -215,7 +219,7 @@ export const Grid: StoryObj = {
 
       <div />
 
-      <Popover position="right">
+      <Popover overlayConfig={{ position: 'right' }}>
         <PopoverTrigger>
           Middle Right
         </PopoverTrigger>
@@ -224,7 +228,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="bottom-start">
+      <Popover overlayConfig={{ position: 'bottom-start' }}>
         <PopoverTrigger>
           Bottom Left
         </PopoverTrigger>
@@ -233,7 +237,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="bottom">
+      <Popover overlayConfig={{ position: 'bottom' }}>
         <PopoverTrigger>
           Bottom
         </PopoverTrigger>
@@ -242,7 +246,7 @@ export const Grid: StoryObj = {
         </PopoverContent>
       </Popover>
 
-      <Popover position="bottom-end">
+      <Popover overlayConfig={{ position: 'bottom-end' }}>
         <PopoverTrigger>
           Bottom Right
         </PopoverTrigger>
@@ -327,7 +331,7 @@ export const SameWidth: Story = {
   },
   tags: ['!dev'],
   render: ({}) => (
-    <Popover sameWidth>
+    <Popover overlayConfig={{ sameWidth: true }}>
       <PopoverTrigger>
         Show popover that will take this width as reference
       </PopoverTrigger>
@@ -398,7 +402,7 @@ export const ZIndex: Story = {
 
       <Popover
         open
-        position={ POPOVER_POSITION.bottom }
+        overlayConfig={{ position: POPOVER_POSITION.bottom }}
         positionerStyle={{ zIndex: 'calc(var(--ods-theme-overlay-z-index) + 1)'}}>
         <PopoverTrigger asChild>
           <Icon name={ ICON_NAME.circleInfo } style={{ fontSize: '24px' }} />
@@ -411,7 +415,7 @@ export const ZIndex: Story = {
 
       <Popover
         open
-        position={ POPOVER_POSITION.bottom }>
+        overlayConfig={{ position: POPOVER_POSITION.bottom }}>
         <PopoverTrigger asChild>
           <Icon name={ ICON_NAME.circleInfo } style={{ fontSize: '24px' }} />
         </PopoverTrigger>

--- a/packages/storybook/stories/components/select/select.stories.tsx
+++ b/packages/storybook/stories/components/select/select.stories.tsx
@@ -8,10 +8,12 @@ import { excludeFromDemoControls, orderControls } from '../../../src/helpers/con
 import { staticSourceRenderConfig } from '../../../src/helpers/source';
 
 type Story = StoryObj<SelectProp>;
-type DemoArg = Partial<SelectProp> & Partial<SelectControlProp> & {};
+type DemoArg = Partial<SelectProp> & Partial<SelectControlProp> & {
+  sameWidth?: boolean;
+};
 
 const meta: Meta<SelectProp> = {
-  argTypes: excludeFromDemoControls(['defaultValue', 'id', 'items', 'name', 'onValueChange', 'required', 'value']),
+  argTypes: excludeFromDemoControls(['defaultOpen', 'defaultValue', 'fitControlWidth', 'id', 'items', 'name', 'onOpenChange', 'onValueChange', 'open', 'overlayConfig', 'positionerStyle', 'required', 'value']),
   component: Select,
   subcomponents: { SelectContent, SelectControl },
   title: 'React Components/Select',
@@ -23,7 +25,6 @@ export const Demo: StoryObj = {
   render: (arg: DemoArg) => (
     <Select
       disabled={ arg.disabled }
-      fitControlWidth={ arg.fitControlWidth }
       invalid={ arg.invalid }
       items={[
         { label: 'Dog', value:'dog' },
@@ -34,6 +35,7 @@ export const Demo: StoryObj = {
         { label: 'Goldfish', value:'goldfish' },
       ]}
       multiple={ arg.multiple }
+      overlayConfig={{ sameWidth: arg.sameWidth }}
       readOnly={ arg.readOnly }>
       <SelectControl
         multipleSelectionLabel={ arg.multipleSelectionLabel }
@@ -44,12 +46,6 @@ export const Demo: StoryObj = {
   ),
   argTypes: orderControls({
     disabled: {
-      table: {
-        category: CONTROL_CATEGORY.general,
-      },
-      control: { type: 'boolean' },
-    },
-    fitControlWidth: {
       table: {
         category: CONTROL_CATEGORY.general,
       },
@@ -87,6 +83,12 @@ export const Demo: StoryObj = {
         category: CONTROL_CATEGORY.general,
       },
       control: 'boolean',
+    },
+    sameWidth: {
+      table: {
+        category: CONTROL_CATEGORY.general,
+      },
+      control: { type: 'boolean' },
     },
   }),
 };

--- a/packages/storybook/stories/components/tooltip/tooltip.stories.tsx
+++ b/packages/storybook/stories/components/tooltip/tooltip.stories.tsx
@@ -9,11 +9,14 @@ import { staticSourceRenderConfig } from '../../../src/helpers/source';
 
 type Story = StoryObj<TooltipProp>;
 type DemoArg = Partial<TooltipProp> & Partial<TooltipContentProp> & {
-  content?: string,
+  content?: string;
+  gutter?: number,
+  position?: TOOLTIP_POSITION,
+  sameWidth?: boolean,
 };
 
 const meta: Meta<TooltipProp> = {
-  argTypes: excludeFromDemoControls(['onOpenChange', 'open']),
+  argTypes: excludeFromDemoControls(['onOpenChange', 'open', 'overlayConfig', 'positionerStyle']),
   component: Tooltip,
   subcomponents: { TooltipContent, TooltipTrigger },
   title: 'React Components/Tooltip',
@@ -29,7 +32,11 @@ export const Demo: StoryObj = {
     <Tooltip
       closeDelay={ arg.closeDelay }
       openDelay={ arg.openDelay }
-      position={ arg.position }>
+      overlayConfig={{
+        gutter: arg.gutter,
+        position: arg.position,
+        sameWidth: arg.sameWidth,
+      }}>
       <TooltipTrigger asChild>
         <Icon
           name={ ICON_NAME.circleQuestion }
@@ -54,6 +61,13 @@ export const Demo: StoryObj = {
       },
       control: 'text',
     },
+    gutter: {
+      table: {
+        category: CONTROL_CATEGORY.design,
+        type: { summary: 'number' }
+      },
+      control: 'number',
+    },
     openDelay: {
       table: {
         category: CONTROL_CATEGORY.general,
@@ -67,6 +81,12 @@ export const Demo: StoryObj = {
       },
       control: { type: 'select' },
       options: TOOLTIP_POSITIONS,
+    },
+    sameWidth: {
+      table: {
+        category: CONTROL_CATEGORY.design,
+      },
+      control: { type: 'boolean' },
     },
     withArrow: {
       table: {
@@ -179,7 +199,7 @@ export const Grid: StoryObj = {
   tags: ['!dev'],
   render: ({}) => (
     <>
-      <Tooltip position="top-start">
+      <Tooltip overlayConfig={{ position: 'top-start' }}>
         <TooltipTrigger>
           Top Left
         </TooltipTrigger>
@@ -188,7 +208,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="top">
+      <Tooltip overlayConfig={{ position: 'top' }}>
         <TooltipTrigger>
           Top
         </TooltipTrigger>
@@ -197,7 +217,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="top-end">
+      <Tooltip overlayConfig={{ position: 'top-end' }}>
         <TooltipTrigger>
           Top Right
         </TooltipTrigger>
@@ -206,7 +226,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="left">
+      <Tooltip overlayConfig={{ position: 'left' }}>
         <TooltipTrigger>
           Middle Left
         </TooltipTrigger>
@@ -217,7 +237,7 @@ export const Grid: StoryObj = {
 
       <div />
 
-      <Tooltip position="right">
+      <Tooltip overlayConfig={{ position: 'right' }}>
         <TooltipTrigger>
           Middle Right
         </TooltipTrigger>
@@ -226,7 +246,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="bottom-start">
+      <Tooltip overlayConfig={{ position: 'bottom-start' }}>
         <TooltipTrigger>
           Bottom Left
         </TooltipTrigger>
@@ -235,7 +255,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="bottom">
+      <Tooltip overlayConfig={{ position: 'bottom' }}>
         <TooltipTrigger>
           Bottom
         </TooltipTrigger>
@@ -244,7 +264,7 @@ export const Grid: StoryObj = {
         </TooltipContent>
       </Tooltip>
 
-      <Tooltip position="bottom-end">
+      <Tooltip overlayConfig={{ position: 'bottom-end' }}>
         <TooltipTrigger>
           Bottom Right
         </TooltipTrigger>
@@ -357,7 +377,7 @@ export const ZIndex: Story = {
 
       <Tooltip
         open
-        position={ TOOLTIP_POSITION.bottom }
+        overlayConfig={{ position: TOOLTIP_POSITION.bottom }}
         positionerStyle={{ zIndex: 'calc(var(--ods-theme-overlay-z-index) + 1)'}}>
         <TooltipTrigger asChild>
           <Icon name={ ICON_NAME.circleInfo } style={{ fontSize: '24px' }} />
@@ -370,7 +390,7 @@ export const ZIndex: Story = {
 
       <Tooltip
         open
-        position={ TOOLTIP_POSITION.bottom }>
+        overlayConfig={{ position: TOOLTIP_POSITION.bottom }}>
         <TooltipTrigger asChild>
           <Icon name={ ICON_NAME.circleInfo } style={{ fontSize: '24px' }} />
         </TooltipTrigger>


### PR DESCRIPTION
Update all components that use overlays so that they all expose:
- open state management and associated handler.
- overlayConfig object that controls the overlay behavior (not all component get a whole config, only bare minimum was exposed for now for each, but it'll be easy to extend this in the future).

Combobox:
- add `defaultOpen`, `onOpenChange` , `open` and `overlayConfig` attributes.

Datepicker:
- add `onOpenChange` and `overlayConfig` attributes.

Menu:
- add `overlayConfig` attribute.
- depreciate `position` attribute.

Popover:
- add `overlayConfig` attribute.
- depreciate `gutter`, `position` and `sameWidth` attributes.

Select:
- add `defaultOpen`, `onOpenChange` , `open` and `overlayConfig` attributes.
- depreciate `fitControlWidth` attribute.

Tooltip:
- add `overlayConfig` attribute.
- depreciate `position` attribute.

Documentation:
- display object attribute as distincts rows with more information.