### PR TITLE
fix(combobox): allow controlled combobox to be cleared programmatically

### DIFF
--- a/packages/ods-react/src/components/combobox/src/contexts/useCombobox.tsx
+++ b/packages/ods-react/src/components/combobox/src/contexts/useCombobox.tsx
@@ -254,6 +254,10 @@ const ComboboxProvider = ({
   }, [open]);
 
   useEffect(() => {
+    if (!value) {
+      return;
+    }
+
     const matchingItems = getDefaultSelection(items, value);
 
     if (matchingItems.length) {
@@ -264,6 +268,9 @@ const ComboboxProvider = ({
         setInputValue('');
         _setSelection(matchingItems);
       }
+    } else if (value.length === 0) {
+      setInputValue('');
+      _setSelection([]);
     }
   }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/ods-react/src/components/combobox/tests/behavior/combobox.e2e.ts
+++ b/packages/ods-react/src/components/combobox/tests/behavior/combobox.e2e.ts
@@ -90,6 +90,16 @@ describe('Combobox behaviour', () => {
 
       expect(await getInputValue(page)).toBe('Banana');
     });
+
+    it('should clear value when set to []', async() => {
+      const clearValueButton = await page.$('#clear-value');
+
+      expect(await getInputValue(page)).toBe('Apple');
+
+      await clearValueButton?.click();
+
+      expect(await getInputValue(page)).toBe('');
+    });
   });
 
   describe('on blur', () => {

--- a/packages/ods-react/src/components/combobox/tests/behavior/combobox.stories.tsx
+++ b/packages/ods-react/src/components/combobox/tests/behavior/combobox.stories.tsx
@@ -65,6 +65,12 @@ export const ControlledValue = () => {
         Force value "Banana"
       </button>
 
+      <button
+        id="clear-value"
+        onClick={ () => setValues([]) }>
+        Clear value
+      </button>
+
       <Combobox
         items={ simpleItems }
         onValueChange={ ({ value }) => setValues(value) }


### PR DESCRIPTION
As per reported by a user: 
Controlled combobox could be set to values but not emptied