### PR TITLE
WIP feat(Pagination): permit links instead of buttons

### DIFF
--- a/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
@@ -1,6 +1,7 @@
 import { Pagination as VendorPagination, usePaginationContext } from '@ark-ui/react/pagination';
 import { type FC, type JSX } from 'react';
 import { BUTTON_VARIANT, Button } from '../../../../button/src';
+import { usePagination } from '../../contexts/usePagination';
 import style from './paginationItem.module.scss';
 
 interface PaginationItemProp {
@@ -17,6 +18,7 @@ const PaginationItem: FC<PaginationItemProp> = ({
   page,
 }): JSX.Element => {
   const { page: currentPage } = usePaginationContext();
+  const { getPageUrl } = usePagination();
 
   return (
     <VendorPagination.Item
@@ -26,6 +28,7 @@ const PaginationItem: FC<PaginationItemProp> = ({
       type="page"
       { ...page }>
       <Button
+        as={ getPageUrl ? 'a' : 'button' }
         disabled={ disabled }
         variant={ currentPage === page.value ? BUTTON_VARIANT.default : BUTTON_VARIANT.ghost }>
         { page.value }

--- a/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
@@ -1,4 +1,4 @@
-import { Pagination as VendorPagination } from '@ark-ui/react/pagination';
+import { Pagination as VendorPagination, usePaginationContext } from '@ark-ui/react/pagination';
 import classNames from 'classnames';
 import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
 import { BUTTON_VARIANT, Button } from '../../../../button/src';
@@ -14,7 +14,13 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
   className,
   ...props
 }, ref): JSX.Element => {
-  const { disabled, labelTooltipNext, labelTooltipPrev } = usePagination();
+  const { disabled, getPageUrl, labelTooltipNext, labelTooltipPrev } = usePagination();
+  const { nextPage, previousPage } = usePaginationContext();
+  const isLink = !!getPageUrl;
+  // In link mode zag drops the href at the boundaries but never marks the trigger disabled, as
+  // an anchor takes no `disabled` attribute. Button turns it into the `aria-disabled` contract.
+  const isPrevDisabled = isLink ? (disabled || !previousPage) : disabled;
+  const isNextDisabled = isLink ? (disabled || !nextPage) : disabled;
 
   return (
     <div
@@ -24,7 +30,10 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
       { ...props }>
       <PaginationButtonWithTooltip tooltip={ labelTooltipPrev }>
         <VendorPagination.PrevTrigger asChild>
-          <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
+          <Button
+            as={ isLink ? 'a' : 'button' }
+            disabled={ isPrevDisabled }
+            variant={ BUTTON_VARIANT.ghost }>
             <Icon name={ ICON_NAME.chevronLeft } />
           </Button>
         </VendorPagination.PrevTrigger>
@@ -53,7 +62,10 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
 
       <PaginationButtonWithTooltip tooltip={ labelTooltipNext }>
         <VendorPagination.NextTrigger asChild>
-          <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
+          <Button
+            as={ isLink ? 'a' : 'button' }
+            disabled={ isNextDisabled }
+            variant={ BUTTON_VARIANT.ghost }>
             <Icon name={ ICON_NAME.chevronRight } />
           </Button>
         </VendorPagination.NextTrigger>

--- a/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
@@ -18,7 +18,7 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
   withPageSizeSelector,
   ...props
 }, ref): JSX.Element => {
-  const { currentPage, handlePageChange, itemsPerPage } = usePagination();
+  const { currentPage, getPageUrl, handlePageChange, itemsPerPage } = usePagination();
 
   useEffect(() => {
     if (!children) {
@@ -32,11 +32,13 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
       count={ totalItems }
       data-ods="pagination"
       defaultPage={ defaultPage }
+      getPageUrl={ getPageUrl }
       onPageChange={ handlePageChange }
       page={ currentPage }
       pageSize={ itemsPerPage }
       ref={ ref }
       siblingCount={ siblingCount }
+      type={ getPageUrl ? 'link' : 'button' }
       { ...props }>
       {/* [Deprecated] remove non children default render on next major release */}
       {
@@ -57,6 +59,7 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
 const Pagination: FC<PaginationProp> = forwardRef(({
   defaultPage,
   disabled,
+  getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
   onPageChange,
@@ -70,6 +73,7 @@ const Pagination: FC<PaginationProp> = forwardRef(({
     <PaginationProvider
       defaultPage={ defaultPage }
       disabled={ disabled }
+      getPageUrl={ getPageUrl }
       labelTooltipNext={ labelTooltipNext }
       labelTooltipPrev={ labelTooltipPrev }
       onPageChange={ onPageChange }

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -115,6 +115,12 @@ function PaginationProvider({
   const isControlled = page !== undefined;
   const currentPage = isControlled && page ? page : internalPage;
 
+  // Warned at render time, not in an effect: link mode exists for server rendered listings, and
+  // an effect never runs on the server - which is exactly where the mistake is made.
+  if (getPageUrl && page === undefined && defaultPage === undefined) {
+    console.warn('getPageUrl renders the pages as links, so the URL holds the active page. Please provide a controlled `page` read back from the URL, or a `defaultPage` when the page is rendered by the server, otherwise the pagination stays on page 1.');
+  }
+
   useEffect(() => {
     if (!isControlled) {
       setInternalPage(defaultPage ?? 1);

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -17,6 +17,11 @@ interface PaginationPageSizeChangeDetail {
   pageSize: number,
 }
 
+interface PaginationPageUrlDetail {
+  page: number;
+  pageSize: number;
+}
+
 interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   /**
    * The initial active page. Use when you don't need to control the active page of the pagination.
@@ -26,6 +31,12 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
    * Whether the component is disabled.
    */
   disabled?: boolean;
+  /**
+   * Build the URL of a given page.
+   * Providing it renders the page items and the previous / next triggers as links instead of
+   * buttons, so that the pages can be crawled, opened in a new tab and restored on reload.
+   */
+  getPageUrl?: (detail: PaginationPageUrlDetail) => string;
   /**
    * The tooltip label on the "next page" button.
    */
@@ -73,7 +84,7 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   withPageSizeSelector?: boolean;
 }
 
-interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'labelTooltipNext' | 'labelTooltipPrev' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
+interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'getPageUrl' | 'labelTooltipNext' | 'labelTooltipPrev' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
   children: ReactNode;
 }
 
@@ -90,6 +101,7 @@ function PaginationProvider({
   children,
   defaultPage,
   disabled,
+  getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
   onPageChange,
@@ -110,7 +122,10 @@ function PaginationProvider({
   }, [defaultPage, isControlled, itemsPerPage, totalItems]);
 
   function handlePageChange(detail: PaginationPageChangeDetail): void {
-    if (!isControlled) {
+    // In link mode the URL holds the page, so the component must not move on its own: React
+    // flushes a click synchronously, and a page change would rewrite the trigger href before
+    // the browser follows it, sending the user one page too far.
+    if (!isControlled && !getPageUrl) {
       setInternalPage(detail.page);
     }
     onPageChange?.(detail);
@@ -129,6 +144,7 @@ function PaginationProvider({
       currentPage,
       defaultPage,
       disabled,
+      getPageUrl,
       handlePageChange,
       handlePageSizeChange,
       itemsPerPage,
@@ -154,6 +170,7 @@ export {
   type PaginationContextType,
   type PaginationPageChangeDetail,
   type PaginationPageSizeChangeDetail,
+  type PaginationPageUrlDetail,
   PaginationProvider,
   type PaginationRootProp,
   type PaginationTotalItemsLabelRenderer,

--- a/packages/ods-react/src/components/pagination/src/index.ts
+++ b/packages/ods-react/src/components/pagination/src/index.ts
@@ -3,4 +3,4 @@ export { PaginationPageSelector, type PaginationPageSelectorProp } from './compo
 export { PaginationPageSizeSelector, type PaginationPageSizeSelectorProp } from './components/pagination-page-size-selector/PaginationPageSizeSelector';
 export { PaginationPages, type PaginationPagesProp } from './components/pagination-pages/PaginationPages';
 export { PAGINATION_PER_PAGE } from './constants/pagination-per-page';
-export { type PaginationPageChangeDetail, type PaginationPageSizeChangeDetail } from './contexts/usePagination';
+export { type PaginationPageChangeDetail, type PaginationPageSizeChangeDetail, type PaginationPageUrlDetail } from './contexts/usePagination';

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
@@ -1,0 +1,70 @@
+import 'jest-puppeteer';
+import { gotoStory } from '../../../../helpers/test';
+
+describe('Pagination navigation', () => {
+  describe('link mode', () => {
+    it('should navigate when a page link is activated', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const target = await page.waitForSelector('[data-part="item"][aria-current="page"] + [data-part="item"]');
+      const href = await target?.evaluate((el: Element) => el.getAttribute('href'));
+
+      expect(href).toBe('#page-2-size-10');
+
+      await target?.click();
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#page-2-size-10');
+    });
+
+    it('should follow the next trigger to the page it points at', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+      const href = await trigger?.evaluate((el: Element) => el.getAttribute('href'));
+
+      expect(href).toBe('#page-2-size-10');
+
+      await trigger?.click();
+
+      expect(await page.evaluate(() => window.location.hash)).toBe(href);
+    });
+
+    it('should walk the pages with the triggers when the page comes from the url', async() => {
+      await gotoStory(page, 'navigation/link-from-url');
+      await page.waitForSelector('[data-testid="link-from-url"]');
+
+      async function activate(part: string): Promise<string | null | undefined> {
+        const trigger = await page.waitForSelector(`[data-part="${part}"]`);
+
+        await trigger?.click();
+
+        return page.evaluate(() => window.location.hash);
+      }
+
+      expect(await activate('next-trigger')).toBe('#page-2-size-10');
+      expect(await activate('next-trigger')).toBe('#page-3-size-10');
+      expect(await activate('prev-trigger')).toBe('#page-2-size-10');
+    });
+
+    it('should not navigate when the inert previous trigger is clicked', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      await page.click('[data-part="prev-trigger"]');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('');
+    });
+
+    it('should keep the inert previous trigger out of the tab order', async() => {
+      await gotoStory(page, 'navigation/link');
+
+      const trigger = await page.waitForSelector('[data-part="prev-trigger"]');
+
+      await page.keyboard.press('Tab');
+
+      expect(await trigger?.evaluate((el: Element) => document.activeElement === el)).toBe(false);
+    });
+  });
+});

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
@@ -1,0 +1,56 @@
+import { type JSX, useEffect, useState } from 'react';
+import { Pagination, PaginationPages, type PaginationPageUrlDetail } from '../../src';
+
+export default {
+  component: Pagination,
+  title: 'Tests navigation',
+};
+
+const PAGE_SIZE = 10;
+
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `#page-${page}-size-${pageSize}`;
+}
+
+function readPageFromHash(): number {
+  const match = window.location.hash.match(/^#page-(\d+)-size-\d+$/);
+
+  return match ? Number(match[1]) : 1;
+}
+
+// The realistic wiring of link mode: the URL holds the page, the component only renders it.
+function LinkFromUrl(): JSX.Element {
+  const [page, setPage] = useState(readPageFromHash);
+
+  useEffect(() => {
+    function sync(): void {
+      setPage(readPageFromHash());
+    }
+
+    window.addEventListener('hashchange', sync);
+
+    return () => window.removeEventListener('hashchange', sync);
+  }, []);
+
+  return (
+    <Pagination
+      data-testid="link-from-url"
+      getPageUrl={ getPageUrl }
+      page={ page }
+      pageSize={ PAGE_SIZE }
+      totalItems={ 200 }>
+      <PaginationPages />
+    </Pagination>
+  );
+}
+
+export const link = () => (
+  <Pagination
+    data-testid="link"
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const linkFromUrl = () => <LinkFromUrl />;

--- a/packages/ods-react/src/components/pagination/tests/rendering/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/rendering/pagination.e2e.ts
@@ -9,6 +9,112 @@ describe('Pagination rendering', () => {
     expect(await page.waitForSelector('[data-ods="pagination"]')).not.toBeNull();
   });
 
+  describe('link mode', () => {
+    it('should render every page as a link carrying the page and the page size', async() => {
+      await gotoStory(page, 'rendering/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const items = await page.$$('[data-part="item"]');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        href: el.getAttribute('href'),
+        tagName: el.tagName,
+        type: el.getAttribute('type'),
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+      expect(rendered[0].href).toBe('#page-1-size-10');
+
+      rendered.forEach(({ href, tagName, type }) => {
+        expect(tagName).toBe('A');
+        expect(type).toBeNull();
+        expect(href).toMatch(/^#page-\d+-size-10$/);
+      });
+    });
+
+    it('should render every page as a button without a page url builder', async() => {
+      await gotoStory(page, 'rendering/pages');
+      await page.waitForSelector('[data-testid="pages"]');
+
+      const items = await page.$$('[data-part="item"]');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        href: el.getAttribute('href'),
+        tagName: el.tagName,
+        type: el.getAttribute('type'),
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+
+      rendered.forEach(({ href, tagName, type }) => {
+        expect(tagName).toBe('BUTTON');
+        expect(type).toBe('button');
+        expect(href).toBeNull();
+      });
+    });
+
+    it('should mark the active page link with aria-current', async() => {
+      await gotoStory(page, 'rendering/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const current = await page.$$('[data-part="item"][aria-current="page"]');
+
+      expect(current.length).toBe(1);
+      expect(await current[0].evaluate((el: Element) => el.textContent)).toBe('1');
+    });
+
+    it('should render the previous trigger as an inert link on the first page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const trigger = await page.waitForSelector('[data-part="prev-trigger"]');
+
+      expect(await trigger?.evaluate((el: Element) => el.tagName)).toBe('A');
+      expect(await trigger?.evaluate((el: Element) => el.hasAttribute('href'))).toBe(false);
+      expect(await trigger?.evaluate((el: Element) => el.getAttribute('aria-disabled'))).toBe('true');
+      expect(await trigger?.evaluate((el: Element) => el.getAttribute('tabindex'))).toBe('-1');
+    });
+
+    it('should render the next trigger as a link to the next page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+
+      expect(await trigger?.evaluate((el: Element) => el.tagName)).toBe('A');
+      expect(await trigger?.evaluate((el: Element) => el.getAttribute('href'))).toBe('#page-2-size-10');
+      expect(await trigger?.evaluate((el: Element) => el.getAttribute('aria-disabled'))).toBeNull();
+    });
+
+    it('should strip the href of every page link when the pagination is disabled', async() => {
+      await gotoStory(page, 'rendering/link-disabled');
+      await page.waitForSelector('[data-testid="link-disabled"]');
+
+      const items = await page.$$('[data-part="item"]');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        hasHref: el.hasAttribute('href'),
+        tabIndex: el.getAttribute('tabindex'),
+        tagName: el.tagName,
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+
+      rendered.forEach(({ ariaDisabled, hasHref, tabIndex, tagName }) => {
+        expect(tagName).toBe('A');
+        expect(hasHref).toBe(false);
+        expect(ariaDisabled).toBe('true');
+        expect(tabIndex).toBe('-1');
+      });
+    });
+
+    it('should keep the ellipsis a disabled button, as it is not a page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const ellipsis = await page.waitForSelector('[data-part="ellipsis"]');
+
+      expect(await ellipsis?.evaluate((el: Element) => el.tagName)).toBe('BUTTON');
+      expect(await ellipsis?.evaluate((el: Element) => el.hasAttribute('disabled'))).toBe(true);
+      expect(await ellipsis?.evaluate((el: Element) => el.hasAttribute('href'))).toBe(false);
+    });
+  });
+
   describe('custom style', () => {
     it('should render with custom style applied', async() => {
       await gotoStory(page, 'rendering/custom-style');

--- a/packages/ods-react/src/components/pagination/tests/rendering/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/rendering/pagination.stories.tsx
@@ -1,15 +1,46 @@
-import { Pagination } from '../../src';
+import { Pagination, PaginationPages, type PaginationPageUrlDetail } from '../../src';
 
 export default {
   component: Pagination,
   title: 'Tests rendering',
 };
 
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `#page-${page}-size-${pageSize}`;
+}
+
 export const customStyle = () => (
   <Pagination
     totalItems={20}
     data-testid="custom-style"
     style={{ height: '42px' }} />
+);
+
+export const link = () => (
+  <Pagination
+    data-testid="link"
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const linkDisabled = () => (
+  <Pagination
+    data-testid="link-disabled"
+    disabled
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const pages = () => (
+  <Pagination
+    data-testid="pages"
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
 );
 
 export const render = () => (

--- a/packages/storybook/stories/components/pagination/documentation.mdx
+++ b/packages/storybook/stories/components/pagination/documentation.mdx
@@ -116,31 +116,35 @@ Allows users to directly select a page from an number input.
 
 <Heading label="Page links" level={ 3 } />
 
-By default each page is a Button: activating one changes the page in place, and the pages exist only in
-the current session. Passing `getPageUrl` turns every page, along with the previous and next triggers,
-into a real link. It receives the target page and the current page size, and returns the address of that
-page: given `{ page: 2, pageSize: 10 }` a blog listing would return `/blog?page=2&size=10`.
+By default every page is a **Button** that changes the page in place. Passing `getPageUrl` renders the pages
+as real links instead, so each page gets its own address: one a search engine can crawl, and one a user can
+open in a new tab, bookmark or reload.
 
-Each page then has an address that can be crawled by a search engine, opened in a new tab, bookmarked and
-restored on reload, which is what a public listing needs. The page size is part of the URL as well, so a
+`getPageUrl` is called for every page and for the previous and next triggers. It receives the page to link
+to and the current page size, and returns the address of that page - for a blog listing,
+`{ page: 2, pageSize: 10 }` becomes `/blog?page=2&size=10`. The page size travels in the URL as well, so a
 listing that also exposes a page size selector stays consistent.
 
-In link mode the URL holds the page, and the component only renders it: it does not move on its own when a
-link is activated. Read the page back from the URL - the query string on a server rendered listing, the
-router or the hash in a single page application - and pass it as `page`. Do **not** set `page` from
-`onPageChange` in link mode: React flushes a click synchronously, so a page change made during the click
-rewrites the previous / next `href` before the browser follows it, and the user lands one page too far.
-`onPageChange` still fires, so it remains useful to trigger the routing itself.
-
-The ellipsis is not a page, so it stays a disabled Button with no address. At the boundaries there is no
-page to link to either: on the first page the previous trigger carries no `href` at all, and neither does
-the next trigger on the last page.
-
-Only the pages and the previous / next triggers become links. The go-to-page form and the page size
-selector still change the state in place and report it through `onPageChange` and `onPageSizeChange`; a
-listing that pages through the URL has to act on those callbacks itself.
-
 <Canvas of={ PaginationStories.Links } sourceState="shown" />
+
+**In link mode the URL holds the active page.** The **Pagination** renders the page it is given and never
+moves on its own when a link is activated. Read the page back from wherever the navigation left it - the
+query string of a server rendered listing, the router or the hash of a single page application - and pass
+it as `page`, or as `defaultPage` when every request is rendered by the server. Without either, the
+**Pagination** stays on page 1 whatever the URL says.
+
+Do not set `page` from `onPageChange` in link mode. That callback runs during the click, and changing the
+page at that moment rewrites the previous and next `href` before the browser has followed it, sending the
+user one page too far. `onPageChange` does still fire, so use it to trigger the navigation, never to store
+the page.
+
+Not everything becomes a link:
+
+- the **ellipsis** is not a page, so it stays a disabled Button with no address;
+- the **previous** trigger on the first page and the **next** trigger on the last page have no page to
+  point at, so they carry no `href` and are marked `aria-disabled`;
+- the go-to-page form and the page size selector are not navigation, so they keep reporting through
+  `onPageChange` and `onPageSizeChange` for the listing to act on.
 
 <Heading label="Navigation" level={ 2 } />
 

--- a/packages/storybook/stories/components/pagination/documentation.mdx
+++ b/packages/storybook/stories/components/pagination/documentation.mdx
@@ -51,6 +51,7 @@ A **Pagination** component is used in two situations :
     '- Ensure Pagination is used when the total number of pages is known or predictable',
     '- Display a reasonable number of items per page (typically around 20–30) to balance readability and navigation',
     '- Use Next/Previous buttons and page numbers to help users track their position within the dataset',
+    '- Turn the pages into links (`getPageUrl`) when the listing is public and each page has its own URL',
   ]}
 />
 
@@ -113,6 +114,34 @@ Depending on the current page number and the amount of pages, here are the diffe
 
 Allows users to directly select a page from an number input.
 
+<Heading label="Page links" level={ 3 } />
+
+By default each page is a Button: activating one changes the page in place, and the pages exist only in
+the current session. Passing `getPageUrl` turns every page, along with the previous and next triggers,
+into a real link. It receives the target page and the current page size, and returns the address of that
+page: given `{ page: 2, pageSize: 10 }` a blog listing would return `/blog?page=2&size=10`.
+
+Each page then has an address that can be crawled by a search engine, opened in a new tab, bookmarked and
+restored on reload, which is what a public listing needs. The page size is part of the URL as well, so a
+listing that also exposes a page size selector stays consistent.
+
+In link mode the URL holds the page, and the component only renders it: it does not move on its own when a
+link is activated. Read the page back from the URL - the query string on a server rendered listing, the
+router or the hash in a single page application - and pass it as `page`. Do **not** set `page` from
+`onPageChange` in link mode: React flushes a click synchronously, so a page change made during the click
+rewrites the previous / next `href` before the browser follows it, and the user lands one page too far.
+`onPageChange` still fires, so it remains useful to trigger the routing itself.
+
+The ellipsis is not a page, so it stays a disabled Button with no address. At the boundaries there is no
+page to link to either: on the first page the previous trigger carries no `href` at all, and neither does
+the next trigger on the last page.
+
+Only the pages and the previous / next triggers become links. The go-to-page form and the page size
+selector still change the state in place and report it through `onPageChange` and `onPageSizeChange`; a
+listing that pages through the URL has to act on those callbacks itself.
+
+<Canvas of={ PaginationStories.Links } sourceState="shown" />
+
 <Heading label="Navigation" level={ 2 } />
 
 <Heading label="Focus Management" level={ 3 } />
@@ -121,7 +150,9 @@ When tabbing through the page, focus moves sequentially through all interactive 
 
 The current page Button is not interactive.
 
-Disabled navigation Buttons (e.g., “Previous” on the first page) are skipped in the tab order.
+Disabled navigation Buttons (e.g., “Previous” on the first page) are skipped in the tab order. Page links
+behave the same way: an inert previous or next trigger is marked `aria-disabled` and taken out of the tab
+order, since an anchor takes no `disabled` attribute.
 
 <Heading label="General Keyboard Shortcuts" level={ 3 } />
 

--- a/packages/storybook/stories/components/pagination/examples.mdx
+++ b/packages/storybook/stories/components/pagination/examples.mdx
@@ -25,6 +25,10 @@ import * as PaginationStories from './pagination.stories';
 
 <Canvas of={ PaginationStories.ItemsPerPage } sourceState="shown" />
 
+<Heading label="Page links" level={ 2 } />
+
+<Canvas of={ PaginationStories.Links } sourceState="shown" />
+
 <Heading label="Sibling count" level={ 2 } />
 
 <Canvas of={ PaginationStories.SiblingCount } sourceState="shown" />

--- a/packages/storybook/stories/components/pagination/pagination.stories.tsx
+++ b/packages/storybook/stories/components/pagination/pagination.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pagination, PaginationPageChangeDetail, PaginationPageSelector, PaginationPageSizeSelector, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
 import { excludeFromDemoControls } from '../../../src/helpers/controls';
 import { staticSourceRenderConfig } from '../../../src/helpers/source';
@@ -107,6 +107,45 @@ export const ItemsPerPage: Story = {
       <PaginationPages />
     </Pagination>
   ),
+};
+
+export const Links: Story = {
+  globals: {
+    imports: `import { Pagination, PaginationPages } from '@ovhcloud/ods-react';
+import { useEffect, useState } from 'react';`,
+  },
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: { ...staticSourceRenderConfig() },
+    },
+  },
+  render: ({}) => {
+    const [page, setPage] = useState(1);
+
+    // In link mode the URL holds the page: read it back rather than the onPageChange callback.
+    useEffect(() => {
+      function syncFromUrl(): void {
+        const match = window.location.hash.match(/^#page-(\d+)-size-\d+$/);
+
+        setPage(match ? Number(match[1]) : 1);
+      }
+
+      syncFromUrl();
+      window.addEventListener('hashchange', syncFromUrl);
+
+      return () => window.removeEventListener('hashchange', syncFromUrl);
+    }, []);
+
+    return (
+      <Pagination
+        getPageUrl={ ({ page: target, pageSize }) => `#page-${target}-size-${pageSize}` }
+        page={ page }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    );
+  },
 };
 
 export const Overview: Story = {


### PR DESCRIPTION
Stacked on the Button `as` PR. Please target that branch.

`getPageUrl` renders every page and the previous / next triggers as real anchors, so a public listing is crawlable, bookmarkable and openable in a new tab.

### Notes for review
- The vendor already implements link mode: zag exposes `type: 'link'` + `getPageUrl({ page, pageSize })` and Ark forwards both. This is typing and context plumbing, not a reimplementation. Keeping the vendor signature keeps `pageSize` in the URL, which a pagination with a page size selector needs.
- **In link mode the URL owns the page**, and that is a correctness requirement. The component no longer advances its own state on activation: React flushes a click synchronously, so a page change made during the click rewrote the trigger `href` before the browser followed it, and "next" on page 1 landed on page 3.
  Two e2e pin it, and they click for real: a synthetic `el.click()` is not flushed the same way and hides the bug entirely.
- A dev warning fires when `getPageUrl` arrives without `page` or `defaultPage`.
  It is at render time, not in an effect, so it also fires during SSR, which is where link mode is meant to be used.
- zag never marks a trigger disabled in link mode, it only drops the `href`, so Button's anchor contract supplies `aria-disabled` and the tab order at the boundaries and when the whole pagination is disabled.
- Unchanged on purpose, and documented: the ellipsis stays a disabled button, and the go-to-page form and page size selector still report through their callbacks rather than navigating.

### Tested
pagination e2e 14/14 (7 new rendering, 5 new navigation), `tsc -b` over ods-react, workspace `lint:ts`, typedoc.

Additive: minor, no MIGRATION entry.