### PR TITLE
fix(): correct html list semantics on safari

### DIFF
--- a/packages/ods-react/src/components/breadcrumb/src/components/breadcrumb/breadcrumb.module.scss
+++ b/packages/ods-react/src/components/breadcrumb/src/components/breadcrumb/breadcrumb.module.scss
@@ -5,7 +5,7 @@
       flex-wrap: wrap;
       margin: 0;
       padding: 0;
-      list-style-type: none;
+      list-style-type: "";
     }
   }
 }

--- a/packages/ods-react/src/components/query-filter/src/components/query-filter-tags/queryFilterTags.module.scss
+++ b/packages/ods-react/src/components/query-filter/src/components/query-filter-tags/queryFilterTags.module.scss
@@ -5,7 +5,7 @@
     gap: var(--ods-theme-row-gap) var(--ods-theme-column-gap);
     margin: 0;
     padding: 0;
-    list-style: none;
+    list-style-type: "";
 
     &__tag {
       white-space: nowrap;

--- a/packages/ods-recipes/src/components/feature-list-product-card/src/css-modules/index.module.scss
+++ b/packages/ods-recipes/src/components/feature-list-product-card/src/css-modules/index.module.scss
@@ -146,7 +146,7 @@
     flex-flow: column;
     row-gap: calc(var(--ods-theme-row-gap) * 2);
     margin: 0;
-    list-style: none;
+    list-style-type: "";
 
     &__section {
       display: flex;
@@ -166,7 +166,7 @@
         row-gap: var(--ods-theme-row-gap);
         margin: 0;
         padding: 0;
-        list-style: none;
+        list-style-type: "";
 
         &__item {
           display: flex;

--- a/packages/ods-recipes/src/components/feature-list/src/css-modules/index.module.scss
+++ b/packages/ods-recipes/src/components/feature-list/src/css-modules/index.module.scss
@@ -4,7 +4,7 @@
   row-gap: var(--ods-theme-row-gap);
   margin: 0;
   padding: 0;
-  list-style: none;
+  list-style-type: "";
 
   &__item {
     display: flex;

--- a/packages/storybook/src/components/iconGallery/iconGallery.module.css
+++ b/packages/storybook/src/components/iconGallery/iconGallery.module.css
@@ -16,5 +16,5 @@
   justify-content: center;
   margin: 0;
   padding: 0;
-  list-style: none;
+  list-style-type: "";
 }


### PR DESCRIPTION
Safari strips down "list" role from `<ul>` and `<ol>` that don't have a list-style,
A good practice is to set them as empty strings

 <kbd>
<img width="1367" height="488" alt="Capture d’écran 2026-06-23 à 18 29 29" src="https://github.com/user-attachments/assets/f13f6367-2528-48ec-825e-161d1ebb7843" />
 </kbd>
<br />
<br />
 <kbd>
<img width="1367" height="488" alt="Capture d’écran 2026-06-23 à 18 27 28" src="https://github.com/user-attachments/assets/422126b1-bce2-4a99-abd9-5790739cb56d" />
 </kbd>
