### PR TITLE
WIP feat(Button): permit link instead of button

### DIFF
--- a/packages/ods-react/src/components/button/src/components/button/Button.tsx
+++ b/packages/ods-react/src/components/button/src/components/button/Button.tsx
@@ -1,17 +1,30 @@
 import classNames from 'classnames';
-import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type ElementType, type ForwardedRef, type JSX, type MouseEvent, forwardRef } from 'react';
 import { SPINNER_COLOR, SPINNER_SIZE, Spinner } from '../../../../spinner/src';
 import { BUTTON_COLOR, type ButtonColor } from '../../constants/button-color';
 import { BUTTON_SIZE, type ButtonSize } from '../../constants/button-size';
 import { BUTTON_VARIANT, type ButtonVariant } from '../../constants/button-variant';
 import style from './button.module.scss';
 
-interface ButtonProp extends ComponentPropsWithRef<'button'> {
+interface ButtonProp<T extends ElementType = 'button'> extends ComponentPropsWithRef<'button'> {
+  /**
+   * \@default-value='button'
+   * Pass a component you may want to use as custom Button component.
+   * Useful for example to render the button as a link, either a plain anchor or the Link
+   * component of a routing library.
+   * */
+  as?: T,
   /**
    * @type=BUTTON_COLOR
    * The color preset to use.
    */
   color?: ButtonColor,
+  /**
+   * Whether the component is disabled.
+   * A non-button element takes no `disabled` attribute, so it is disabled through
+   * `aria-disabled` instead: no `href`, out of the tab order, clicks prevented.
+   */
+  disabled?: boolean,
   /**
    * Whether the component is in loading state, disabling it.
    */
@@ -26,17 +39,61 @@ interface ButtonProp extends ComponentPropsWithRef<'button'> {
   variant?: ButtonVariant,
 }
 
-const Button: FC<ButtonProp> = forwardRef(({
+/**
+ * The props owned by the component, as opposed to the ones it forwards to the rendered element.
+ * Only these are removed from the `as` target props, so that `href`, `ref` and the rest keep the
+ * type of the element actually rendered.
+ * @internal
+ */
+type ButtonOwnProp<T extends ElementType = 'button'> = Pick<ButtonProp<T>, 'as' | 'color' | 'disabled' | 'loading' | 'size' | 'variant'>;
+
+// The attributes read back from the forwarded props, whichever element is rendered.
+type ButtonDomProp = Omit<ComponentPropsWithRef<'button'>, 'onClick'>
+  & Pick<ComponentPropsWithRef<'a'>, 'href'>
+  & { onClick?: (event: MouseEvent<HTMLElement>) => void };
+
+const ButtonRoot = forwardRef(function Button<T extends ElementType>({
+  as,
   children,
   className,
   color = BUTTON_COLOR.primary,
+  disabled,
   loading = false,
   size = BUTTON_SIZE.md,
   variant = BUTTON_VARIANT.default,
   ...props
-}, ref): JSX.Element => {
+}: ButtonProp<T> & Omit<ComponentPropsWithRef<T>, keyof ButtonOwnProp<T>>, ref: ForwardedRef<HTMLButtonElement>): JSX.Element {
+  const Component = as || 'button';
+  const isButton = Component === 'button';
+  const isDisabled = disabled || loading;
+  const domProps = props as ButtonDomProp;
+
+  // A non-button element takes neither the `disabled` nor the `type` attribute, so a disabled
+  // one is made inert the way `Link` does it: no `href` to follow, out of the tab order, and
+  // clicks stopped before they reach a parent handler.
+  const elementProps = isButton
+    ? {
+      disabled: isDisabled,
+      type: domProps.type || 'button',
+    }
+    : {
+      'aria-disabled': isDisabled ? true : domProps['aria-disabled'],
+      href: isDisabled ? undefined : domProps.href,
+      tabIndex: isDisabled ? -1 : domProps.tabIndex,
+    };
+
+  function onClick(event: MouseEvent<HTMLElement>): void {
+    if (isDisabled && !isButton) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    domProps.onClick?.(event);
+  }
+
   return (
-    <button
+    <Component
       className={ classNames(
         style['button'],
         style[`button--${color}`],
@@ -45,10 +102,10 @@ const Button: FC<ButtonProp> = forwardRef(({
         className,
       )}
       data-ods="button"
-      disabled={ props.disabled || loading }
       ref={ ref }
       { ...props }
-      type={ props.type || 'button' }>
+      { ...elementProps }
+      onClick={ onClick }>
       {
         loading &&
         <span className={ style['button__spinner'] }>
@@ -60,11 +117,18 @@ const Button: FC<ButtonProp> = forwardRef(({
       }
 
       { children }
-    </button>
+    </Component>
   );
 });
 
-Button.displayName = 'Button';
+ButtonRoot.displayName = 'Button';
+
+// `forwardRef` cannot carry a generic through, so its inferred props type accepts anything and
+// requires nothing. Restating the signature keeps `as` type safe: the props and the ref of the
+// rendered element are enforced at the call site.
+const Button = ButtonRoot as <T extends ElementType = 'button'>(
+  props: ButtonOwnProp<T> & Omit<ComponentPropsWithRef<T>, keyof ButtonOwnProp<T>>,
+) => JSX.Element;
 
 export {
   Button,

--- a/packages/ods-react/src/components/button/tests/navigation/button.e2e.ts
+++ b/packages/ods-react/src/components/button/tests/navigation/button.e2e.ts
@@ -20,6 +20,28 @@ describe('Button navigation', () => {
       expect(await isFocused(button)).toBe(true);
     });
 
+    it('should be focused on tabulation when rendered as a link', async() => {
+      await gotoStory(page, 'navigation/focus-link');
+
+      const button = await page.waitForSelector('[data-testid="focus-link"]');
+
+      expect(await isFocused(button)).toBe(false);
+
+      await page.keyboard.press('Tab');
+
+      expect(await isFocused(button)).toBe(true);
+    });
+
+    it('should navigate on enter when rendered as a link', async() => {
+      await gotoStory(page, 'navigation/focus-link');
+
+      await page.waitForSelector('[data-testid="focus-link"]');
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Enter');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#dummy-target');
+    });
+
     it('should not be focusable if disabled', async() => {
       await gotoStory(page, 'navigation/disabled');
 
@@ -30,6 +52,27 @@ describe('Button navigation', () => {
       await page.keyboard.press('Tab');
 
       expect(await isFocused(button)).toBe(false);
+    });
+
+    it('should not be focusable if a disabled link', async() => {
+      await gotoStory(page, 'navigation/disabled-link');
+
+      const button = await page.waitForSelector('[data-testid="disabled-link"]');
+
+      expect(await isFocused(button)).toBe(false);
+
+      await page.keyboard.press('Tab');
+
+      expect(await isFocused(button)).toBe(false);
+    });
+
+    it('should not navigate on click if a disabled link', async() => {
+      await gotoStory(page, 'navigation/disabled-link');
+
+      await page.waitForSelector('[data-testid="disabled-link"]');
+      await page.click('[data-testid="disabled-link"]');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('');
     });
 
     it('should not be focusable if is-loading is set', async() => {

--- a/packages/ods-react/src/components/button/tests/navigation/button.stories.tsx
+++ b/packages/ods-react/src/components/button/tests/navigation/button.stories.tsx
@@ -13,9 +13,28 @@ export const disabled = () => (
   </Button>
 );
 
+export const disabledLink = () => (
+  <Button
+    as="a"
+    data-testid="disabled-link"
+    disabled={ true }
+    href="#dummy-target">
+    Disabled link
+  </Button>
+);
+
 export const focus = () => (
   <Button data-testid="focus">
     Focus
+  </Button>
+);
+
+export const focusLink = () => (
+  <Button
+    as="a"
+    data-testid="focus-link"
+    href="#dummy-target">
+    Focus link
   </Button>
 );
 

--- a/packages/ods-react/src/components/button/tests/rendering/button.e2e.ts
+++ b/packages/ods-react/src/components/button/tests/rendering/button.e2e.ts
@@ -20,6 +20,66 @@ describe('Button rendering', () => {
     });
   });
 
+  describe('as', () => {
+    it('should render a button by default', async() => {
+      await gotoStory(page, 'rendering/render');
+
+      const button = await page.waitForSelector('[data-testid="render"]');
+
+      expect(await button?.evaluate((el: Element) => el.tagName)).toBe('BUTTON');
+      expect(await button?.evaluate((el: Element) => el.getAttribute('type'))).toBe('button');
+    });
+
+    it('should render a link when asked to', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const button = await page.waitForSelector('[data-testid="link"]');
+
+      expect(await button?.evaluate((el: Element) => el.tagName)).toBe('A');
+      expect(await button?.evaluate((el: Element) => el.getAttribute('href'))).toBe('#dummy-target');
+    });
+
+    it('should not render the button only attributes on a link', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const button = await page.waitForSelector('[data-testid="link"]');
+
+      expect(await button?.evaluate((el: Element) => el.getAttribute('type'))).toBeNull();
+      expect(await button?.evaluate((el: Element) => el.hasAttribute('disabled'))).toBe(false);
+    });
+
+    it('should render a link without the browser underline', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const button = await page.waitForSelector('[data-testid="link"]');
+
+      expect(await button?.evaluate((el: Element) => getComputedStyle(el).textDecorationLine)).toBe('none');
+    });
+
+    it('should make a disabled link inert without the disabled attribute', async() => {
+      await gotoStory(page, 'rendering/link-disabled');
+
+      const link = await page.waitForSelector('[data-testid="link-disabled"]');
+
+      expect(await link?.evaluate((el: Element) => el.getAttribute('aria-disabled'))).toBe('true');
+      expect(await link?.evaluate((el: Element) => el.hasAttribute('href'))).toBe(false);
+      expect(await link?.evaluate((el: Element) => el.getAttribute('tabindex'))).toBe('-1');
+    });
+
+    it('should apply the disabled style to a disabled link', async() => {
+      await gotoStory(page, 'rendering/link-disabled');
+
+      const button = await page.waitForSelector('[data-testid="link-disabled-button"]');
+      const link = await page.waitForSelector('[data-testid="link-disabled"]');
+
+      const buttonColor = await button?.evaluate((el: Element) => getComputedStyle(el).color);
+      const linkColor = await link?.evaluate((el: Element) => getComputedStyle(el).color);
+
+      expect(await link?.evaluate((el: Element) => getComputedStyle(el).cursor)).toBe('not-allowed');
+      expect(linkColor).toBe(buttonColor);
+    });
+  });
+
   describe('loading', () => {
     it('should disable the button', async() => {
       await gotoStory(page, 'rendering/is-loading');

--- a/packages/ods-react/src/components/button/tests/rendering/button.stories.tsx
+++ b/packages/ods-react/src/components/button/tests/rendering/button.stories.tsx
@@ -21,6 +21,33 @@ export const isLoading = () => (
   </Button>
 );
 
+export const link = () => (
+  <Button
+    as="a"
+    data-testid="link"
+    href="#dummy-target">
+    Link
+  </Button>
+);
+
+export const linkDisabled = () => (
+  <>
+    <Button
+      data-testid="link-disabled-button"
+      disabled={ true }>
+      Disabled button
+    </Button>
+
+    <Button
+      as="a"
+      data-testid="link-disabled"
+      disabled={ true }
+      href="#dummy-target">
+      Disabled link
+    </Button>
+  </>
+);
+
 export const render = () => (
   <Button
     data-testid="render">

--- a/packages/ods-react/src/components/button/typedoc.json
+++ b/packages/ods-react/src/components/button/typedoc.json
@@ -8,6 +8,9 @@
   "excludeInternal": true,
   "excludePrivate": true,
   "excludeProtected": true,
+  "intentionallyNotExported": [
+    "ButtonOwnProp"
+  ],
   "outputs": [
     {
       "name": "json",

--- a/packages/ods-react/src/style/_button.scss
+++ b/packages/ods-react/src/style/_button.scss
@@ -200,13 +200,15 @@ $ods-button-size-md: 40px;
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  text-decoration: none;
   font-family: inherit;
   font-size: 1rem;
   font-weight: 600;
   font-style: normal;
   cursor: pointer;
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     @include state.ods-is-disabled();
   }
 
@@ -245,7 +247,7 @@ $ods-button-size-md: 40px;
   border-width: var(--ods-button-border-radius-width);
   border-style: solid;
 
-  &:not(:disabled) {
+  &:not(:disabled, [aria-disabled="true"]) {
     @if $color == 'critical' {
       border-color: var(--ods-button-border-color-critical);
       background-color: var(--ods-button-background-color-critical);
@@ -343,11 +345,12 @@ $ods-button-size-md: 40px;
 @mixin ods-button-variant-ghost($color) {
   border: var(--ods-button-border-radius-width) solid transparent;
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     background-color: inherit;
   }
 
-  &:not(:disabled) {
+  &:not(:disabled, [aria-disabled="true"]) {
     @if $color == 'critical' {
       background-color: var(--ods-button-background-color-critical-ghost);
       color: var(--ods-button-text-color-critical-ghost);
@@ -440,7 +443,7 @@ $ods-button-size-md: 40px;
   border-width: var(--ods-button-border-radius-width);
   border-style: solid;
 
-  &:not(:disabled) {
+  &:not(:disabled, [aria-disabled="true"]) {
     @if $color == 'critical' {
       border-color: var(--ods-button-border-color-critical-outline);
       background-color: var(--ods-button-background-color-critical-outline);

--- a/packages/storybook/stories/components/button/button.stories.tsx
+++ b/packages/storybook/stories/components/button/button.stories.tsx
@@ -52,6 +52,21 @@ export const Default: Story = {
   ),
 };
 
+export const Link: StoryObj = {
+  decorators: [(story) => <div style={{ display: 'flex', flexFlow: 'row', gap: '8px', alignItems: 'center' }}>{ story() }</div>],
+  globals: {
+    imports: `import { BUTTON_VARIANT, Button } from '@ovhcloud/ods-react';`,
+  },
+  tags: ['!dev'],
+  render: ({}) => (
+    <>
+      <Button as="a" href="#pricing">See pricing</Button>
+      <Button as="a" href="#docs" variant={ BUTTON_VARIANT.outline }>Read the docs</Button>
+      <Button as="a" disabled={ true } href="#soon">Not available yet</Button>
+    </>
+  ),
+};
+
 export const Loading: StoryObj = {
   globals: {
     imports: `import { Button } from '@ovhcloud/ods-react';`,

--- a/packages/storybook/stories/components/button/documentation.mdx
+++ b/packages/storybook/stories/components/button/documentation.mdx
@@ -44,6 +44,8 @@ They must respect the proximity law in order to guide the user on the action to 
 A **Button** label indicates what happens when the user taps the **Button**, even if it's just to acknowledge something.
 
 **Buttons** don't usually redirect to an external page. For that, see <StorybookLink kind={ REACT_COMPONENTS_TITLE.link } story={ STORY.documentation }>Link</StorybookLink>.
+When a navigation does need the visual weight of a **Button**, render the **Button** as a link with `as="a"` instead
+of navigating from a real `button` element.
 
 <Heading label="When to use a link or a button?" level={ 3 } />
 
@@ -51,14 +53,17 @@ Links and buttons serve different purposes, and using them correctly improves bo
 
 * Use a link when the action navigates the user to another page or resource, either within your application or to an external site
 * Use a button when the action performs a function or triggers a behavior on the current page, like submitting a form, opening a modal, or toggling a menu
+* Use a **Button** rendered as a link (`as="a"`) when the action navigates but deserves the emphasis of a **Button**, like a main call to action leading to another page
 
 A button should not mimic a link. It can lead to confusion for users and assistive technologies, as button are not typically expected to handle navigation.
+The `as` prop is the answer to that: it changes the rendered element without changing the look, so the destination stays a
+real `href` that is announced as a link, opens in a new tab on a middle click, and can be followed by a search engine.
 
 <Heading label="Dos & Don'ts" level={ 3 } />
 
 <BestPractices
   donts={[
-    '- Don\'t use a Button as a link, use the Link component instead',
+    '- Don\'t navigate from a plain Button, pass `as="a"` so the rendered element matches the action',
     '- Don\'t show more than one primary button per view',
     '- Don\'t place two identical Buttons side by side (same label and style)',
     '- Don\'t use standalone decorative icons in Buttons unless the action is universally understood',
@@ -71,6 +76,7 @@ A button should not mimic a link. It can lead to confusion for users and assisti
     '- Maintain a clear visual hierarchy between Button types (primary, outline, ghost)',
     '- Use icons when they add clarity to the action (e.g., arrow for "Next", trash for "Delete")',
     '- Choose the appropriate size based on context',
+    '- Use a link Button (`as="a"`) when a call to action navigates to another page',
   ]}
 />
 
@@ -112,23 +118,41 @@ An icon can be displayed on the left or right of the **Button** label. Icon-only
 - **Small**: actions in compact spaces or within densely packed interfaces, providing a more subtle and space-efficient option.
 - **Medium** _(default)_: main usage of **Buttons**, when they can be displayed in an important manner.
 
+<Heading label="Element" level={ 3 } />
+
+- **Button** _(default)_: acting on the current page, such as submitting a form, opening a modal or toggling a menu.
+- **Link**: navigating to another page. Pass `as="a"` with an `href`, or `as` a routing library component
+  (`as={ Link }` with react-router, for instance) to keep client side navigation.
+
+A link **Button** keeps every color, variant and size of the **Button**; only the rendered element changes.
+A disabled one carries no `href` at all, is taken out of the tab order and ignores clicks, since an anchor takes
+no `disabled` attribute.
+
+<Canvas of={ ButtonStories.Link } sourceState="shown" />
+
 <Heading label="Navigation" level={ 2 } />
 
 <Heading label="Focus Management" level={ 3 } />
 
 The **Button** component can receive keyboard focus and is part of the standard tab order.
 
-If the **Button** is disabled, it does not receive focus and cannot be activated via keyboard.
+If the **Button** is disabled, it does not receive focus and cannot be activated via keyboard. A link **Button**
+behaves the same way: it is part of the standard tab order, and a disabled one is removed from it.
 
 <Heading label="General Keyboard Shortcuts" level={ 3 } />
 
 Pressing <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> while the **Button** is focused activates it, triggering its action.
+
+On a link **Button**, only <Kbd>Enter</Kbd> activates it, following the native anchor behaviour.
 
 Pressing <Kbd>Shift</Kbd> + <Kbd>Alt</Kbd> moves focus to the previous interactive element.
 
 <Heading label="Accessibility" level={ 2 } />
 
 This component complies with the <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/button/">Button WAI-ARIA design pattern</ExternalLink>.
+
+Rendered as a link with `as`, it is a real anchor and follows the native link semantics instead: it is announced as a
+link, and a disabled one is announced as such through `aria-disabled`.
 
 <Heading label="Always provide an explicit text content" level={ 3 } />
 

--- a/packages/storybook/stories/components/button/examples.mdx
+++ b/packages/storybook/stories/components/button/examples.mdx
@@ -17,6 +17,10 @@ import * as ButtonStories from './button.stories';
 
 <Canvas of={ ButtonStories.Color } sourceState="shown" />
 
+<Heading label="Link" level={ 2 } />
+
+<Canvas of={ ButtonStories.Link } sourceState="shown" />
+
 <Heading label="Loading" level={ 2 } />
 
 <Canvas of={ ButtonStories.Loading } sourceState="shown" />


### PR DESCRIPTION
Adds `as` to Button, so a navigation that needs the visual weight of a button renders a real anchor instead of a `<button>` handling a route. Prerequisite for the Pagination link mode PR.

### Notes for review
- `as` follows the existing ODS convention (Link, BreadcrumbLink, Tag). The signature is restated on the exported value because `forwardRef` erases the generic; without that, nothing about `as` is type checked.
- `ButtonProp` still extends the `<button>` props, so the seven prop types that extend it downstream are untouched. The polymorphic Omit therefore keys off a separate internal `ButtonOwnProp`, which keeps the ref following `as`.
- `_button.scss` gated all 5 state selectors on `:disabled`, which an anchor can never match, and reset no `text-decoration`. Both fixed. `ods-button()` is used only by `button.module.scss`, so the change is scoped to the component.
- Behaviour fix riding along: `disabled` is resolved once instead of being overridden by the props spread, so `<Button disabled={false} loading />` is now disabled as its prop doc claims.

### Tested
button e2e 20/20 (6 new rendering, 4 new navigation), `tsc -b` over ods-react, workspace `lint:ts`, `lint:scss`, typedoc.

Additive: minor, no MIGRATION entry.