### PR TITLE
WIP feat(Tag): allow rendering the tag as a link

### DIFF
--- a/packages/ods-react/src/components/tag/src/components/tag/Tag.tsx
+++ b/packages/ods-react/src/components/tag/src/components/tag/Tag.tsx
@@ -1,11 +1,18 @@
 import classNames from 'classnames';
-import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type ElementType, type ForwardedRef, type JSX, forwardRef } from 'react';
 import { ICON_NAME, Icon, type IconName } from '../../../../icon/src';
 import { TAG_COLOR, type TagColor } from '../../constants/tag-color';
 import { TAG_SIZE, type TagSize } from '../../constants/tag-size';
 import style from './tag.module.scss';
 
-interface TagProp extends ComponentPropsWithRef<'button'> {
+interface TagProp<T extends ElementType = 'button'> {
+  /**
+   * \@default-value='button'
+   * Pass a component you may want to use as custom Tag component.
+   * Useful for example to render the tag as a link, either a plain anchor or the Link
+   * component of a routing library.
+   * */
+  as?: T,
   /**
    * @type=TAG_COLOR
    * The color preset to use.
@@ -13,6 +20,7 @@ interface TagProp extends ComponentPropsWithRef<'button'> {
   color?: TagColor;
   /**
    * The icon to display on the right side.
+   * Only rendered when the tag is a button.
    */
   icon?: IconName | null,
   /**
@@ -21,16 +29,20 @@ interface TagProp extends ComponentPropsWithRef<'button'> {
   size?: TagSize;
 }
 
-const Tag: FC<TagProp> = forwardRef(({
+const TagRoot = forwardRef(function Tag<T extends ElementType>({
+  as,
   children,
   className,
   color = TAG_COLOR.information,
   icon = ICON_NAME.xmark,
   size = TAG_SIZE.md,
   ...props
-}, ref): JSX.Element => {
+}: TagProp<T> & Omit<ComponentPropsWithRef<T>, keyof TagProp<T>>, ref: ForwardedRef<HTMLButtonElement>): JSX.Element {
+  const Component = as || 'button';
+  const isButton = Component === 'button';
+
   return (
-    <button
+    <Component
       className={ classNames(
         style['tag'],
         style[`tag--${color}`],
@@ -39,21 +51,28 @@ const Tag: FC<TagProp> = forwardRef(({
       )}
       data-ods="tag"
       ref={ ref }
-      type="button"
+      type={ isButton ? 'button' : undefined }
       { ...props }>
       { children }
 
       {
-        !!icon &&
+        isButton && !!icon &&
         <Icon
           className={ style['tag__close'] }
           name={ icon } />
       }
-    </button>
+    </Component>
   );
 });
 
-Tag.displayName = 'Tag';
+TagRoot.displayName = 'Tag';
+
+// `forwardRef` cannot carry a generic through, so its inferred props type accepts anything and
+// requires nothing. Restating the signature keeps `as` type safe: the props and the ref of the
+// rendered element are enforced at the call site.
+const Tag = TagRoot as <T extends ElementType = 'button'>(
+  props: TagProp<T> & Omit<ComponentPropsWithRef<T>, keyof TagProp<T>>,
+) => JSX.Element;
 
 export {
   Tag,

--- a/packages/ods-react/src/components/tag/tests/navigation/tag.e2e.ts
+++ b/packages/ods-react/src/components/tag/tests/navigation/tag.e2e.ts
@@ -20,6 +20,28 @@ describe('Tag navigation', () => {
       expect(await isFocused(tag)).toBe(true);
     });
 
+    it('should be focused on tabulation when rendered as a link', async() => {
+      await gotoStory(page, 'navigation/focus-link');
+
+      const tag = await page.waitForSelector('[data-testid="focus-link"]');
+
+      expect(await isFocused(tag)).toBe(false);
+
+      await page.keyboard.press('Tab');
+
+      expect(await isFocused(tag)).toBe(true);
+    });
+
+    it('should navigate on enter when rendered as a link', async() => {
+      await gotoStory(page, 'navigation/focus-link');
+
+      await page.waitForSelector('[data-testid="focus-link"]');
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Enter');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#dummy-target');
+    });
+
     it('should not be focusable if disabled', async() => {
       await gotoStory(page, 'navigation/disabled');
 

--- a/packages/ods-react/src/components/tag/tests/navigation/tag.stories.tsx
+++ b/packages/ods-react/src/components/tag/tests/navigation/tag.stories.tsx
@@ -13,6 +13,15 @@ export const disabled = () => (
   </Tag>
 );
 
+export const focusLink = () => (
+  <Tag
+    as="a"
+    data-testid="focus-link"
+    href="#dummy-target">
+    Focus link
+  </Tag>
+);
+
 export const focus = () => (
   <Tag data-testid="focus">
     Focus

--- a/packages/ods-react/src/components/tag/tests/rendering/tag.e2e.ts
+++ b/packages/ods-react/src/components/tag/tests/rendering/tag.e2e.ts
@@ -20,6 +20,57 @@ describe('Tag rendering', () => {
     });
   });
 
+  describe('as', () => {
+    it('should render a button with its removal icon by default', async() => {
+      await gotoStory(page, 'rendering/render');
+
+      const tag = await page.waitForSelector('[data-testid="render"]');
+      const tagName = await tag?.evaluate((el: Element) => el.tagName);
+      const type = await tag?.evaluate((el: Element) => el.getAttribute('type'));
+      const icon = await tag?.$('[data-ods="icon"]');
+
+      expect(tagName).toBe('BUTTON');
+      expect(type).toBe('button');
+      expect(icon).not.toBeNull();
+    });
+
+    it('should render a link when asked to', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const tag = await page.waitForSelector('[data-testid="link"]');
+      const tagName = await tag?.evaluate((el: Element) => el.tagName);
+      const href = await tag?.evaluate((el: Element) => el.getAttribute('href'));
+
+      expect(tagName).toBe('A');
+      expect(href).toBe('#dummy-target');
+    });
+
+    it('should not render the removal icon on a link, as there is nothing to remove', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const tag = await page.waitForSelector('[data-testid="link"]');
+
+      expect(await tag?.$('[data-ods="icon"]')).toBeNull();
+    });
+
+    it('should not render the button type attribute on a link', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const tag = await page.waitForSelector('[data-testid="link"]');
+
+      expect(await tag?.evaluate((el: Element) => el.getAttribute('type'))).toBeNull();
+    });
+
+    it('should render a link without the browser underline', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const tag = await page.waitForSelector('[data-testid="link"]');
+      const decoration = await tag?.evaluate((el: Element) => getComputedStyle(el).textDecorationLine);
+
+      expect(decoration).toBe('none');
+    });
+  });
+
   describe('sizes', () => {
     it('should respect increase order ( md < lg)', async() => {
       await gotoStory(page, 'rendering/sizes');

--- a/packages/ods-react/src/components/tag/tests/rendering/tag.stories.tsx
+++ b/packages/ods-react/src/components/tag/tests/rendering/tag.stories.tsx
@@ -13,6 +13,15 @@ export const customStyle = () => (
   </Tag>
 );
 
+export const link = () => (
+  <Tag
+    as="a"
+    data-testid="link"
+    href="#dummy-target">
+    Link
+  </Tag>
+);
+
 export const render = () => (
   <Tag
     data-testid="render">

--- a/packages/ods-react/src/style/_tag.scss
+++ b/packages/ods-react/src/style/_tag.scss
@@ -81,6 +81,7 @@ $ods-tag-padding-vertical-lg: calc(var(--ods-theme-padding-vertical) / 4);
   border-width: var(--ods-tag-border-width);
   border-style: solid;
   border-radius: var(--ods-border-radius-lg);
+  text-decoration: none;
   font-family: inherit;
   cursor: pointer;
 

--- a/packages/storybook/stories/components/tag/documentation.mdx
+++ b/packages/storybook/stories/components/tag/documentation.mdx
@@ -49,6 +49,7 @@ Ensure that **Tags** are clearly labelled and easily distinguishable from other 
     '- Don\'t use full sentences or long text in a Tag label',
     '- Don\'t mix Tags with different behaviors (e.g., some removable, some static) unless necessary and clearly indicated',
     '- Don\'t use Tags as primary action triggers (e.g., "Submit", "Save"), use Buttons instead',
+    '- Don\'t use a removable Tag to navigate, nor a link Tag to filter: the element has to match the action',
   ]}
   dos={[
     '- Use Tags to represent interactive labels such as filters, categories, or user-defined keywords',
@@ -57,6 +58,7 @@ Ensure that **Tags** are clearly labelled and easily distinguishable from other 
     '- Allow Tags to be removable or toggleable if the interaction requires it (e.g., deselecting a filter)',
     '- Keep visual distinction between Tags (interactive) and Badges (static)',
     '- Trigger removal action when the Tag displays a delete icon',
+    '- Use a link Tag (`as="a"`) when the Tag navigates, for instance a blog category leading to its own page',
   ]}
 />
 
@@ -96,6 +98,18 @@ Multiple **Tags** can be displayed:
 - **Medium** _(default)_: main size for displaying **Tags**.
 - **Large**: highlighting important labels or metadata with greater visibility and emphasis, making them easily noticeable to users.
 
+<Heading label="Element" level={ 3 } />
+
+- **Button** _(default)_: interacting with the **Tag** in place, typically removing it or toggling a filter.
+- **Link**: navigating to another page. Pass `as="a"` with an `href`, or `as` a routing library
+  component (`as={ Link }` with react-router, for instance) to keep client side navigation.
+
+A link **Tag** never displays the removal icon, since there is nothing to remove: the icon is the
+removal affordance of the button **Tag**. Rendering the **Tag** as a link also makes its destination
+visible to search engines, which a button cannot do.
+
+<Canvas of={ TagStories.Link } sourceState='shown' />
+
 <Heading label="Navigation" level={ 2 } />
 
 <Heading label="Focus Management" level={ 3 } />
@@ -107,6 +121,8 @@ The **Tag** component is focusable and follows the same keyboard interactions as
 Pressing <Kbd>Tab</Kbd> moves focus to the **Tag**.
 
 Pressing <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> triggers the assigned action: removing the **Tag**.
+
+On a link **Tag**, only <Kbd>Enter</Kbd> activates it, following the native anchor behaviour.
 
 Pressing <Kbd>Shift</Kbd> + <Kbd>Tab</Kbd> moves focus to the previous interactive element.
 

--- a/packages/storybook/stories/components/tag/examples.mdx
+++ b/packages/storybook/stories/components/tag/examples.mdx
@@ -25,6 +25,10 @@ import * as TagStories from './tag.stories';
 
 <Canvas of={ TagStories.Size } sourceState="shown" />
 
+<Heading label="Link" level={ 2 } />
+
+<Canvas of={ TagStories.Link } sourceState="shown" />
+
 <Heading label="Custom icon" level={ 2 } />
 
 <Canvas of={ TagStories.CustomIcon } sourceState="shown" />

--- a/packages/storybook/stories/components/tag/tag.stories.tsx
+++ b/packages/storybook/stories/components/tag/tag.stories.tsx
@@ -96,6 +96,22 @@ export const Disabled: Story = {
   ),
 };
 
+export const Link: Story = {
+  decorators: [(story) => <div style={{ display: 'flex', flexFlow: 'row', gap: '8px', alignItems: 'center' }}>{ story() }</div>],
+  globals: {
+    imports: `import { Tag } from '@ovhcloud/ods-react';`,
+  },
+  tags: ['!dev'],
+  parameters: {
+    layout: 'centered',
+  },
+  render: ({}) => (
+    <Tag as="a" href="#kubernetes">
+      Kubernetes
+    </Tag>
+  ),
+};
+
 export const Overview: Story = {
   tags: ['!dev'],
   parameters: {


### PR DESCRIPTION
Tag now accepts `as`, following the convention already used by Link and BreadcrumbLink, 
so it can render a plain anchor or a routing component:

```tsx
    <Tag as="a" href="/blog/tag/kubernetes">Kubernetes</Tag>
    <Tag as={ Link } to="/blog/tag/kubernetes">Kubernetes</Tag>   // react-router
```

- the removal icon is only rendered on a button Tag: it is the removal affordance, and a link has nothing to remove
- no `type` attribute is emitted on anything but a button
- `text-decoration: none` in the tag mixin, so an anchor is not underlined

`TagProp` no longer extends the `button` attributes: those now come from whatever `as` renders. The exported signature restates the generic, so the props and the ref of the rendered element are checked at the call site (`forwardRef` alone erases the generic, which is why `<Link as="a" to="/x">` compiles today).

Tests: 5 rendering and 2 navigation e2e cases (element type, href, no icon, no type, no underline, Tab focus, Enter navigates).
Docs: link example, an "Element" variation section, and the keyboard note that only Enter activates a link Tag.