### PR TITLE
fix(drawer): keep closed drawers inert to pointer events

### DIFF
--- a/packages/ods-react/src/components/drawer/src/components/drawer-content/DrawerContent.tsx
+++ b/packages/ods-react/src/components/drawer/src/components/drawer-content/DrawerContent.tsx
@@ -46,6 +46,8 @@ const DrawerContent: FC<DrawerContentProp> = forwardRef(({
         ...(backdrop ? { zIndex: 'calc(var(--ods-theme-overlay-z-index) + 2)' } : {}),
         ...(positionerStyle || {}),
       }}>
+        { /* zag inlines pointer-events:auto on non-modal dialog content even when
+             closed: without the override below, closed drawers swallow clicks. */ }
         <Dialog.Content
           aria-describedby={ props['aria-describedby'] || '' }
           aria-labelledby={ props['aria-labelledby'] || '' }
@@ -59,7 +61,7 @@ const DrawerContent: FC<DrawerContentProp> = forwardRef(({
           { ...props }
           style={{
             ...props.style,
-            ...(!open ? { opacity: 0 } : {}),
+            ...(!open ? { opacity: 0, pointerEvents: 'none' } : {}),
           }}>
           { children }
         </Dialog.Content>

--- a/packages/ods-react/src/components/drawer/tests/rendering/drawer.e2e.ts
+++ b/packages/ods-react/src/components/drawer/tests/rendering/drawer.e2e.ts
@@ -24,4 +24,21 @@ describe('Drawer rendering', () => {
 
     expect(await page.$('[data-scope="dialog"][data-part="backdrop"]')).toBeNull();
   });
+
+  it('should not intercept pointer events while closed', async() => {
+    await gotoStory(page, 'rendering/closed-inert');
+    await page.waitForSelector('[data-ods="drawer-content"]');
+
+    const probe = await page.evaluate(() => {
+      const contents = document.querySelectorAll('[data-ods="drawer-content"][data-state="closed"]');
+      const target = document.querySelector('[data-testid="under-drawer"]') as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      return { closedCount: contents.length, isHit: hit === target };
+    });
+
+    // All three non-modal variants are mounted closed over the button area.
+    expect(probe.closedCount).toBe(3);
+    expect(probe.isHit).toBe(true);
+  });
 });

--- a/packages/ods-react/src/components/drawer/tests/rendering/drawer.stories.tsx
+++ b/packages/ods-react/src/components/drawer/tests/rendering/drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '../../src';
+import { DRAWER_POSITION, Drawer, DrawerBody, DrawerContent, DrawerTrigger } from '../../src';
 
 export default {
   component: Drawer,
@@ -42,4 +42,46 @@ export const withoutBackdrop = () => (
       </DrawerBody>
     </DrawerContent>
   </Drawer>
+);
+
+// The three non-modal variants: closed, they used to intercept clicks on their area.
+export const closedInert = () => (
+  <>
+    <Drawer>
+      <DrawerTrigger data-testid="trigger-portal">
+        Portal
+      </DrawerTrigger>
+      <DrawerContent position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Portaled, no backdrop
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <Drawer backdrop={ false }>
+      <DrawerTrigger data-testid="trigger-backdrop-false">
+        Backdrop false
+      </DrawerTrigger>
+      <DrawerContent position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Portaled, backdrop false
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <Drawer>
+      <DrawerTrigger data-testid="trigger-inline">
+        Inline
+      </DrawerTrigger>
+      <DrawerContent createPortal={ false } position={ DRAWER_POSITION.left }>
+        <DrawerBody>
+          Not portaled, no backdrop
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+
+    <button data-testid="under-drawer" type="button">
+      Sits inside the closed drawers area
+    </button>
+  </>
 );


### PR DESCRIPTION
## Summary

Since the ark bump `5.25.1 → 5.37.2` (c1018d62d, merged in #1101), every mounted **closed** `Drawer` is an invisible, full-size, click-swallowing panel. Supersedes #1105, which misattributed the root cause to the backdrop feature (#1080 is unrelated — drawers have always been non-modal by design).

## Root cause

Somewhere between `@zag-js/dialog` 1.35 and 1.38 (bisected on the npm tarballs), zag started inlining a style on **non-modal** dialog content, open or closed:

```js
// @zag-js/dialog dialog.connect.mjs — getContentProps(), still present in latest (1.43.1)
style: compact({
  pointerEvents: prop("modal") ? void 0 : "auto"
})
```

ODS drawers are non-modal by design (the page stays interactive behind them), so every drawer gets that inline `pointer-events: auto` — which defeats the component's closed-state CSS (`[data-state='closed'] { pointer-events: none; opacity: 0 }`: inline styles beat any stylesheet). The closed content also stays `display: block` (the drawer mixin overrides the UA `[hidden]` rule), so the result is a mounted, transparent, fixed-position panel with `pointer-events: auto`: `left`/`right` drawers become an invisible 320px-wide strip spanning the full viewport height, `top`/`bottom` an invisible full-width banner — each swallowing every click on its area.

## Measurements

Probed on the closed content element, live render:

| Variant | inline style at mount | computed `pointer-events` | intercepts clicks |
|---|---|---|---|
| `createPortal={ false }`, no `backdrop` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled (default), no `backdrop` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled, `backdrop={ false }` | `pointer-events: auto; opacity: 0;` | `auto` | **yes** |
| portaled, `backdrop` (true → modal) | `opacity: 0;` | `none` | no |

- The harmful window is **from mount until the first open**: after one full open → close cycle, zag drops the inline `pointer-events` on that instance. Most drawers on a page are never opened, so in practice the panels persist.
- Published v19.7.3 (ark 5.25.1 / zag dialog 1.24.2, pre-dating the zag change) is unaffected.
- Latest zag (1.43.1) still carries the behavior, so bumping ark again does not help.

## Fix

`DrawerContent` already forces `opacity: 0` inline when closed; this adds `pointerEvents: 'none'` in the same branch. The user style wins over the zag inline style in Ark's `mergeProps`, the open (non-modal) behavior is untouched, and the exit animation is preserved — no lifecycle change (alternatives considered: `lazyMount`/`unmountOnExit` would drop internal state of drawer content on close, and honoring `[hidden]` via CSS would kill the close animation). Filing the underlying issue upstream (zag putting `pointer-events: auto` on *closed* content) is worth doing regardless; this fix stays as defense in depth.

## Tests

New `closedInert` rendering story stacking the three affected variants (portaled, `backdrop={ false }`, `createPortal={ false }`) over a probe button, and an e2e test asserting via `elementFromPoint` that the button — not a closed drawer panel — receives the pointer. Red without the fix, green with it (4/4 drawer e2e). Also covers future dependency bumps.
