### PR TITLE
fix(select): pluralize the merged selection default label

### DIFF
--- a/packages/ods-react/src/components/select/src/components/select-merged-selection/SelectMergedSelection.tsx
+++ b/packages/ods-react/src/components/select/src/components/select-merged-selection/SelectMergedSelection.tsx
@@ -10,12 +10,14 @@ interface SelectMergedSelectionProp {
 
 const SelectMergedSelection: FC<SelectMergedSelectionProp> = ({
   disabled,
-  multipleSelectionLabel = 'Selected item',
+  multipleSelectionLabel,
   total,
 }): JSX.Element => {
+  const label = multipleSelectionLabel || `Selected item${total > 1 ? 's' : ''}`;
+
   return (
     <span>
-      { multipleSelectionLabel }&nbsp;
+      { label }&nbsp;
       <span
         className={ classNames(
           style['select-merged-selection__total'],

--- a/packages/ods-react/src/components/select/tests/component/selectMergedSelection.spec.tsx
+++ b/packages/ods-react/src/components/select/tests/component/selectMergedSelection.spec.tsx
@@ -1,0 +1,26 @@
+import { renderToString } from 'react-dom/server';
+import { SelectMergedSelection } from '../../src/components/select-merged-selection/SelectMergedSelection';
+
+describe('SelectMergedSelection', () => {
+  it('should render the singular default label for a single selection', () => {
+    expect(renderToString(<SelectMergedSelection total={ 1 } />))
+      .toContain('Selected item');
+  });
+
+  it('should render the plural default label for multiple selections', () => {
+    expect(renderToString(<SelectMergedSelection total={ 3 } />))
+      .toContain('Selected items');
+  });
+
+  it('should render the default label when an empty label is given', () => {
+    expect(renderToString(<SelectMergedSelection multipleSelectionLabel="" total={ 2 } />))
+      .toContain('Selected items');
+  });
+
+  it('should render the given label', () => {
+    const rendered = renderToString(<SelectMergedSelection multipleSelectionLabel="Chosen" total={ 4 } />);
+
+    expect(rendered).toContain('Chosen');
+    expect(rendered).not.toContain('Selected item');
+  });
+});


### PR DESCRIPTION
The default label for a merged multiple selection was the fixed string 'Selected item', which read incorrectly for more than one selected item. Derive it from the total instead, and fall back to it when the consumer passes an empty label as well as when the prop is omitted.