### PR TITLE
fix(drawer): keep closed drawers inert to pointer events

### DIFF
--- a/packages/ods-react/src/components/drawer/src/components/drawer-content/DrawerContent.tsx
+++ b/packages/ods-react/src/components/drawer/src/components/drawer-content/DrawerContent.tsx
@@ -57,9 +57,13 @@ const DrawerContent: FC<DrawerContentProp> = forwardRef(({
           data-ods="drawer-content"
           ref={ ref }
           { ...props }
+          /* pointerEvents counters zag's inline 'pointer-events: auto' (set on any
+             non-modal dialog content, open or closed, i.e. any drawer without backdrop):
+             left in place, a closed drawer is an invisible panel swallowing every click
+             on its area. User style wins in Ark's mergeProps. */
           style={{
             ...props.style,
-            ...(!open ? { opacity: 0 } : {}),
+            ...(!open ? { opacity: 0, pointerEvents: 'none' } : {}),
           }}>
           { children }
         </Dialog.Content>

--- a/packages/ods-react/src/components/drawer/tests/rendering/drawer.e2e.ts
+++ b/packages/ods-react/src/components/drawer/tests/rendering/drawer.e2e.ts
@@ -24,4 +24,24 @@ describe('Drawer rendering', () => {
 
     expect(await page.$('[data-scope="dialog"][data-part="backdrop"]')).toBeNull();
   });
+
+  // Backdrop-less drawers are non-modal: zag then inlines 'pointer-events: auto' on the
+  // content, open or closed. A closed drawer must never swallow clicks on its area,
+  // whatever its variant (portaled or not, backdrop omitted or explicitly false).
+  it('should not intercept pointer events while closed', async() => {
+    await gotoStory(page, 'rendering/closed-inert');
+    await page.waitForSelector('[data-ods="drawer-content"]');
+
+    const probe = await page.evaluate(() => {
+      const contents = document.querySelectorAll('[data-ods="drawer-content"][data-state="closed"]');
+      const target = document.querySelector('[data-testid="under-drawer"]') as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      return { closedCount: contents.length, isHit: hit === target };
+    });
+
+    // All three non-modal variants are mounted closed over the button area.
+    expect(probe.closedCount).toBe(3);
+    expect(probe.isHit).toBe(true);
+  });
 });

--- a/packages/ods-react/src/components/drawer/tests/rendering/drawer.stories.tsx
+++ b/packages/ods-react/src/components/drawer/tests/rendering/drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '../../src';
+import { DRAWER_POSITION, Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '../../src';
 
 export default {
   component: Drawer,
@@ -42,4 +42,47 @@ export const withoutBackdrop = () => (
       </DrawerBody>
     </DrawerContent>
   </Drawer>
+);
+
+// Every non-modal variant (any drawer without backdrop=true) — each of them used
+// to swallow clicks on its area while closed.
+export const closedInert = () => (
+  <>
+    <Drawer>
+      <DrawerTrigger data-testid="trigger-portal">
+        Portal
+      </DrawerTrigger>
+      <DrawerContent position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Portaled, no backdrop
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <Drawer backdrop={ false }>
+      <DrawerTrigger data-testid="trigger-backdrop-false">
+        Backdrop false
+      </DrawerTrigger>
+      <DrawerContent position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Portaled, backdrop false
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <Drawer>
+      <DrawerTrigger data-testid="trigger-inline">
+        Inline
+      </DrawerTrigger>
+      <DrawerContent createPortal={ false } position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Not portaled, no backdrop
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <button data-testid="under-drawer" type="button">
+      Sits inside the closed drawers area
+    </button>
+  </>
 );


### PR DESCRIPTION
## Summary

Since `feat(drawer): add backdrop attribute` (3a61821d1), every `Drawer` that does not explicitly pass `backdrop` renders its **closed** content as an invisible, full-size, click-swallowing panel. The closed-state CSS fix is still in place — the regression is a side effect of the new `modal` derivation.

## Root cause

`Drawer.tsx` derives modality from the new prop (`modal={ backdrop === true }`), so every Drawer without an explicit `backdrop` is non-modal. Zag's dialog then puts an inline style on the dialog content — open **or closed**:

```js
// @zag-js/dialog@1.41.2 — dialog.connect.mjs, getContentProps()
style: compact({
  pointerEvents: prop("modal") ? void 0 : "auto"
})
```

That inline `pointer-events: auto` defeats the component's closed-state CSS (`.drawer-content[data-state='closed'] { pointer-events: none; opacity: 0 }` — inline styles beat any stylesheet). The closed content also stays `display: block` (the drawer mixin overrides the UA `[hidden]` rule), so the result is a mounted, transparent, fixed-position panel with `pointer-events: auto`: `left`/`right` drawers become an invisible 320px-wide strip spanning the full viewport height, `top`/`bottom` an invisible full-width banner — each swallowing every click on its area.

Measured matrix (probed on the closed content element, live render):

| Variant | inline style at mount | computed `pointer-events` | intercepts clicks |
|---|---|---|---|
| `createPortal={ false }`, no `backdrop` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled (default), no `backdrop` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled, `backdrop={ false }` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled, `backdrop` (true) | `opacity: 0;` | `none` | no |

The harmful window is from mount until the first open: after one full open → close cycle, zag drops the inline `pointer-events` on that instance. Most drawers on a page are never opened, so in practice the panels persist. The published v19.7.3 (pre-feature, always modal) is not affected.

## Fix

`DrawerContent` already forces `opacity: 0` inline when closed; this adds `pointerEvents: 'none'` in the same branch. The user style wins over the zag inline style in Ark's `mergeProps`, the open (non-modal) behavior is untouched, and the exit animation is preserved — no lifecycle change (alternatives considered: `lazyMount`/`unmountOnExit` would drop internal state of drawer content on close, and honoring `[hidden]` via CSS would kill the close animation).

## Tests

New `closedInert` rendering story stacking the three affected variants (portaled, `backdrop={ false }`, `createPortal={ false }`) over a probe button, and an e2e test asserting via `elementFromPoint` that the button — not a closed drawer panel — receives the pointer. Red without the fix, green with it (4/4 drawer e2e).
