### PR TITLE
fix(datepicker): text input display bug

### DIFF
--- a/packages/ods-react/src/components/datepicker/src/components/datepicker-input/DatepickerInput.tsx
+++ b/packages/ods-react/src/components/datepicker/src/components/datepicker-input/DatepickerInput.tsx
@@ -1,5 +1,5 @@
 import { useDatePickerContext } from '@ark-ui/react/date-picker';
-import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type FC, type FormEvent, type JSX, forwardRef, useEffect, useState } from 'react';
 import { type Locale } from '../../../../../utils/locales';
 import { useFormField } from '../../../../form-field/src';
 import { INPUT_TYPE, Input } from '../../../../input/src';
@@ -20,6 +20,17 @@ const DatepickerInput: FC<DatepickerInputProp> = forwardRef(({
   const { i18n, invalid, locale, required } = useDatepicker();
   const fieldContext = useFormField();
   const { defaultValue, id: defaultId, ...arkProp } = getInputProps();
+  const [inputValue, setInputValue] = useState(defaultValue ?? '');
+
+  useEffect(() => {
+    setInputValue(defaultValue ?? '');
+  }, [defaultValue]);
+
+  const handleInput = (e: FormEvent<HTMLInputElement>): void => {
+    setInputValue(e.currentTarget.value);
+    arkProp.onInput?.(e);
+    props.onInput?.(e);
+  };
 
   return (
     <Input
@@ -31,10 +42,11 @@ const DatepickerInput: FC<DatepickerInputProp> = forwardRef(({
       invalid={ invalid || fieldContext?.invalid }
       loading={ loading }
       locale={ locale as Locale }
+      onInput={ handleInput }
       ref={ ref }
       required={ required }
       type={ INPUT_TYPE.text }
-      value={ defaultValue || '' } />
+      value={ inputValue } />
   );
 });
 

--- a/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
+++ b/packages/ods-react/src/components/datepicker/src/components/datepicker/Datepicker.tsx
@@ -18,6 +18,7 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
   disabled,
   disabledDates,
   disabledWeekDays,
+  i18n,
   id,
   invalid,
   locale,
@@ -71,7 +72,9 @@ const Datepicker: FC<DatepickerProp> = forwardRef(({
 
   return (
     <DatepickerProvider
+      i18n={ i18n }
       invalid={ invalid }
+      locale={ locale }
       positionerStyle={ positionerStyle }
       required={ required }>
       <DatePicker.Root

--- a/packages/ods-react/src/components/datepicker/tests/behavior/datepicker.e2e.ts
+++ b/packages/ods-react/src/components/datepicker/tests/behavior/datepicker.e2e.ts
@@ -13,7 +13,21 @@ async function getInputValue(page: Page): Promise<string> {
 }
 
 describe('Datepicker behavior', () => {
-  describe('clearable', () => {
+  describe('input', () => {
+    beforeEach(async() => {
+      await gotoStory(page, 'behavior/type-and-blur');
+      await page.waitForSelector('[data-ods="datepicker"]');
+    });
+
+    it('should keep the typed date visible after blur', async() => {
+      await page.type('[data-ods="datepicker-control"]', '01/01/2026');
+      await page.keyboard.press('Tab');
+
+      expect(await getInputValue(page)).not.toBe('');
+    });
+  });
+
+  describe.only('clearable', () => {
     describe('uncontrolled', () => {
       beforeEach(async() => {
         await gotoStory(page, 'behavior/clearable');

--- a/packages/ods-react/src/components/datepicker/tests/behavior/datepicker.stories.tsx
+++ b/packages/ods-react/src/components/datepicker/tests/behavior/datepicker.stories.tsx
@@ -16,6 +16,13 @@ export const Clearable = () => (
   </Datepicker>
 );
 
+export const TypeAndBlur = () => (
+  <Datepicker locale="en">
+    <DatepickerControl />
+    <DatepickerContent />
+  </Datepicker>
+);
+
 export const ClearableControlled = () => {
   const [value, setValue] = useState<Date | null>(new Date());
 

--- a/packages/ods-react/src/components/datepicker/tests/rendering/datepicker.stories.tsx
+++ b/packages/ods-react/src/components/datepicker/tests/rendering/datepicker.stories.tsx
@@ -34,7 +34,7 @@ export const ClearableValue = () => (
 );
 
 export const Render = () => (
-  <Datepicker>
+  <Datepicker locale='en'>
     <DatepickerControl />
 
     <DatepickerContent />


### PR DESCRIPTION
Ark UI manages the datepicker input as an uncontrolled element: 
-> getInputProps() returns defaultValue (not value).
therefore in `<Input value={defaultValue || ''} />`, defaultValue only reflects the last committed date (after blur, Enter, or calendar selection), and not the text being actively typed.

Before the date is committed via blur, defaultValue is undefined, so React enforced value='', overriding Ark's DOM updates.

We need to track keystrokes to properly sync the display and avoid Ark/React conflicts

\+ added e2e and fixed `locale` & `i18n` missing props




