### PR TITLE
fix(datatable): sticky-header z-index simpler fix

### DIFF
--- a/packages/ods-react/src/components/data-table/src/controller/dataTable.ts
+++ b/packages/ods-react/src/components/data-table/src/controller/dataTable.ts
@@ -3,7 +3,10 @@ import { type CSSProperties } from 'react';
 
 function getCellZIndex(isPinned: boolean, stickyHeader: boolean): number {
   if (isPinned) {
-    return 2;
+    if (stickyHeader) {
+      return 2;
+    }
+    return 1;
   }
 
   return stickyHeader ? 1 : 0;


### PR DESCRIPTION
Correct buggy header z-index when stickyHeader and pinned column at the same time