### PR TITLE
fix(e2e): fix flaky tests caused by Vite dep re-optimization on pnpm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,12 +20,31 @@
     "eslint-plugin-tsdoc",
     "react"
   ],
-  "ignorePatterns": ["packages/storybook/**", "**/*.stories.tsx"],
+  "ignorePatterns": ["packages/storybook/**", "**/tests/**/*.stories.tsx"],
   "overrides": [
     {
       "files": ["*.js", "*.mjs", "*.config.ts"],
       "parserOptions": {
         "project": false
+      }
+    },
+    {
+      "files": ["**/src/dev.stories.tsx"],
+      "parserOptions": {
+        "project": false
+      },
+      "rules": {
+        "@typescript-eslint/consistent-type-exports": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "no-console": "off",
+        "react/no-unescaped-entities": "off",
+        "no-restricted-imports": ["error", {
+          "paths": [{
+            "name": "@ovhcloud/ods-react",
+            "message": "Use relative imports to sibling component sources instead of the package barrel."
+          }]
+        }],
+        "sort-keys": "off"
       }
     }
   ],

--- a/packages/ods-react/src/components/accordion/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/accordion/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { Button } from '../../button/src';
-import { Text, TEXT_PRESET } from '../../text/src';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, EXPAND_ICON_POSITION } from '.';
 import style from './dev.module.css';
+import { Button } from '../../button/src';
+import { TEXT_PRESET, Text } from '../../text/src';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, EXPAND_ICON_POSITION } from '.';
 
 export default {
   component: Accordion,
@@ -223,8 +223,8 @@ export const Product = () => (
   <Accordion>
     <AccordionItem value="1">
       <AccordionTrigger className={ style['accordion-custom-trigger'] } expandIconPosition={ EXPAND_ICON_POSITION.left }>
-        <Text preset={ TEXT_PRESET.paragraph } style={{ margin: 0}}>Nom de la famille du produit</Text>
-        <Text preset={ TEXT_PRESET.heading4 } as={'span'} style={{ margin: 0}}>Nom du produit</Text>
+        <Text preset={ TEXT_PRESET.paragraph } style={{ margin: 0 }}>Nom de la famille du produit</Text>
+        <Text preset={ TEXT_PRESET.heading4 } as={'span'} style={{ margin: 0 }}>Nom du produit</Text>
       </AccordionTrigger>
       <AccordionContent className={ style['product-details']}>
         <Text preset="paragraph">
@@ -233,4 +233,4 @@ export const Product = () => (
       </AccordionContent>
     </AccordionItem>
   </Accordion>
-)
+);

--- a/packages/ods-react/src/components/accordion/tsconfig.json
+++ b/packages/ods-react/src/components/accordion/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/avatar/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/avatar/src/dev.stories.tsx
@@ -1,4 +1,4 @@
-import { Icon, ICON_NAME } from '../../icon/src';
+import { ICON_NAME, Icon } from '../../icon/src';
 import { Avatar } from '.';
 
 export default {
@@ -14,18 +14,18 @@ export const Initials = () => (
   <Avatar>
     T
   </Avatar>
-)
+);
 
 export const Image = () => (
-  <Avatar src={"https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/Logo-OVH.svg/960px-Logo-OVH.svg.png"} />
-)
+  <Avatar src={'https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/Logo-OVH.svg/960px-Logo-OVH.svg.png'} />
+);
 
 export const Fallback = () => (
-  <Avatar fallback={'T'} src={"/asdasdwqe"} />
-)
+  <Avatar fallback={'T'} src={'/asdasdwqe'} />
+);
 
 export const AI = () => (
   <Avatar>
     <Icon name={ ICON_NAME.sparkle } />
   </Avatar>
-)
+);

--- a/packages/ods-react/src/components/avatar/tsconfig.json
+++ b/packages/ods-react/src/components/avatar/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/badge/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/badge/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { BADGE_COLORS, BADGE_SIZES, Badge } from '.';
 import style from './dev.module.css';
+import { BADGE_COLORS, BADGE_SIZES, Badge } from '.';
 
 export default {
   component: Badge,

--- a/packages/ods-react/src/components/badge/tsconfig.json
+++ b/packages/ods-react/src/components/badge/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/breadcrumb/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/breadcrumb/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useRef } from 'react';
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '.';
 import style from './dev.module.css';
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '.';
 
 export default {
   component: Breadcrumb,
@@ -177,6 +177,7 @@ export const Ref = () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DummyLink = forwardRef(({ children, ...props }: any, ref) => {
   return (
     <a data-test="dummy" { ...props } ref={ ref }>{ children }</a>

--- a/packages/ods-react/src/components/breadcrumb/tsconfig.json
+++ b/packages/ods-react/src/components/breadcrumb/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/button-group/tsconfig.json
+++ b/packages/ods-react/src/components/button-group/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/button/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/button/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { BUTTON_COLOR, BUTTON_COLORS, BUTTON_SIZES, BUTTON_VARIANTS, Button } from '.';
 import style from './dev.module.css';
+import { BUTTON_COLOR, BUTTON_COLORS, BUTTON_SIZES, BUTTON_VARIANTS, Button } from '.';
 
 export default {
   component: Button,
@@ -63,7 +63,7 @@ export const Accessibility = () => (
   <Button aria-label="Accessibility">
     Accessibility
   </Button>
-)
+);
 
 export const Sizes = () => (
   <div style={{ display: 'flex', flexFlow: 'column', rowGap: '16px' }}>

--- a/packages/ods-react/src/components/button/tsconfig.json
+++ b/packages/ods-react/src/components/button/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/card/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/card/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { CARD_COLORS, Card } from '.';
 import style from './dev.module.css';
+import { CARD_COLORS, Card } from '.';
 
 export default {
   component: Card,

--- a/packages/ods-react/src/components/card/tsconfig.json
+++ b/packages/ods-react/src/components/card/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/cart/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/cart/src/dev.stories.tsx
@@ -1,8 +1,8 @@
+import styles from './dev.module.css';
 import { formatPrice } from '../../../utils';
 import { ICON_NAME, Icon } from '../../icon/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Cart, CartAction, CartEmpty, CartExtraContent, CartProductGroup, CartProductGroupItem, CartTotal } from '.';
-import styles from './dev.module.css';
 
 export default {
   component: Cart,

--- a/packages/ods-react/src/components/cart/tsconfig.json
+++ b/packages/ods-react/src/components/cart/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/checkbox/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/checkbox/src/dev.stories.tsx
@@ -1,8 +1,8 @@
-import { Checkbox, CheckboxControl, CheckboxGroup, CheckboxLabel } from '.';
+import { useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper } from '../../form-field/src';
 import { TEXT_PRESET, Text } from '../../text/src';
-import style from './dev.module.css';
-import { useState } from 'react';
+import { Checkbox, CheckboxControl, CheckboxGroup, CheckboxLabel } from '.';
 
 export default {
   component: Checkbox,
@@ -211,6 +211,7 @@ export const ControlledIndeterminate = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
       <Checkbox
+        // eslint-disable-next-line no-nested-ternary
         checked={isAllSelected ? true : isIndeterminate ? 'indeterminate' : false}
         onCheckedChange={handleSelectAllChange}
       >
@@ -247,12 +248,13 @@ export const UncontrolledIndeterminate = () => {
     const newValues = details.checked ? items : [];
     setCurrentValue(newValues);
     setDefaultValue(newValues);
-    setGroupKey(k => k + 1);
+    setGroupKey((k: number) => k + 1);
   };
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
       <Checkbox
+        // eslint-disable-next-line no-nested-ternary
         checked={allChecked ? true : isIndeterminate ? 'indeterminate' : false}
         onCheckedChange={handleSelectAllChange}
       >

--- a/packages/ods-react/src/components/checkbox/tsconfig.json
+++ b/packages/ods-react/src/components/checkbox/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/clipboard/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/clipboard/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
+import style from './dev.module.css';
 import { INPUT_I18N } from '../../input/src';
 import { Clipboard, ClipboardControl, ClipboardTrigger } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Clipboard,

--- a/packages/ods-react/src/components/clipboard/tsconfig.json
+++ b/packages/ods-react/src/components/clipboard/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/code/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/code/src/dev.stories.tsx
@@ -1,7 +1,7 @@
-import { Code } from '.';
-import style from './dev.module.css'
 import lang from '@shikijs/langs/typescript';
 import theme from '@shikijs/themes/nord';
+import style from './dev.module.css';
+import { Code } from '.';
 
 export default {
   component: Code,
@@ -10,19 +10,19 @@ export default {
 
 export const CanCopy = () => (
   <Code canCopy>
-    {`import { Text } from '@ovhcloud/ods-react';`}
+    {'import { Text } from \'@ovhcloud/ods-react\';'}
   </Code>
 );
 
 export const CustomStyle = () => (
   <Code canCopy className={ style['custom-code'] }>
-    {`import { Text } from '@ovhcloud/ods-react';`}
+    {'import { Text } from \'@ovhcloud/ods-react\';'}
   </Code>
 );
 
 export const Default = () => (
   <Code>
-    {`import { Text } from '@ovhcloud/ods-react';`}
+    {'import { Text } from \'@ovhcloud/ods-react\';'}
   </Code>
 );
 
@@ -33,7 +33,7 @@ export const Highlight = () => (
         language: lang,
         theme: theme,
       }}>
-      {`import { Text } from '@ovhcloud/ods-react';`}
+      {'import { Text } from \'@ovhcloud/ods-react\';'}
     </Code>
 
     <br /><br />
@@ -44,7 +44,7 @@ export const Highlight = () => (
         language: lang,
         theme: theme,
       }}>
-      {`import { Text } from '@ovhcloud/ods-react';`}
+      {'import { Text } from \'@ovhcloud/ods-react\';'}
     </Code>
   </>
 );

--- a/packages/ods-react/src/components/code/tsconfig.json
+++ b/packages/ods-react/src/components/code/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/combobox/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/combobox/src/dev.stories.tsx
@@ -1,10 +1,10 @@
 import { type FormEvent, useRef, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldLabel } from '../../form-field/src';
 import { ICON_NAME, Icon } from '../../icon/src';
 import { INPUT_I18N } from '../../input/src';
 import { Modal, ModalBody, ModalContent, ModalTrigger } from '../../modal/src';
 import { Combobox, ComboboxContent, ComboboxControl, type ComboboxItem, type ComboboxValueChangeDetails } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Combobox,
@@ -93,7 +93,7 @@ export const Clearable = () => (
   <>
     <Combobox
       items={ items }
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -103,7 +103,7 @@ export const Clearable = () => (
     <Combobox
       defaultValue={ [items[0].value] }
       items={ items }
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -114,7 +114,7 @@ export const Clearable = () => (
       defaultValue={ [items[0].value] }
       disabled
       items={ items }
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -124,8 +124,9 @@ export const Clearable = () => (
     <Combobox
       defaultValue={ [items[0].value] }
       items={ items }
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }
-      readOnly>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }
+      readOnly
+    >
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -146,7 +147,7 @@ export const Controlled = () => {
       </p>
 
       <button onClick={ () => setValues(['the-cat']) }>
-        Force value "Cat"
+        Force value `Cat`
       </button>
 
       <Combobox
@@ -158,7 +159,7 @@ export const Controlled = () => {
       </Combobox>
     </>
   );
-}
+};
 
 export const CustomFilter = () => (
   <>
@@ -182,12 +183,12 @@ export const CustomOptionRenderer = () => {
   }
 
   const items = [
-    { label: 'Dog', value: 'dog', customRendererData: { description: 'My dog is stupid' }},
-    { label: 'Cat', value: 'cat', customRendererData: { description: 'All cats are awesome' }},
-    { label: 'Hamster', value: 'hamster', customRendererData: { description: 'Where is my hamster?' }},
-    { label: 'Parrot', value: 'parrot', customRendererData: { description: 'Repeat repeat repeat' }},
-    { label: 'Spider', value: 'spider', customRendererData: { description: 'Spider? Where?' }},
-    { label: 'Goldfish', value: 'goldfish', customRendererData: { description: 'Cool a new aquarium' }},
+    { label: 'Dog', value: 'dog', customRendererData: { description: 'My dog is stupid' } },
+    { label: 'Cat', value: 'cat', customRendererData: { description: 'All cats are awesome' } },
+    { label: 'Hamster', value: 'hamster', customRendererData: { description: 'Where is my hamster?' } },
+    { label: 'Parrot', value: 'parrot', customRendererData: { description: 'Repeat repeat repeat' } },
+    { label: 'Spider', value: 'spider', customRendererData: { description: 'Spider? Where?' } },
+    { label: 'Goldfish', value: 'goldfish', customRendererData: { description: 'Cool a new aquarium' } },
   ];
 
   return (
@@ -343,7 +344,7 @@ export const Handlers = () => {
         value={ valueChangeEvents.join('\n----------\n') } />
     </>
   );
-}
+};
 
 export const HighlightResults = () => (
   <Combobox
@@ -398,7 +399,7 @@ export const InFormRequired = () => {
     const formData = new FormData(formRef.current!);
 
     for (const [key, value] of formData) {
-      console.log(`${key}: ${value}`)
+      console.log(`${key}: ${value}`);
     }
   }
 
@@ -529,7 +530,7 @@ export const Opened = () => {
       </Combobox>
     </>
   );
-}
+};
 
 export const Placeholder = () => (
   <Combobox items={ items }>
@@ -630,7 +631,7 @@ export const MultipleClearable = () => (
     <Combobox
       items={ items }
       multiple
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -641,7 +642,7 @@ export const MultipleClearable = () => (
       defaultValue={ [items[0].value] }
       items={ items }
       multiple
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -653,7 +654,7 @@ export const MultipleClearable = () => (
       disabled
       items={ items }
       multiple
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }>
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }>
       <ComboboxControl clearable />
       <ComboboxContent />
     </Combobox>
@@ -664,7 +665,7 @@ export const MultipleClearable = () => (
       defaultValue={ [items[0].value] }
       items={ items }
       multiple
-      onValueChange={ (v) => console.log(`[DEV]: value:`, v) }
+      onValueChange={ (v) => console.log('[DEV]: value:', v) }
       readOnly>
       <ComboboxControl clearable />
       <ComboboxContent />
@@ -686,7 +687,7 @@ export const MultipleControlled = () => {
       </p>
 
       <button onClick={ () => setValues(['the-cat']) }>
-        Force value "Cat"
+        Force value `Cat`
       </button>
 
       <Combobox
@@ -699,7 +700,7 @@ export const MultipleControlled = () => {
       </Combobox>
     </>
   );
-}
+};
 
 export const MultipleCustomFilter = () => (
   <>
@@ -774,7 +775,7 @@ export const MultipleHandlers = () => {
         value={ valueChangeEvents.join('\n----------\n') } />
     </>
   );
-}
+};
 
 export const MultipleNoCustom = () => (
   <Combobox

--- a/packages/ods-react/src/components/combobox/tsconfig.json
+++ b/packages/ods-react/src/components/combobox/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/data-table/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/data-table/src/dev.stories.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { DataTable, DataTableBody, type DataTableColumnDef, type DataTableColumnPinningState, type DataTableColumnVisibilityState, DataTableEmpty, DataTableHead, type DataTableRowSelectionState, type DataTableSortingState } from '.';
 import { Editable, EditableActions, EditableDisplay, EditableDisplayEmpty, EditableInput } from '../../editable/src';
 import { ICON_NAME, Icon } from '../../icon/src';
-import { Quantity, QuantityControl, QuantityInput } from '../../quantity/src';
 import { Pagination } from '../../pagination/src';
+import { Quantity, QuantityControl, QuantityInput } from '../../quantity/src';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../tooltip/src';
+import { DataTable, DataTableBody, type DataTableColumnDef, type DataTableColumnPinningState, type DataTableColumnVisibilityState, DataTableEmpty, DataTableHead, type DataTableRowSelectionState, type DataTableSortingState } from '.';
 
 export default {
   component: DataTable,
@@ -100,6 +100,7 @@ export const CustomRender = () => {
       id: 'age',
       cell: ({ cell }) => {
         const value = cell.getValue<number>();
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         const bufferValue = useRef(value);
 
         return (
@@ -127,7 +128,7 @@ export const CustomRender = () => {
 
             <EditableActions />
           </Editable>
-        )
+        );
       },
       header: () => (
         <div>
@@ -214,7 +215,7 @@ export const Pinning = () => {
         <DataTableBody />
       </DataTable>
 
-      <button onClick={() => setPinningState({right: ['firstName']})}>UPDATE</button>
+      <button onClick={() => setPinningState({ right: ['firstName'] })}>UPDATE</button>
     </>
   );
 };
@@ -306,7 +307,8 @@ export const Sorting = () => {
         const valueB = rowB.getValue<string>(columnId).split('-')[1];
 
         return Number(valueA) - Number(valueB);
-      }},
+      },
+    },
   ], []);
 
   const customSortingData = useMemo(() => [
@@ -380,7 +382,7 @@ export const StickyHeader = () => {
     }
 
     return dummyData;
-  }, [])
+  }, []);
 
   return (
     <DataTable
@@ -396,7 +398,7 @@ export const StickyHeader = () => {
       </DataTableEmpty>
     </DataTable>
   );
-}
+};
 
 export const Visibility = () => {
   const [columnVisibility, setColumnVisibility] = useState<DataTableColumnVisibilityState>({
@@ -421,7 +423,7 @@ export const Visibility = () => {
       </DataTableEmpty>
     </DataTable>
   );
-}
+};
 
 type PaginationPerson = {
   id: string;

--- a/packages/ods-react/src/components/data-table/tsconfig.json
+++ b/packages/ods-react/src/components/data-table/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/datepicker/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/datepicker/src/dev.stories.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { INPUT_I18N } from '../../input/src';
 import { Modal, ModalBody, ModalContent } from '../../modal/src';
 import { Datepicker, DatepickerContent, DatepickerControl, type DatepickerView } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Datepicker,
@@ -45,7 +45,7 @@ export const Controlled = () => {
       </Datepicker>
     </>
   );
-}
+};
 
 export const CustomStyle = () => (
   <Datepicker className={ style['custom-datepicker'] }>

--- a/packages/ods-react/src/components/datepicker/tsconfig.json
+++ b/packages/ods-react/src/components/datepicker/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/divider/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/divider/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { DIVIDER_COLOR, Divider } from '.';
 import style from './dev.module.css';
+import { DIVIDER_COLOR, Divider } from '.';
 
 export default {
   component: Divider,

--- a/packages/ods-react/src/components/divider/tsconfig.json
+++ b/packages/ods-react/src/components/divider/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/drawer/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/drawer/src/dev.stories.tsx
@@ -1,6 +1,6 @@
-import { DRAWER_POSITION, Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '.';
-import { Popover, PopoverContent, PopoverTrigger } from '../../popover/src';
 import style from './dev.module.css';
+import { Popover, PopoverContent, PopoverTrigger } from '../../popover/src';
+import { DRAWER_POSITION, Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '.';
 
 export default {
   component: Drawer,
@@ -76,50 +76,50 @@ export const OverlayBehind = () => (
 export const Position = () => (
   <div>
 
-  <Drawer>
-    <DrawerTrigger>
-      Top
-    </DrawerTrigger>
-
-    <DrawerContent position={ DRAWER_POSITION.top }>
-      <DrawerBody>
+    <Drawer>
+      <DrawerTrigger>
         Top
-      </DrawerBody>
-    </DrawerContent>
-  </Drawer>
+      </DrawerTrigger>
 
-  <Drawer>
-    <DrawerTrigger>
-      Left
-    </DrawerTrigger>
+      <DrawerContent position={ DRAWER_POSITION.top }>
+        <DrawerBody>
+          Top
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
 
-    <DrawerContent position={ DRAWER_POSITION.left }>
-      <DrawerBody>
+    <Drawer>
+      <DrawerTrigger>
         Left
-      </DrawerBody>
-    </DrawerContent>
-  </Drawer>
-  <Drawer>
-    <DrawerTrigger>
-      Bottom
-    </DrawerTrigger>
+      </DrawerTrigger>
 
-    <DrawerContent position={ DRAWER_POSITION.bottom }>
-      <DrawerBody>
+      <DrawerContent position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Left
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+    <Drawer>
+      <DrawerTrigger>
         Bottom
-      </DrawerBody>
-    </DrawerContent>
-  </Drawer>
-  <Drawer>
-    <DrawerTrigger>
-      Right
-    </DrawerTrigger>
+      </DrawerTrigger>
 
-    <DrawerContent position={ DRAWER_POSITION.right }>
-      <DrawerBody>
+      <DrawerContent position={ DRAWER_POSITION.bottom }>
+        <DrawerBody>
+          Bottom
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+    <Drawer>
+      <DrawerTrigger>
         Right
-      </DrawerBody>
-    </DrawerContent>
-  </Drawer>
+      </DrawerTrigger>
+
+      <DrawerContent position={ DRAWER_POSITION.right }>
+        <DrawerBody>
+          Right
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
   </div>
 );

--- a/packages/ods-react/src/components/drawer/tsconfig.json
+++ b/packages/ods-react/src/components/drawer/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/editable/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/editable/src/dev.stories.tsx
@@ -126,15 +126,15 @@ export const CustomActions = () => (
       {
         ({ editing }) => (
           editing
-          ? <>
-            <EditableSubmitTrigger asChild>
-              <button>Custom Submit</button>
-            </EditableSubmitTrigger>
-            <EditableCancelTrigger asChild>
-              <button>Custom Cancel</button>
-            </EditableCancelTrigger>
-          </>
-          : <EditableEditTrigger asChild>
+            ? <>
+              <EditableSubmitTrigger asChild>
+                <button>Custom Submit</button>
+              </EditableSubmitTrigger>
+              <EditableCancelTrigger asChild>
+                <button>Custom Cancel</button>
+              </EditableCancelTrigger>
+            </>
+            : <EditableEditTrigger asChild>
               <button>Custom Edit</button>
             </EditableEditTrigger>
         )
@@ -182,11 +182,11 @@ export const Refs = () => {
   const editTriggerAsChildRef = useRef<HTMLButtonElement>(null);
 
   function logRefs() {
-    console.log(`rootRef:`, rootRef.current);
-    console.log(`displayRef:`, displayRef.current);
-    console.log(`inputRef:`, inputRef.current);
-    console.log(`editTriggerRef:`, editTriggerRef.current);
-    console.log(`editTriggerAsChildRef:`, editTriggerAsChildRef.current);
+    console.log('rootRef:', rootRef.current);
+    console.log('displayRef:', displayRef.current);
+    console.log('inputRef:', inputRef.current);
+    console.log('editTriggerRef:', editTriggerRef.current);
+    console.log('editTriggerAsChildRef:', editTriggerAsChildRef.current);
   }
 
   return (

--- a/packages/ods-react/src/components/editable/tsconfig.json
+++ b/packages/ods-react/src/components/editable/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/file-thumbnail/tsconfig.json
+++ b/packages/ods-react/src/components/file-thumbnail/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/file-upload/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/file-upload/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { FILE_UPLOAD_VARIANT, FileUpload, FileUploadItem, FileUploadList } from '.';
-import style from './dev.module.css';
 
 export default {
   component: FileUpload,
@@ -43,10 +43,11 @@ export const AccessibilityErrors = () => {
         uploadFile(file);
       }
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files]);
 
   function toggleGlobalError() {
-    setGlobalError((err) => !!err ? '' : 'Global Error!');
+    setGlobalError((err) => err ? '' : 'Global Error!');
   }
 
   function uploadFile(file: MyFile): void {
@@ -241,6 +242,7 @@ export const FakeUpload = () => {
         uploadFile(file);
       }
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files]);
 
   function uploadFile(file: MyFile): void {

--- a/packages/ods-react/src/components/file-upload/tsconfig.json
+++ b/packages/ods-react/src/components/file-upload/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/form-field/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/form-field/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { type FormEvent, useRef } from 'react';
-import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel, FormFieldLabelSubLabel } from '.';
+import style from './dev.module.css';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Textarea } from '../../textarea/src';
-import style from './dev.module.css';
+import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel, FormFieldLabelSubLabel } from '.';
 
 export default {
   component: FormField,
@@ -24,7 +24,7 @@ export const FullForm = () => {
     const formData = new FormData(formRef.current!);
 
     for (const [key, value] of formData) {
-      console.log(`${key}: ${value}`)
+      console.log(`${key}: ${value}`);
     }
   }
 

--- a/packages/ods-react/src/components/form-field/tsconfig.json
+++ b/packages/ods-react/src/components/form-field/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/icon/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/icon/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { ICON_NAME, Icon } from '.';
 import style from './dev.module.css';
+import { ICON_NAME, Icon } from '.';
 
 export default {
   component: Icon,
@@ -11,8 +11,8 @@ export const Default = () => (
 );
 
 export const CustomStyle = () => (
-    <Icon
-      className={ style['custom-icon'] }
-      name={ ICON_NAME.circleCheck }
-    />
+  <Icon
+    className={ style['custom-icon'] }
+    name={ ICON_NAME.circleCheck }
+  />
 );

--- a/packages/ods-react/src/components/icon/tsconfig.json
+++ b/packages/ods-react/src/components/icon/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/input/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/input/src/dev.stories.tsx
@@ -1,8 +1,9 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { INPUT_TYPE, Input } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Input,
@@ -160,7 +161,9 @@ export const ClearableControlled = () => {
 
       <Input
         clearable
-        onChange={ (e: ChangeEvent<HTMLInputElement>) => { setInputValue(e.target.value)} }
+        onChange={ (e: ChangeEvent<HTMLInputElement>) => {
+          setInputValue(e.target.value);
+        }}
         value={ inputValue } />
     </>
   );
@@ -175,7 +178,9 @@ export const ControlledUncontrolled = () => {
       <Input
         clearable
         onChange={ (e: ChangeEvent<HTMLInputElement>) => setControlledValue(e.target.value) }
-        onClear={ () => { setControlledValue('') } }
+        onClear={ () => {
+          setControlledValue('');
+        }}
         value={ controlledValue } />
 
       <br /><br />
@@ -321,7 +326,7 @@ export const Ref = () => {
   return (
     <Input ref={ inputRef } />
   );
-}
+};
 
 export const States = () => (
   <>

--- a/packages/ods-react/src/components/input/tsconfig.json
+++ b/packages/ods-react/src/components/input/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/kbd/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/kbd/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { Kbd } from '.';
 import style from './dev.module.css';
+import { Kbd } from '.';
 
 export default {
   component: Kbd,

--- a/packages/ods-react/src/components/kbd/tsconfig.json
+++ b/packages/ods-react/src/components/kbd/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/link/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/link/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useRef } from 'react';
+import style from './dev.module.css';
 import { ICON_NAME, Icon } from '../../icon/src';
 import { Link } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Link,
@@ -98,6 +98,7 @@ export const Ref = () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DummyLink = forwardRef(({ children, ...props }: any, ref) => {
   return (
     <a data-test="dummy" { ...props } ref={ ref }>{ children }</a>
@@ -145,15 +146,15 @@ export const CustomStyle = () => (
       </Link>
     </div>
   </>
-)
+);
 
 export const Accessibility = () => (
   <>
     <h3>Icon only</h3>
     <h4>With href</h4>
-  <Link aria-label="Go to homepage" href="https://www.ovhcloud.com/">
-    <Icon name={ ICON_NAME.home } />
-  </Link>
+    <Link aria-label="Go to homepage" href="https://www.ovhcloud.com/">
+      <Icon name={ ICON_NAME.home } />
+    </Link>
     <h4>Without href</h4>
     <Link aria-label="Go to homepage">
       <Icon name={ ICON_NAME.home } />

--- a/packages/ods-react/src/components/link/tsconfig.json
+++ b/packages/ods-react/src/components/link/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/logo/tsconfig.json
+++ b/packages/ods-react/src/components/logo/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/markdown/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/markdown/src/dev.stories.tsx
@@ -21,7 +21,7 @@ export const CustomComponents = () => (
             { children as string }
           </Code>
         );
-      }
+      },
     }}
     content={`# heading 1
   \`\`\`
@@ -76,4 +76,4 @@ export const ODSComponents = () => {
         content={ content } />
     </>
   );
-}
+};

--- a/packages/ods-react/src/components/markdown/tsconfig.json
+++ b/packages/ods-react/src/components/markdown/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/medium/tsconfig.json
+++ b/packages/ods-react/src/components/medium/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/menu/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/menu/src/dev.stories.tsx
@@ -1,13 +1,13 @@
 import { Menu as ArkMenu } from '@ark-ui/react/menu';
 import { Portal } from '@ark-ui/react/portal';
 import { type JSX, useState } from 'react';
+import style from './dev.module.css';
 import { BADGE_COLOR, Badge } from '../../badge/src';
 import { Button } from '../../button/src';
 import { Checkbox, CheckboxControl, CheckboxLabel } from '../../checkbox/src';
 import { ICON_NAME, Icon } from '../../icon/src';
 import { Kbd } from '../../kbd/src';
 import { Menu, MenuContent, MenuGroup, MenuGroupLabel, MenuItem, MenuSubmenu, MenuTrigger } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Menu,

--- a/packages/ods-react/src/components/menu/tsconfig.json
+++ b/packages/ods-react/src/components/menu/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/message-bubble/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/message-bubble/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { MESSAGE_BUBBLE_VARIANT, MessageBubble } from '.';
 import styles from './dev.module.css';
+import { MESSAGE_BUBBLE_VARIANT, MessageBubble } from '.';
 
 export default {
   component: MessageBubble,
@@ -16,8 +16,8 @@ export const Typing = () => (
 
 export const Variant = () => (
   <>
-  <MessageBubble variant={ MESSAGE_BUBBLE_VARIANT.ai } />
-  <MessageBubble variant={ MESSAGE_BUBBLE_VARIANT.human } />
+    <MessageBubble variant={ MESSAGE_BUBBLE_VARIANT.ai } />
+    <MessageBubble variant={ MESSAGE_BUBBLE_VARIANT.human } />
   </>
 );
 
@@ -34,4 +34,4 @@ export const Conversation = () => (
     <MessageBubble>How are you?</MessageBubble>
     <MessageBubble typing />
   </div>
-)
+);

--- a/packages/ods-react/src/components/message-bubble/tsconfig.json
+++ b/packages/ods-react/src/components/message-bubble/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/message/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/message/src/dev.stories.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import type { Locale } from '../../../utils/locales';
 import { useState } from 'react';
-import { MESSAGE_COLORS, MESSAGE_I18N, MESSAGE_VARIANTS, Message, MessageBody, MessageIcon } from '.';
 import style from './dev.module.css';
-import { Locale } from '../../../utils/locales';
+import { MESSAGE_COLORS, MESSAGE_I18N, MESSAGE_VARIANTS, Message, MessageBody, MessageIcon } from '.';
 
 export default {
   component: Message,
@@ -47,7 +48,7 @@ export const A11Y = () => {
       </div>
     </>
   );
-}
+};
 
 export const Colors = () => (
   <div style={{ display: 'flex', flexFlow: 'column', rowGap: '8px' }}>
@@ -165,7 +166,11 @@ export const Multiline = () => (
   <>
     <Message>
       <MessageBody>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
       </MessageBody>
     </Message>
 
@@ -175,7 +180,11 @@ export const Multiline = () => (
       <MessageIcon name="circle-info" />
 
       <MessageBody>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
       </MessageBody>
     </Message>
   </>

--- a/packages/ods-react/src/components/message/tsconfig.json
+++ b/packages/ods-react/src/components/message/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/meter/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/meter/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Meter } from '.';
 import style from './dev.module.css';
+import { Meter } from '.';
 
 export default {
   component: Meter,
@@ -95,7 +95,6 @@ export const Optimum = () => {
     </>
   );
 };
-
 
 export const Thresholds = () => {
   const [high, setHigh] = useState(66);

--- a/packages/ods-react/src/components/meter/tsconfig.json
+++ b/packages/ods-react/src/components/meter/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/modal/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/modal/src/dev.stories.tsx
@@ -1,11 +1,11 @@
 import { useRef, useState } from 'react';
+import style from './dev.module.css';
 import { Button } from '../../button/src';
 import { ICON_NAME, Icon } from '../../icon/src';
 import { Popover, PopoverContent, PopoverTrigger } from '../../popover/src';
 import { Select, SelectContent, SelectControl } from '../../select/src';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../tooltip/src';
 import { Modal, ModalBody, ModalContent, ModalHeader, type ModalOpenChangeDetail, ModalTrigger } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Modal,
@@ -134,9 +134,34 @@ export const LargeContent = () => (
 
     <ModalContent>
       <ModalBody>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-        <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?</p>
-        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.</p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+        <p>
+          Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+          aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+          dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+          amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam
+          aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+          laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea
+          voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+          pariatur?
+        </p>
+        <p>
+          At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti
+          atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique
+          sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum
+          facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil
+          impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor
+          repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et
+          voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus,
+          ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.
+        </p>
       </ModalBody>
     </ModalContent>
   </Modal>

--- a/packages/ods-react/src/components/modal/tsconfig.json
+++ b/packages/ods-react/src/components/modal/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/pagination/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/pagination/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, PaginationPages } from '.';
 import style from './dev.module.css';
+import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, PaginationPages } from '.';
 
 export default {
   component: Pagination,
@@ -134,10 +134,10 @@ export const Refs = () => {
       </Pagination>
 
       <button onClick={ () => {
-        console.log(paginationRef.current)
-        console.log(paginationPagesRef.current)
-        console.log(paginationPageSelectorRef.current)
-        console.log(paginationPageSizeSelectorRef.current)
+        console.log(paginationRef.current);
+        console.log(paginationPagesRef.current);
+        console.log(paginationPageSelectorRef.current);
+        console.log(paginationPageSizeSelectorRef.current);
       }}>
         Log refs
       </button>

--- a/packages/ods-react/src/components/pagination/tsconfig.json
+++ b/packages/ods-react/src/components/pagination/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/password/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/password/src/dev.stories.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import { type ChangeEvent, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { INPUT_I18N } from '../../input/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Password } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Password,
@@ -119,7 +120,7 @@ export const DisabledActions = () => (
 export const I18n = () => (
   <Password i18n={{
     [INPUT_I18N.maskButtonHide]: 'Hide away your password',
-    [INPUT_I18N.maskButtonShow]: 'Show me your password'
+    [INPUT_I18N.maskButtonShow]: 'Show me your password',
   }} />
 );
 

--- a/packages/ods-react/src/components/password/tsconfig.json
+++ b/packages/ods-react/src/components/password/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/phone-number/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/phone-number/src/dev.stories.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { INPUT_I18N } from '../../input/src';
 import { TEXT_PRESET, Text } from '../../text/src';
-import { PHONE_NUMBER_I18N, PhoneNumber, PhoneNumberControl, type PhoneNumberCountryChangeDetail, PhoneNumberCountryList, type PhoneNumberCountryIsoCode, type PhoneNumberValueChangeDetail } from '.';
-import style from './dev.module.css';
+import { PHONE_NUMBER_I18N, PhoneNumber, PhoneNumberControl, type PhoneNumberCountryChangeDetail, type PhoneNumberCountryIsoCode, PhoneNumberCountryList, type PhoneNumberValueChangeDetail } from '.';
 
 export default {
   component: PhoneNumber,
@@ -28,7 +28,7 @@ export const ControlledCountry = () => {
   const [country, setCountry] = useState<PhoneNumberCountryIsoCode>('fr');
 
   function onCountryChange(detail: PhoneNumberCountryChangeDetail) {
-    setCountry(detail.value)
+    setCountry(detail.value);
   }
 
   return (
@@ -58,7 +58,7 @@ export const ControlledInput = () => {
   const [value, setValue] = useState('');
 
   function onValueChange(detail: PhoneNumberValueChangeDetail) {
-    setValue(detail.value)
+    setValue(detail.value);
   }
 
   return (
@@ -231,7 +231,7 @@ export const IsoCode = () => (
       Incorrect isoCode set, should fallback from navigator languages ({ navigator.languages.join(', ') }):
     </p>
 
-    {/* @ts-ignore */}
+    {/* @ts-ignore - incorrect iso code */}
     <PhoneNumber country="ww">
       <PhoneNumberCountryList />
 

--- a/packages/ods-react/src/components/phone-number/tsconfig.json
+++ b/packages/ods-react/src/components/phone-number/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/popover/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/popover/src/dev.stories.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { Popover, PopoverContent, PopoverTrigger } from '.';
+import style from './dev.module.css';
 import { Button } from '../../button/src';
 import { DIVIDER_SPACING, Divider } from '../../divider/src';
 import { Modal, ModalBody, ModalContent, type ModalOpenChangeDetail, ModalTrigger } from '../../modal/src';
-import style from './dev.module.css';
+import { Popover, PopoverContent, PopoverTrigger } from '.';
 
 export default {
   component: Popover,
@@ -344,7 +344,7 @@ export const OnPositionChange = () => {
       </Popover>
     </>
   );
-}
+};
 
 export const SameWidth = () => (
   <>

--- a/packages/ods-react/src/components/popover/tsconfig.json
+++ b/packages/ods-react/src/components/popover/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/progress-bar/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/progress-bar/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { ProgressBar } from '.';
 import style from './dev.module.css';
+import { ProgressBar } from '.';
 
 export default {
   component: ProgressBar,

--- a/packages/ods-react/src/components/progress-bar/tsconfig.json
+++ b/packages/ods-react/src/components/progress-bar/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/prompt-input/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/prompt-input/src/dev.stories.tsx
@@ -1,11 +1,12 @@
-/* eslint-disable no-console */
-import { BUTTON_VARIANT, Divider, FileThumbnail } from '@ovhcloud/ods-react';
 import { useState } from 'react';
 import { PromptInputControls } from './components/prompt-input-controls/PromptInputControls';
 import { PromptInputFileUploadButton } from './components/prompt-input-file-upload-button/PromptInputFileUploadButton';
 import { PromptInputFiles } from './components/prompt-input-files/PromptInputFiles';
 import { PromptInputSendButton } from './components/prompt-input-send-button/PromptInputSendButton';
 import { PromptInputTextControl } from './components/prompt-input-text-control/PromptInputTextControl';
+import { BUTTON_VARIANT } from '../../button/src';
+import { Divider } from '../../divider/src';
+import { FileThumbnail } from '../../file-thumbnail/src';
 import { FormField, FormFieldError, FormFieldHelper } from '../../form-field/src';
 import { PromptInput } from '.';
 

--- a/packages/ods-react/src/components/prompt-input/tsconfig.json
+++ b/packages/ods-react/src/components/prompt-input/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/quantity/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/quantity/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Quantity, QuantityControl, QuantityInput } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Quantity,
@@ -192,7 +192,7 @@ export const MaxMin = () => (
 export const Placeholder = () => (
   <Quantity>
     <QuantityControl>
-      <QuantityInput placeholder="--"  />
+      <QuantityInput placeholder="--" />
     </QuantityControl>
   </Quantity>
 );

--- a/packages/ods-react/src/components/quantity/tsconfig.json
+++ b/packages/ods-react/src/components/quantity/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/query-filter/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/query-filter/src/dev.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState } from 'react';
 import { QueryFilter, QueryFilterClear, QueryFilterContent, QueryFilterControl, QueryFilterTags, type QueryFilterValueChangeDetails } from '.';
 
 export default {
@@ -46,7 +46,7 @@ const filterOption = {
         { label: 'Stopped', value: 'stopped' },
       ],
     },
-  }
+  },
 };
 
 export const AllowCustomValue = () => (
@@ -98,7 +98,7 @@ export const Controlled = () => {
       </QueryFilter>
     </>
   );
-}
+};
 
 export const Default = () => (
   <QueryFilter

--- a/packages/ods-react/src/components/query-filter/tsconfig.json
+++ b/packages/ods-react/src/components/query-filter/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/radio-group/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/radio-group/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Radio, RadioControl, RadioGroup, RadioLabel } from '.';
-import style from './dev.module.css';
 
 export default {
   component: RadioGroup,

--- a/packages/ods-react/src/components/radio-group/tsconfig.json
+++ b/packages/ods-react/src/components/radio-group/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/range/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/range/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { Range, type RangeValueChangeDetail } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Range,
@@ -188,7 +188,7 @@ export const Ref = () => {
       <button type="button" onClick={ () => console.log(rangeRef.current) }>Log Ref</button>
     </>
   );
-}
+};
 
 export const States = () => (
   <>
@@ -264,4 +264,4 @@ export const TicksLabels = () => {
         ticks={ qualityTicks } />
     </>
   );
-}
+};

--- a/packages/ods-react/src/components/range/tsconfig.json
+++ b/packages/ods-react/src/components/range/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/select/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/select/src/dev.stories.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { ICON_NAME, Icon } from '../../icon/src';
-import { Select, SelectContent, SelectControl, type SelectCustomGroupRendererArg, type SelectCustomItemRendererArg, type SelectCustomOptionRendererArg, type SelectItem, type SelectOptionItem } from '.';
 import { TEXT_PRESET, Text } from '../../text/src';
-import style from './dev.module.css';
+import { Select, SelectContent, SelectControl, type SelectCustomGroupRendererArg, type SelectCustomItemRendererArg, type SelectCustomOptionRendererArg, type SelectItem, type SelectOptionItem } from '.';
 
 export default {
   component: Select,
@@ -19,7 +19,7 @@ export const Accessibility = () => {
         res.push({ label: `${value[0].toUpperCase()}${value.slice(1)}`, value });
       }
       return res;
-    }, [])
+    }, []);
   }, []);
 
   return (
@@ -28,7 +28,7 @@ export const Accessibility = () => {
       <SelectContent />
     </Select>
   );
-}
+};
 
 export const Controlled = () => {
   const [values, setValues] = useState(['dog']);
@@ -49,7 +49,7 @@ export const Controlled = () => {
       <SelectContent />
     </Select>
   );
-}
+};
 
 export const CustomLabel = () => (
   <>
@@ -185,7 +185,7 @@ export const CustomRenderer = () => {
               { label: 'France', value: 'fr' },
               { label: 'Germany', value: 'de', disabled: true },
               { label: 'Italy', value: 'it' },
-            ]
+            ],
           },
           {
             customRendererData: { code: 'AS' },
@@ -195,7 +195,7 @@ export const CustomRenderer = () => {
               { label: 'China', value: 'cn' },
               { label: 'Japan', value: 'jp' },
               { label: 'Russia', value: 'ru' },
-            ]
+            ],
           },
           { label: 'World', value: 'world' },
         ]}>
@@ -270,7 +270,7 @@ export const Groups = () => (
           { label: 'France', value: 'fr' },
           { label: 'Germany', value: 'de' },
           { label: 'Italy', value: 'it' },
-        ]
+        ],
       },
       {
         label: 'Asia',
@@ -278,7 +278,7 @@ export const Groups = () => (
           { label: 'China', value: 'cn' },
           { label: 'Japan', value: 'jp' },
           { label: 'Russia', value: 'ru' },
-        ]
+        ],
       },
       { label: 'World', value: 'world' },
     ]}>
@@ -416,7 +416,7 @@ export const Opened = () => {
       </Select>
     </>
   );
-}
+};
 
 export const Placeholder = () => (
   <Select

--- a/packages/ods-react/src/components/select/tsconfig.json
+++ b/packages/ods-react/src/components/select/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/skeleton/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/skeleton/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from '.';
 import style from './dev.module.css';
+import { Skeleton } from '.';
 
 export default {
   component: Skeleton,

--- a/packages/ods-react/src/components/skeleton/tsconfig.json
+++ b/packages/ods-react/src/components/skeleton/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/spinner/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/spinner/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { Spinner } from '.';
 import style from './dev.module.css';
+import { Spinner } from '.';
 
 export default {
   component: Spinner,
@@ -18,11 +18,11 @@ export const Accessibility = () => (
   <div aria-busy="true" aria-live="polite">
     <Spinner />
   </div>
-)
+);
 
 export const AccessibilityAriaLabelledBy = () => (
   <div aria-busy="true" aria-live="polite">
     <Spinner aria-labelledby="loading-text" />
     <p id="loading-text">Loading...</p>
   </div>
-)
+);

--- a/packages/ods-react/src/components/spinner/tsconfig.json
+++ b/packages/ods-react/src/components/spinner/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/switch/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/switch/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import style from './dev.module.css';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Switch, SwitchItem, type SwitchValueChangeDetail } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Switch,
@@ -36,7 +36,7 @@ export const ControlledInput = () => {
   const [value, setValue] = useState('item-1');
 
   function onValueChange({ value }: SwitchValueChangeDetail) {
-    setValue(value)
+    setValue(value);
   }
 
   return (

--- a/packages/ods-react/src/components/switch/tsconfig.json
+++ b/packages/ods-react/src/components/switch/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/table/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/table/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { Table } from '.';
 import style from './dev.module.css';
+import { Table } from '.';
 
 export default {
   component: Table,
@@ -13,33 +13,33 @@ export const Default = () => (
       Front-end web developer course 2021
     </caption>
     <thead>
-    <tr>
-      <th scope="col">Person</th>
-      <th scope="col">Most interest in</th>
-      <th scope="col">Age</th>
-    </tr>
+      <tr>
+        <th scope="col">Person</th>
+        <th scope="col">Most interest in</th>
+        <th scope="col">Age</th>
+      </tr>
     </thead>
     <tbody>
-    <tr>
-      <th scope="row">Chris</th>
-      <td>HTML tables</td>
-      <td>22</td>
-    </tr>
-    <tr>
-      <th scope="row">Dennis</th>
-      <td>Web accessibility</td>
-      <td>45</td>
-    </tr>
-    <tr>
-      <th scope="row">Sarah</th>
-      <td>JavaScript frameworks</td>
-      <td>29</td>
-    </tr>
-    <tr>
-      <th scope="row">Karen</th>
-      <td>Web performance</td>
-      <td>36</td>
-    </tr>
+      <tr>
+        <th scope="row">Chris</th>
+        <td>HTML tables</td>
+        <td>22</td>
+      </tr>
+      <tr>
+        <th scope="row">Dennis</th>
+        <td>Web accessibility</td>
+        <td>45</td>
+      </tr>
+      <tr>
+        <th scope="row">Sarah</th>
+        <td>JavaScript frameworks</td>
+        <td>29</td>
+      </tr>
+      <tr>
+        <th scope="row">Karen</th>
+        <td>Web performance</td>
+        <td>36</td>
+      </tr>
     </tbody>
   </Table>
 );
@@ -51,33 +51,33 @@ export const Size = () => (
         Front-end web developer course 2021
       </caption>
       <thead>
-      <tr>
-        <th scope="col">Person</th>
-        <th scope="col">Most interest in</th>
-        <th scope="col">Age</th>
-      </tr>
+        <tr>
+          <th scope="col">Person</th>
+          <th scope="col">Most interest in</th>
+          <th scope="col">Age</th>
+        </tr>
       </thead>
       <tbody>
-      <tr>
-        <th scope="row">Chris</th>
-        <td>HTML tables</td>
-        <td>22</td>
-      </tr>
-      <tr>
-        <th scope="row">Dennis</th>
-        <td>Web accessibility</td>
-        <td>45</td>
-      </tr>
-      <tr>
-        <th scope="row">Sarah</th>
-        <td>JavaScript frameworks</td>
-        <td>29</td>
-      </tr>
-      <tr>
-        <th scope="row">Karen</th>
-        <td>Web performance</td>
-        <td>36</td>
-      </tr>
+        <tr>
+          <th scope="row">Chris</th>
+          <td>HTML tables</td>
+          <td>22</td>
+        </tr>
+        <tr>
+          <th scope="row">Dennis</th>
+          <td>Web accessibility</td>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th scope="row">Sarah</th>
+          <td>JavaScript frameworks</td>
+          <td>29</td>
+        </tr>
+        <tr>
+          <th scope="row">Karen</th>
+          <td>Web performance</td>
+          <td>36</td>
+        </tr>
       </tbody>
     </Table>
     <Table size="md">
@@ -85,33 +85,33 @@ export const Size = () => (
         Front-end web developer course 2021
       </caption>
       <thead>
-      <tr>
-        <th scope="col">Person</th>
-        <th scope="col">Most interest in</th>
-        <th scope="col">Age</th>
-      </tr>
+        <tr>
+          <th scope="col">Person</th>
+          <th scope="col">Most interest in</th>
+          <th scope="col">Age</th>
+        </tr>
       </thead>
       <tbody>
-      <tr>
-        <th scope="row">Chris</th>
-        <td>HTML tables</td>
-        <td>22</td>
-      </tr>
-      <tr>
-        <th scope="row">Dennis</th>
-        <td>Web accessibility</td>
-        <td>45</td>
-      </tr>
-      <tr>
-        <th scope="row">Sarah</th>
-        <td>JavaScript frameworks</td>
-        <td>29</td>
-      </tr>
-      <tr>
-        <th scope="row">Karen</th>
-        <td>Web performance</td>
-        <td>36</td>
-      </tr>
+        <tr>
+          <th scope="row">Chris</th>
+          <td>HTML tables</td>
+          <td>22</td>
+        </tr>
+        <tr>
+          <th scope="row">Dennis</th>
+          <td>Web accessibility</td>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th scope="row">Sarah</th>
+          <td>JavaScript frameworks</td>
+          <td>29</td>
+        </tr>
+        <tr>
+          <th scope="row">Karen</th>
+          <td>Web performance</td>
+          <td>36</td>
+        </tr>
       </tbody>
     </Table>
     <Table size="lg">
@@ -119,33 +119,33 @@ export const Size = () => (
         Front-end web developer course 2021
       </caption>
       <thead>
-      <tr>
-        <th scope="col">Person</th>
-        <th scope="col">Most interest in</th>
-        <th scope="col">Age</th>
-      </tr>
+        <tr>
+          <th scope="col">Person</th>
+          <th scope="col">Most interest in</th>
+          <th scope="col">Age</th>
+        </tr>
       </thead>
       <tbody>
-      <tr>
-        <th scope="row">Chris</th>
-        <td>HTML tables</td>
-        <td>22</td>
-      </tr>
-      <tr>
-        <th scope="row">Dennis</th>
-        <td>Web accessibility</td>
-        <td>45</td>
-      </tr>
-      <tr>
-        <th scope="row">Sarah</th>
-        <td>JavaScript frameworks</td>
-        <td>29</td>
-      </tr>
-      <tr>
-        <th scope="row">Karen</th>
-        <td>Web performance</td>
-        <td>36</td>
-      </tr>
+        <tr>
+          <th scope="row">Chris</th>
+          <td>HTML tables</td>
+          <td>22</td>
+        </tr>
+        <tr>
+          <th scope="row">Dennis</th>
+          <td>Web accessibility</td>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th scope="row">Sarah</th>
+          <td>JavaScript frameworks</td>
+          <td>29</td>
+        </tr>
+        <tr>
+          <th scope="row">Karen</th>
+          <td>Web performance</td>
+          <td>36</td>
+        </tr>
       </tbody>
     </Table>
   </>
@@ -176,19 +176,17 @@ export const StickyHeader = () => {
         </tr>
       </thead>
       <tbody>
-      {
-        data.map((dummyData) => (
-          <tr>
+        { data.map((dummyData) => (
+          <tr key={ dummyData.id }>
             <td>{ dummyData.id }</td>
             <td>{ dummyData.name }</td>
             <td>{ dummyData.age }</td>
           </tr>
-        ))
-      }
+        ))}
       </tbody>
     </Table>
   );
-}
+};
 
 export const Variant = () => (
   <div style={ { display: 'flex', gap: '1rem' } }>
@@ -197,33 +195,33 @@ export const Variant = () => (
         Front-end web developer course 2021
       </caption>
       <thead>
-      <tr>
-        <th scope="col">Person</th>
-        <th scope="col">Most interest in</th>
-        <th scope="col">Age</th>
-      </tr>
+        <tr>
+          <th scope="col">Person</th>
+          <th scope="col">Most interest in</th>
+          <th scope="col">Age</th>
+        </tr>
       </thead>
       <tbody>
-      <tr>
-        <th scope="row">Chris</th>
-        <td>HTML tables</td>
-        <td>22</td>
-      </tr>
-      <tr>
-        <th scope="row">Dennis</th>
-        <td>Web accessibility</td>
-        <td>45</td>
-      </tr>
-      <tr>
-        <th scope="row">Sarah</th>
-        <td>JavaScript frameworks</td>
-        <td>29</td>
-      </tr>
-      <tr>
-        <th scope="row">Karen</th>
-        <td>Web performance</td>
-        <td>36</td>
-      </tr>
+        <tr>
+          <th scope="row">Chris</th>
+          <td>HTML tables</td>
+          <td>22</td>
+        </tr>
+        <tr>
+          <th scope="row">Dennis</th>
+          <td>Web accessibility</td>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th scope="row">Sarah</th>
+          <td>JavaScript frameworks</td>
+          <td>29</td>
+        </tr>
+        <tr>
+          <th scope="row">Karen</th>
+          <td>Web performance</td>
+          <td>36</td>
+        </tr>
       </tbody>
     </Table>
     <Table variant="striped">
@@ -231,33 +229,33 @@ export const Variant = () => (
         Front-end web developer course 2021
       </caption>
       <thead>
-      <tr>
-        <th scope="col">Person</th>
-        <th scope="col">Most interest in</th>
-        <th scope="col">Age</th>
-      </tr>
+        <tr>
+          <th scope="col">Person</th>
+          <th scope="col">Most interest in</th>
+          <th scope="col">Age</th>
+        </tr>
       </thead>
       <tbody>
-      <tr>
-        <th scope="row">Chris</th>
-        <td>HTML tables</td>
-        <td>22</td>
-      </tr>
-      <tr>
-        <th scope="row">Dennis</th>
-        <td>Web accessibility</td>
-        <td>45</td>
-      </tr>
-      <tr>
-        <th scope="row">Sarah</th>
-        <td>JavaScript frameworks</td>
-        <td>29</td>
-      </tr>
-      <tr>
-        <th scope="row">Karen</th>
-        <td>Web performance</td>
-        <td>36</td>
-      </tr>
+        <tr>
+          <th scope="row">Chris</th>
+          <td>HTML tables</td>
+          <td>22</td>
+        </tr>
+        <tr>
+          <th scope="row">Dennis</th>
+          <td>Web accessibility</td>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th scope="row">Sarah</th>
+          <td>JavaScript frameworks</td>
+          <td>29</td>
+        </tr>
+        <tr>
+          <th scope="row">Karen</th>
+          <td>Web performance</td>
+          <td>36</td>
+        </tr>
       </tbody>
     </Table>
   </div>
@@ -266,33 +264,33 @@ export const Variant = () => (
 export const CustomStyle = () => (
   <Table className={ style[ 'custom-table' ] }>
     <thead>
-    <tr>
-      <th scope="col">Person</th>
-      <th scope="col">Most interest in</th>
-      <th scope="col">Age</th>
-    </tr>
+      <tr>
+        <th scope="col">Person</th>
+        <th scope="col">Most interest in</th>
+        <th scope="col">Age</th>
+      </tr>
     </thead>
     <tbody>
-    <tr>
-      <th scope="row">Chris</th>
-      <td>HTML tables</td>
-      <td>22</td>
-    </tr>
-    <tr>
-      <th scope="row">Dennis</th>
-      <td>Web accessibility</td>
-      <td>45</td>
-    </tr>
-    <tr>
-      <th scope="row">Sarah</th>
-      <td>JavaScript frameworks</td>
-      <td>29</td>
-    </tr>
-    <tr>
-      <th scope="row">Karen</th>
-      <td>Web performance</td>
-      <td>36</td>
-    </tr>
+      <tr>
+        <th scope="row">Chris</th>
+        <td>HTML tables</td>
+        <td>22</td>
+      </tr>
+      <tr>
+        <th scope="row">Dennis</th>
+        <td>Web accessibility</td>
+        <td>45</td>
+      </tr>
+      <tr>
+        <th scope="row">Sarah</th>
+        <td>JavaScript frameworks</td>
+        <td>29</td>
+      </tr>
+      <tr>
+        <th scope="row">Karen</th>
+        <td>Web performance</td>
+        <td>36</td>
+      </tr>
     </tbody>
   </Table>
 );

--- a/packages/ods-react/src/components/table/tsconfig.json
+++ b/packages/ods-react/src/components/table/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/tabs/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tabs/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { TABS_SIZE, TABS_VARIANT, Tab, TabContent, TabList, Tabs } from '.';
 import style from './dev.module.css';
+import { TABS_SIZE, TABS_VARIANT, Tab, TabContent, TabList, Tabs } from '.';
 
 export default {
   component: Tabs,

--- a/packages/ods-react/src/components/tabs/tsconfig.json
+++ b/packages/ods-react/src/components/tabs/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/tag/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tag/src/dev.stories.tsx
@@ -1,9 +1,9 @@
-import { Tag } from '.';
-import { ICON_NAME, Icon } from '../../icon/src';
-import { Text } from '../../text/src';
 import { TAG_COLORS } from './constants/tag-color';
 import { TAG_SIZE } from './constants/tag-size';
 import style from './dev.module.css';
+import { ICON_NAME, Icon } from '../../icon/src';
+import { Text } from '../../text/src';
+import { Tag } from '.';
 
 export default {
   component: Tag,
@@ -101,4 +101,4 @@ export const Multiline = () => (
       with multiples lines
     </span>
   </Tag>
-)
+);

--- a/packages/ods-react/src/components/tag/tsconfig.json
+++ b/packages/ods-react/src/components/tag/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/text/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/text/src/dev.stories.tsx
@@ -1,5 +1,5 @@
-import { Text } from '.';
 import style from './dev.module.css';
+import { Text } from '.';
 
 export default {
   component: Text,

--- a/packages/ods-react/src/components/text/tsconfig.json
+++ b/packages/ods-react/src/components/text/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/textarea/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/textarea/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { type FormEvent, useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { TEXT_PRESET, Text } from '../../text/src';
 import { Textarea } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Textarea,

--- a/packages/ods-react/src/components/textarea/tsconfig.json
+++ b/packages/ods-react/src/components/textarea/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/tile/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tile/src/dev.stories.tsx
@@ -1,15 +1,8 @@
-import {
-  Checkbox,
-  CheckboxControl,
-  CheckboxLabel,
-  Radio,
-  RadioControl,
-  RadioGroup,
-  RadioLabel,
-} from '@ovhcloud/ods-react';
 import { useState } from 'react';
-import { Tile, TileAltContainer } from '.';
 import style from './dev.module.css';
+import { Checkbox, CheckboxControl, CheckboxLabel } from '../../checkbox/src';
+import { Radio, RadioControl, RadioGroup, RadioLabel } from '../../radio-group/src';
+import { Tile, TileAltContainer } from '.';
 
 export default {
   component: Tile,
@@ -65,7 +58,7 @@ export const WithCheckbox = () => {
         </TileAltContainer>
       </Checkbox>
     </Tile>
-  </div>
+  </div>;
 };
 
 export const WithRadio = () => {

--- a/packages/ods-react/src/components/tile/tsconfig.json
+++ b/packages/ods-react/src/components/tile/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/timepicker/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/timepicker/src/dev.stories.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
-import { TEXT_PRESET, Text } from '../../text/src';
-import { TIMEPICKER_I18N, Timepicker, TimepickerControl, type TimepickerTimezoneChangeDetail, TimepickerTimezoneList, type TimepickerValueChangeDetail, Timezone } from '.';
 import { getBrowserTimezone } from './controller/timepicker';
 import style from './dev.module.css';
+import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
+import { TEXT_PRESET, Text } from '../../text/src';
+import { TIMEPICKER_I18N, Timepicker, TimepickerControl, type TimepickerTimezoneChangeDetail, TimepickerTimezoneList, type TimepickerValueChangeDetail, type Timezone } from '.';
 
 export default {
   component: Timepicker,
@@ -40,7 +40,7 @@ export const ControlledTimezone = () => {
   const [timezone, setTimezone] = useState<Timezone>('UTC-2');
 
   function onTimezoneChange(detail: TimepickerTimezoneChangeDetail) {
-    setTimezone(detail.value)
+    setTimezone(detail.value);
   }
 
   return (
@@ -326,7 +326,7 @@ export const Timezones = () => (
       Incorrect timezone set, should fallback to browser ({ getBrowserTimezone() }):
     </p>
 
-    {/* @ts-ignore */}
+    {/* @ts-ignore - this is a test case for an invalid timezone */}
     <Timepicker timezone="XXX">
       <TimepickerControl />
 

--- a/packages/ods-react/src/components/timepicker/tsconfig.json
+++ b/packages/ods-react/src/components/timepicker/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/toaster/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/toaster/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
+import style from './dev.module.css';
 import { ICON_NAME } from '../../icon/src';
 import { TOASTER_POSITION, Toaster, toast } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Toaster,
@@ -78,7 +78,7 @@ export const CustomStyle = () => (
     <Toaster />
 
     <button onClick={ () => toast.information('Icon toast', {
-      className: style['custom-toast']
+      className: style['custom-toast'],
     })}>
       Trigger custom toast
     </button>

--- a/packages/ods-react/src/components/toaster/tsconfig.json
+++ b/packages/ods-react/src/components/toaster/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/toggle/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/toggle/src/dev.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import style from './dev.module.css';
 import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
 import { Toggle, ToggleControl, ToggleLabel } from '.';
-import style from './dev.module.css';
 
 export default {
   component: Toggle,

--- a/packages/ods-react/src/components/toggle/tsconfig.json
+++ b/packages/ods-react/src/components/toggle/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/tooltip/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tooltip/src/dev.stories.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { Tooltip, TooltipContent, TooltipTrigger } from '.';
-import { Button } from '../../button/src';
-import { Icon, ICON_NAME } from '../../icon/src';
 import style from './dev.module.css';
+import { Button } from '../../button/src';
+import { ICON_NAME, Icon } from '../../icon/src';
+import { Tooltip, TooltipContent, TooltipTrigger } from '.';
 
 export default {
   component: Tooltip,

--- a/packages/ods-react/src/components/tooltip/tsconfig.json
+++ b/packages/ods-react/src/components/tooltip/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }

--- a/packages/ods-react/src/components/tree-view/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/tree-view/src/dev.stories.tsx
@@ -1,8 +1,8 @@
-import { TreeView, type TreeViewItem, TreeViewNode, TreeViewNodes, type TreeViewValueChangeDetail } from '.';
 import { useMemo, useRef, useState } from 'react';
-import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
-import { Icon, ICON_NAME } from '../../icon/src';
 import { Button } from '../../button/src';
+import { FormField, FormFieldError, FormFieldHelper, FormFieldLabel } from '../../form-field/src';
+import { ICON_NAME, Icon } from '../../icon/src';
+import { TreeView, type TreeViewItem, TreeViewNode, TreeViewNodes, type TreeViewValueChangeDetail } from '.';
 
 export default {
   component: TreeView,
@@ -44,7 +44,7 @@ export const Default = () => {
   return (
     <TreeView
       items={ collection }
-      >
+    >
       <TreeViewNodes>
         { collection.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -80,7 +80,7 @@ export const Uncontrolled = () => {
     <>
       <TreeView
         items={ collection }
-        >
+      >
         <TreeViewNodes>
           { collection.map((item) => (
             <TreeViewNode key={ item.id } item={ item } />
@@ -117,7 +117,7 @@ export const MultipleSelection = () => {
     <TreeView
       multiple
       items={ collection }
-      >
+    >
       <TreeViewNodes>
         { collection.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -152,8 +152,8 @@ export const DefaultExpanded = () => {
   return (
     <TreeView
       items={ items }
-      defaultExpandedValue={["src", "components"]}
-      >
+      defaultExpandedValue={['src', 'components']}
+    >
       <TreeViewNodes>
         { items.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -278,7 +278,7 @@ export const UncontrolledMultiple = () => {
       <TreeView
         items={ collection }
         multiple
-        >
+      >
         <TreeViewNodes>
           { collection.map((item) => (
             <TreeViewNode key={ item.id } item={ item } />
@@ -315,7 +315,7 @@ export const Disabled = () => {
     <TreeView
       disabled
       items={ collection }
-      >
+    >
       <TreeViewNodes>
         { collection.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -351,7 +351,7 @@ export const DisabledItems = () => {
   return (
     <TreeView
       items={ collection }
-      >
+    >
       <TreeViewNodes>
         { collection.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -388,7 +388,7 @@ export const DisabledItemsMultiple = () => {
     <TreeView
       multiple
       items={ collection }
-      >
+    >
       <TreeViewNodes>
         { collection.map((item) => (
           <TreeViewNode key={ item.id } item={ item } />
@@ -431,6 +431,7 @@ export const CustomRender = () => {
           <TreeViewNode key={ item.id } item={ item }>
             { ({ item, isBranch, isExpanded }) => (
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                {/* eslint-disable-next-line no-nested-ternary */}
                 { isBranch ? isExpanded ? <Icon name={ ICON_NAME.folderMinus } /> : <Icon name={ ICON_NAME.folderPlus } /> : <Icon name={ ICON_NAME.file } /> }
                 <span>{ item.name } { item.customRendererData?.type === 'typescript' ? '(ts)' : '(other)'}
                 </span>
@@ -469,12 +470,13 @@ export const CustomRenderMultiple = () => {
     <TreeView
       items={ items }
       multiple
-      >
+    >
       <TreeViewNodes>
         { items.map((item) => (
           <TreeViewNode key={ item.id } item={ item }>
             { ({ item, isBranch, isExpanded }) => (
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                {/* eslint-disable-next-line no-nested-ternary */}
                 { isBranch ? (isExpanded ? <Icon name={ ICON_NAME.folderMinus } /> : <Icon name={ ICON_NAME.folderPlus } />) : <Icon name={ ICON_NAME.file } /> }
                 <span>{ item.name }</span>
               </span>
@@ -518,7 +520,7 @@ export const InFormField = () => {
 
         <TreeView
           items={ items }
-          >
+        >
           <TreeViewNodes>
             { items.map((item) => (
               <TreeViewNode key={ item.id } item={ item } />
@@ -598,7 +600,7 @@ export const DynamicChildren = () => {
     <TreeView
       multiple
       items={ items }
-      >
+    >
       <TreeViewNodes>
         { items.map((item) => (
           <TreeViewNode key={ item.id } item={ item }>
@@ -613,7 +615,9 @@ export const DynamicChildren = () => {
                     <button
                       type="button"
                       aria-label="Add child"
-                      onClick={(e) => { e.stopPropagation(); handleAddChild(item.id); }}
+                      onClick={(e) => {
+                        e.stopPropagation(); handleAddChild(item.id);
+                      }}
                       style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer' }}>
                       <Icon name={ ICON_NAME.plus } />
                     </button>
@@ -621,7 +625,9 @@ export const DynamicChildren = () => {
                   <button
                     type="button"
                     aria-label="Delete"
-                    onClick={(e) => { e.stopPropagation(); handleDelete(item.id); }}
+                    onClick={(e) => {
+                      e.stopPropagation(); handleDelete(item.id);
+                    }}
                     style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer' }}>
                     <Icon name={ ICON_NAME.xmark } />
                   </button>

--- a/packages/ods-react/src/components/tree-view/tsconfig.json
+++ b/packages/ods-react/src/components/tree-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
   "include": ["modules.d.ts", "src", "tests"],
-  "exclude": [".storybook", "node_modules", "**/*.stories.tsx"]
+  "exclude": [".storybook", "node_modules", "**/tests/**/*.stories.tsx"]
 }


### PR DESCRIPTION
Since migrating from Yarn to pnpm, test:e2e:ci has been flaky across several components, most notably tile and prompt-input. The same tests pass locally with Yarn but intermittently fail on pnpm, both in CI and locally.

---

Some dev.stories.tsx files imported other components via the @ovhcloud/ods-react package barrel (e.g. Checkbox, Divider, FileThumbnail). This import is unresolvable in the context of individual component storybooks because those packages don't declare @ovhcloud/ods-react as a dependency — it's the parent package, not a sibling.

This was invisible with Yarn because Yarn hoists all workspace packages to the root node_modules, making @ovhcloud/ods-react resolvable as a symlink from anywhere. Vite's initial dep scan would complete cleanly and pre-bundle all transitive deps upfront.

With pnpm's strict isolation, Vite fails to resolve @ovhcloud/ods-react and its initial scan is incomplete. When transitive deps like classnames or @zag-js/i18n-utils are then encountered at runtime during the first page load, Vite treats them as newly discovered, triggers a dep re-optimization, and forces a browser reload mid-test. This causes either a Puppeteer context loss (Cannot find context with specified id) or a React hooks crash (Cannot read properties of null (reading 'useState')).

### Fix
- Replace the @ovhcloud/ods-react barrel imports in the two offending dev.stories.tsx files with direct relative imports to the sibling component sources.
- Narrow the ESLint ignorePatterns and all component tsconfig.json excludes from `**/*.stories.tsx` to `**/tests/**/*.stories.tsx` so dev.stories.tsx files are now linted and type-checked.
- Add a no-restricted-imports rule in a dedicated ESLint override for **/src/dev.stories.tsx to prevent this class of import from being reintroduced.