### PR TITLE
feat(docs): responsive layout for the docs platform

### DIFF
--- a/packages/docs/src/demo/demoCanvas.css
+++ b/packages/docs/src/demo/demoCanvas.css
@@ -44,3 +44,20 @@
   border-radius: 0 !important;
   margin: 0 !important;
 }
+
+/* Narrow layout (≤1000px, cf. shell.css): the toolbar actions wrap under the
+   title instead of pushing the card wider than the viewport. */
+@media (max-width: 1000px) {
+  .canvas__toolbar {
+    flex-wrap: wrap;
+  }
+
+  .canvas__title {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .canvas__demo {
+    padding: 16px;
+  }
+}

--- a/packages/docs/src/doc/doc.css
+++ b/packages/docs/src/doc/doc.css
@@ -194,3 +194,24 @@
 body:not([data-theme="dark"]) [data-ods="code"] {
   border: 1px solid var(--ods-color-neutral-200);
 }
+
+/* ——— Narrow layout (≤1000px, keep in sync with shell.css / NARROW_QUERY) ———
+   Wide leaf content (props tables, code, tab strips) scrolls inside its own
+   box so the page itself never scrolls sideways. */
+@media (max-width: 1000px) {
+  .doc-layout [data-ods="table"] {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  [data-ods="tab-list"] {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  [class*="code-highlighter"] {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}

--- a/packages/docs/src/doc/ports/iconGallery/iconGallery.module.css
+++ b/packages/docs/src/doc/ports/iconGallery/iconGallery.module.css
@@ -7,6 +7,7 @@
 }
 
 .icon-gallery__search {
+  max-width: 100%;
   width: 250px;
 }
 

--- a/packages/docs/src/doc/tech/tech.css
+++ b/packages/docs/src/doc/tech/tech.css
@@ -91,3 +91,17 @@
   position: absolute;
   transition: all .12s ease;
 }
+
+/* Narrow layout (≤1000px, cf. shell.css): the anatomy panel stacks (tree above
+   the stage) and the stage scrolls horizontally when the demo is wider than
+   the viewport. */
+@media (max-width: 1000px) {
+  .anatomy {
+    grid-template-columns: 1fr;
+  }
+
+  .anatomy__stage {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}

--- a/packages/docs/src/sandbox/Sandbox.tsx
+++ b/packages/docs/src/sandbox/Sandbox.tsx
@@ -91,7 +91,8 @@ const Sandbox = ({ dark, initialCode, tokens }: { dark: boolean, initialCode?: s
   const [tsErrors, setTsErrors] = useState<number>(-1);
   const [resizing, setResizing] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
-  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>('horizontal');
+  // Side-by-side panes need width: narrow viewports start stacked instead.
+  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>(() => window.matchMedia('(max-width: 1000px)').matches ? 'vertical' : 'horizontal');
   const [shareUrl, setShareUrl] = useState('');
   const [shareOpen, setShareOpen] = useState(false);
   const docTheme = useDocTheme();

--- a/packages/docs/src/sandbox/sandbox.css
+++ b/packages/docs/src/sandbox/sandbox.css
@@ -126,3 +126,15 @@
   cursor: help;
   flex-shrink: 0;
 }
+
+/* Narrow layout (≤1000px, cf. shell.css): toolbar actions wrap instead of
+   overflowing; the pane split itself defaults to vertical (Sandbox.tsx). */
+@media (max-width: 1000px) {
+  .sandbox-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .sandbox-toolbar__actions {
+    flex-wrap: wrap;
+  }
+}

--- a/packages/docs/src/shell/Shell.tsx
+++ b/packages/docs/src/shell/Shell.tsx
@@ -1,6 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link as RouterLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { BADGE_COLOR, BADGE_SIZE, Badge } from '../../../ods-react/src/components/badge/src';
+import { BUTTON_COLOR, BUTTON_VARIANT, Button } from '../../../ods-react/src/components/button/src';
+import { DRAWER_POSITION, Drawer, DrawerBody, DrawerContent } from '../../../ods-react/src/components/drawer/src';
 import { ICON_NAME, Icon } from '../../../ods-react/src/components/icon/src';
 import { Kbd } from '../../../ods-react/src/components/kbd/src';
 import { Link } from '../../../ods-react/src/components/link/src';
@@ -15,6 +17,21 @@ import './shell.css';
 interface ShellContext {
   tokens: Record<string, string>;
 }
+
+/* Single source of truth for the narrow layout; shell.css uses the same value.
+   Below it the sidebar becomes a drawer opened from the topbar. */
+const NARROW_QUERY = '(max-width: 1000px)';
+
+const useNarrow = () => {
+  const [narrow, setNarrow] = useState(() => window.matchMedia(NARROW_QUERY).matches);
+  useEffect(() => {
+    const mq = window.matchMedia(NARROW_QUERY);
+    const onChange = () => setNarrow(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+  return narrow;
+};
 
 /* One sidebar tree. Selection is bound to the active page id; a tree that
    doesn't contain it simply shows nothing selected. */
@@ -57,10 +74,53 @@ const NavTree = ({ currentId, expanded, nodes, onNavigate }: {
   );
 };
 
+/* The whole sidebar content: rendered in the fixed aside on wide screens and
+   inside the navigation drawer on narrow ones. */
+const SidebarPanels = ({ currentId, onNavigate, onSearch }: {
+  currentId?: string;
+  onNavigate: (id: string) => void;
+  onSearch: () => void;
+}) => (
+  <>
+    <RouterLink aria-label="OVHcloud Design System — home" className="shell__brand" to="/">
+      <BrandLogo />
+    </RouterLink>
+
+    <div className="shell__sidebar-selects">
+      <ThemeSelect />
+      <VersionSelect />
+    </div>
+
+    <button className="shell__search-hint" onClick={ onSearch } type="button">
+      <Icon name={ ICON_NAME.magnifyingGlass } /> Search… <span className="shell__search-kbds"><Kbd>cmd</Kbd><span className="shell__search-plus">+</span><Kbd>k</Kbd></span>
+    </button>
+
+    <nav aria-label="Documentation" className="shell__nav">
+      <NavTree currentId={ currentId } expanded={ ['tools'] } nodes={ GUIDES_NAV } onNavigate={ onNavigate } />
+      <div className="shell__tree-divider">
+        <Text preset={ TEXT_PRESET.caption }>Reference</Text>
+      </div>
+      <NavTree currentId={ currentId } expanded={ ['components', 'recipes', 'helpers'] } nodes={ REFERENCE_NAV } onNavigate={ onNavigate } />
+    </nav>
+
+    <div className="shell__sidebar-footer">
+      <Link aria-label="GitHub repository" className="shell__github" href="https://github.com/ovh/design-system" rel="noreferrer" target="_blank">
+        <Icon name={ ICON_NAME.github } /> GitHub
+      </Link>
+    </div>
+  </>
+);
+
+const openSearchPalette = () => {
+  document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'k', metaKey: true }));
+};
+
 const Shell = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const pages = flattenPages();
+  const isNarrow = useNarrow();
+  const [navOpen, setNavOpen] = useState(false);
 
   /* The sandbox chunk (Monaco + the ODS type graph, ~9 MB) is fetched during
      browser idle time so opening the tab is instant instead of a cold load. */
@@ -84,52 +144,68 @@ const Shell = () => {
     document.title = currentPage ? `${currentPage.title} — OVHcloud Design System` : 'OVHcloud Design System';
   }, [currentPage]);
 
+  // Any navigation (tree, palette, in-content link) closes the nav drawer.
+  useEffect(() => {
+    setNavOpen(false);
+  }, [location.pathname]);
+
+  const onNavigate = (id: string) => {
+    const page = pages.find((p) => p.id === id);
+    if (page) {
+      navigate(page.path);
+    }
+  };
+
+  const onSearch = () => {
+    setNavOpen(false);
+    openSearchPalette();
+  };
+
   return (
     <div className="shell">
       <a className="shell__skip" href="#main-content">Skip to content</a>
       <SearchCommand />
 
-      <aside className="shell__sidebar">
-        <RouterLink aria-label="OVHcloud Design System — home" className="shell__brand" to="/">
-          <BrandLogo />
-        </RouterLink>
+      { !isNarrow && (
+        <aside className="shell__sidebar">
+          <SidebarPanels currentId={ currentPage?.id } onNavigate={ onNavigate } onSearch={ openSearchPalette } />
+        </aside>
+      ) }
 
-        <div className="shell__sidebar-selects">
-          <ThemeSelect />
-          <VersionSelect />
-        </div>
-
-        <button className="shell__search-hint" onClick={ () => document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'k', metaKey: true })) } type="button">
-          <Icon name={ ICON_NAME.magnifyingGlass } /> Search… <span className="shell__search-kbds"><Kbd>cmd</Kbd><span className="shell__search-plus">+</span><Kbd>k</Kbd></span>
-        </button>
-
-        { (() => {
-          const onNavigate = (id: string) => {
-            const page = pages.find((p) => p.id === id);
-            if (page) {
-              navigate(page.path);
-            }
-          };
-          return (
-            <nav aria-label="Documentation" className="shell__nav">
-              <NavTree currentId={ currentPage?.id } expanded={ ['tools'] } nodes={ GUIDES_NAV } onNavigate={ onNavigate } />
-              <div className="shell__tree-divider">
-                <Text preset={ TEXT_PRESET.caption }>Reference</Text>
-              </div>
-              <NavTree currentId={ currentPage?.id } expanded={ ['components', 'recipes', 'helpers'] } nodes={ REFERENCE_NAV } onNavigate={ onNavigate } />
-            </nav>
-          );
-        })() }
-
-        <div className="shell__sidebar-footer">
-          <Link aria-label="GitHub repository" className="shell__github" href="https://github.com/ovh/design-system" rel="noreferrer" target="_blank">
-            <Icon name={ ICON_NAME.github } /> GitHub
-          </Link>
-        </div>
-      </aside>
+      { isNarrow && (
+        <Drawer
+          backdrop
+          closeOnInteractOutside
+          onOpenChange={ ({ open }) => setNavOpen(open) }
+          open={ navOpen }>
+          <DrawerContent aria-label="Documentation navigation" className="shell__drawer" position={ DRAWER_POSITION.left }>
+            <DrawerBody className="shell__drawer-body">
+              <Button
+                aria-label="Close navigation"
+                className="shell__drawer-close"
+                color={ BUTTON_COLOR.neutral }
+                onClick={ () => setNavOpen(false) }
+                variant={ BUTTON_VARIANT.ghost }>
+                <Icon name={ ICON_NAME.xmark } />
+              </Button>
+              <SidebarPanels currentId={ currentPage?.id } onNavigate={ onNavigate } onSearch={ onSearch } />
+            </DrawerBody>
+          </DrawerContent>
+        </Drawer>
+      ) }
 
       <div className="shell__main">
         <header className="shell__topbar">
+          { isNarrow && (
+            <Button
+              aria-label="Open navigation"
+              className="shell__menu-button"
+              color={ BUTTON_COLOR.neutral }
+              onClick={ () => setNavOpen(true) }
+              variant={ BUTTON_VARIANT.ghost }>
+              <Icon name={ ICON_NAME.hamburgerMenu } />
+            </Button>
+          ) }
           <Text as="h1" preset={ TEXT_PRESET.heading4 }>{ currentPage?.title ?? 'OVHcloud Design System' }</Text>
         </header>
 

--- a/packages/docs/src/shell/shell.css
+++ b/packages/docs/src/shell/shell.css
@@ -291,6 +291,52 @@ body {
   --ods-theme-anchor-text-color-visited: var(--ods-color-primary-700);
 }
 
+/* ——— Narrow layout (keep in sync with NARROW_QUERY in Shell.tsx) ———
+   The sidebar column disappears (Shell.tsx swaps it for a navigation drawer
+   opened from the topbar) and the content column takes the full width. */
+@media (max-width: 1000px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .shell__topbar {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  /* The page title can be long (component names, guide titles): let it
+     shrink and ellipsize instead of pushing the topbar wide. */
+  .shell__topbar h1 {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .shell__content {
+    padding: 16px;
+  }
+}
+
+/* Navigation drawer (narrow layout): same content as the sidebar. */
+.shell__drawer {
+  width: min(320px, 88vw);
+}
+
+.shell__drawer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.shell__drawer-close {
+  align-self: flex-end;
+  margin-bottom: -8px;
+}
+
 .shell__error {
   align-items: center;
   display: flex;

--- a/packages/docs/src/themeGenerator/ThemeGenerator.tsx
+++ b/packages/docs/src/themeGenerator/ThemeGenerator.tsx
@@ -19,7 +19,8 @@ import styles from './themeGenerator.module.css';
 
 const ThemeGenerator = (): JSX.Element => {
   const [fullscreen, setFullscreen] = useState(false);
-  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>('horizontal');
+  // Side-by-side panes need width: narrow viewports start stacked instead.
+  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>(() => window.matchMedia('(max-width: 1000px)').matches ? 'vertical' : 'horizontal');
   const [selectedTheme, setSelectedTheme] = useState('default');
   const [editedVariables, setEditedVariables] = useState<Record<string, string>>({});
   const [debouncedVariables, setDebouncedVariables] = useState<Record<string, string>>({});

--- a/packages/docs/src/themeGenerator/themeGenerator.module.css
+++ b/packages/docs/src/themeGenerator/themeGenerator.module.css
@@ -51,3 +51,16 @@
   height: 4px;
   min-height: auto;
 }
+
+/* Narrow layout (≤1000px, cf. shell.css): the menu rows wrap instead of
+   overflowing; the pane split defaults to vertical (ThemeGenerator.tsx). */
+@media (max-width: 1000px) {
+  .theme-generator__menu {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .theme-generator__menu__side {
+    flex-wrap: wrap;
+  }
+}

--- a/packages/docs/tests/drawer-check.mjs
+++ b/packages/docs/tests/drawer-check.mjs
@@ -1,0 +1,51 @@
+// Mobile nav drawer interaction check against the gh-pages sim.
+import { chromium } from 'playwright';
+import { serveSite } from './ghpages-server.mjs';
+import { setupSim } from './setup-sim.mjs';
+
+const PORT = Number(process.env.DOCS_TEST_PORT ?? 8126);
+const { simRoot, version } = setupSim();
+const server = await serveSite(simRoot, PORT);
+const base = `http://localhost:${PORT}/design-system/v${version}`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 375, height: 812 } });
+const errors = [];
+page.on('pageerror', (e) => errors.push(e.message));
+
+await page.goto(`${base}/components/button`, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('.shell__topbar', { timeout: 30000 });
+
+// 1. open the drawer
+await page.getByRole('button', { name: 'Open navigation' }).click();
+await page.waitForSelector('.shell__drawer [data-ods="tree-view"], .shell__drawer .shell__nav', { timeout: 5000 });
+const drawerVisible = await page.locator('.shell__drawer').isVisible();
+console.log(`drawer opens: ${drawerVisible}`);
+await page.screenshot({ path: process.argv[2] + '/mobile-drawer-open.png' });
+
+// 2. navigate from the tree
+await page.locator('.shell__drawer').getByText('Get Started', { exact: true }).click();
+await page.waitForURL('**/guides/get-started', { timeout: 10000 });
+await page.waitForTimeout(800);
+const drawerGone = !(await page.locator('.shell__drawer').isVisible().catch(() => false));
+console.log(`navigated to get-started: true`);
+console.log(`drawer closed after nav: ${drawerGone}`);
+
+// 3. close button works
+await page.getByRole('button', { name: 'Open navigation' }).click();
+await page.waitForTimeout(500);
+await page.getByRole('button', { name: 'Close navigation' }).click();
+await page.waitForTimeout(500);
+const closedByButton = !(await page.locator('.shell__drawer').isVisible().catch(() => false));
+console.log(`drawer closes via X: ${closedByButton}`);
+
+// 4. desktop unchanged: sidebar present, no hamburger
+const desktop = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+await desktop.goto(`${base}/components/button`, { waitUntil: 'domcontentloaded' });
+await desktop.waitForSelector('.shell__sidebar', { timeout: 30000 });
+const hamburgerHidden = (await desktop.getByRole('button', { name: 'Open navigation' }).count()) === 0;
+console.log(`desktop sidebar present, hamburger absent: ${hamburgerHidden}`);
+
+console.log(`pageerrors: ${errors.length}${errors.length ? ' — ' + errors[0].slice(0, 120) : ''}`);
+await browser.close();
+server.close();

--- a/packages/docs/tests/responsive-audit.mjs
+++ b/packages/docs/tests/responsive-audit.mjs
@@ -1,0 +1,83 @@
+// Responsive audit: screenshots + overflow/pageerror report for key pages at
+// mobile/tablet/desktop viewports, against the gh-pages sim of the current dist.
+// Usage: node tests/responsive-audit.mjs <outDir>
+import { chromium } from 'playwright';
+import { serveSite } from './ghpages-server.mjs';
+import { setupSim } from './setup-sim.mjs';
+import fs from 'node:fs';
+
+const OUT = process.argv[2] ?? 'responsive-audit';
+fs.mkdirSync(OUT, { recursive: true });
+
+const PORT = Number(process.env.DOCS_TEST_PORT ?? 8125);
+const { simRoot, version } = setupSim();
+const server = await serveSite(simRoot, PORT);
+const base = `http://localhost:${PORT}/design-system/v${version}`;
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 900 },
+];
+
+const PAGES = [
+  { name: 'home', path: '/' },
+  { name: 'component-doc', path: '/components/button' },
+  { name: 'component-examples', path: '/components/datepicker/examples' },
+  { name: 'component-technical', path: '/components/command/technical' },
+  { name: 'guide', path: '/guides/get-started' },
+  { name: 'gallery', path: '/components/icon/gallery' },
+  { name: 'sandbox', path: '/tools/sandbox' },
+  { name: 'themegen', path: '/tools/theme-generator' },
+];
+
+const browser = await chromium.launch();
+const report = [];
+
+for (const vp of VIEWPORTS) {
+  const ctx = await browser.newContext({ viewport: { width: vp.width, height: vp.height } });
+  for (const p of PAGES) {
+    const page = await ctx.newPage();
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    try {
+      await page.goto(`${base}${p.path}`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      await page.waitForSelector('.shell__content, .shell__error', { timeout: 30000 }).catch(() => {});
+      await page.waitForTimeout(2500);
+      // flush before capture (stale rasterization trap)
+      const metrics = await page.evaluate(() => {
+        const doc = document.documentElement;
+        const overflowers = [];
+        for (const el of document.querySelectorAll('body *')) {
+          const r = el.getBoundingClientRect();
+          if (r.right > window.innerWidth + 1 && r.width > 24) {
+            overflowers.push(`${el.tagName.toLowerCase()}.${String(el.className).split(' ')[0]}(${Math.round(r.right)})`);
+            if (overflowers.length >= 5) break;
+          }
+        }
+        return {
+          hScroll: doc.scrollWidth > window.innerWidth + 1,
+          scrollWidth: doc.scrollWidth,
+          innerWidth: window.innerWidth,
+          sidebarVisible: !!document.querySelector('.shell__sidebar') && getComputedStyle(document.querySelector('.shell__sidebar')).display !== 'none',
+          contentWidth: document.querySelector('.shell__content')?.getBoundingClientRect().width ?? 0,
+          overflowers,
+        };
+      });
+      await page.screenshot({ path: `${OUT}/${vp.name}-${p.name}.png` });
+      report.push({ vp: vp.name, page: p.name, ...metrics, errors: errors.slice(0, 3) });
+    } catch (e) {
+      report.push({ vp: vp.name, page: p.name, failed: String(e).slice(0, 120) });
+    }
+    await page.close();
+  }
+  await ctx.close();
+}
+
+await browser.close();
+server.close();
+fs.writeFileSync(`${OUT}/report.json`, JSON.stringify(report, null, 2));
+for (const r of report) {
+  const flag = r.failed ? 'FAIL' : r.hScroll ? 'H-SCROLL' : 'ok';
+  console.log(`${flag.padEnd(9)} ${r.vp.padEnd(8)} ${r.page.padEnd(20)} content=${Math.round(r.contentWidth ?? 0)} ${r.overflowers?.length ? 'overflow: ' + r.overflowers.join(' ') : ''} ${r.errors?.length ? 'ERR: ' + r.errors[0].slice(0, 60) : ''} ${r.failed ?? ''}`);
+}


### PR DESCRIPTION
## Summary

Makes the docs platform usable on mobile and tablet. One breakpoint (1000px, `NARROW_QUERY` in `Shell.tsx`, mirrored by the `@media` rules):

- **Navigation**: below the breakpoint the sidebar becomes an **ODS Drawer** opened from a topbar hamburger — same content (brand, theme/version selects, search, both nav trees, GitHub link). It closes on navigation, on the X button, on backdrop click and on Escape. Only one of aside/drawer is mounted at a time (matchMedia hook), so no duplicated DOM or landmarks.
- **Content containment**: wide leaf content scrolls inside its own box instead of pushing the page — props tables (`[data-ods="table"]`), tab strips (`[data-ods="tab-list"]`), shiki code blocks; demo-canvas toolbars wrap; the Technical tab anatomy stacks (tree above a scrollable stage); the icon-gallery search is width-bounded.
- **Tools**: Sandbox and Theme Generator start with a **vertical split** on narrow viewports; the existing Layout toggle still applies. Toolbars wrap.
- **Tests**: two reusable checks land in `packages/docs/tests/` — `responsive-audit.mjs` (screenshots + per-viewport overflow report over 8 page types) and `drawer-check.mjs` (drawer interactions). Note for future assertions: a closed ODS drawer stays in the DOM at `opacity:0`, so closure is asserted through `data-state`, not visibility.

The blue backdrop is the stock ODS overlay style (`--ods-theme-backdrop-background-color`), kept on purpose — the docs shell dogfoods ODS.

## Validation

- Before: at 375px the content column was **79px wide** (the 296px sidebar is hardcoded on master). After: zero page-level horizontal scroll at 375/768/1280 across home, component doc/examples/technical, guide, gallery, sandbox and theme generator; zero console errors.
- Drawer interactions verified headless (open, navigate-closes, X, backdrop).
- Desktop unchanged: sidebar present, no hamburger, docs harness (snippets, smoke, sweep, themegen, gallery) **all green**.
