### PR TITLE
Feat(pagination): allow usage of links

### DIFF
--- a/packages/docs/src/content/components/pagination/documentation.mdx
+++ b/packages/docs/src/content/components/pagination/documentation.mdx
@@ -34,6 +34,7 @@ A **Pagination** component is used in two situations :
     '- Ensure Pagination is used when the total number of pages is known or predictable',
     '- Display a reasonable number of items per page (typically around 20–30) to balance readability and navigation',
     '- Use Next/Previous buttons and page numbers to help users track their position within the dataset',
+    '- Turn the pages into links when each page has its own URL, so that they can be crawled, opened in a new tab and restored on reload',
   ]}
 />
 
@@ -48,6 +49,8 @@ A **Pagination** component is used in two situations :
 5. **Ellipsis**
 6. **Current page button**
 7. **Unselected page button**
+
+The anatomy above describes the default **Pagination**, whose pages are <DocLink to="/components/button">Buttons</DocLink>. When the pages are links, the same anatomy is rendered with the <DocLink to="/components/link">Link</DocLink> style instead, as described in "Pages as links" below.
 
 <Heading label="Placement" level={ 2 } />
 
@@ -96,6 +99,35 @@ Depending on the current page number and the amount of pages, here are the diffe
 
 Allows users to directly select a page from an number input.
 
+<Heading label="Pages as links" level={ 3 } />
+
+Where the **Pagination** is used to move between actual pages, each with an URL of its own, the pages must be links rather than Buttons.
+
+By default a page is a <DocLink to="/components/button">Button</DocLink>: activating it swaps the content in place, and nothing outside the component knows about it. That fits a paginated <DocLink to="/components/table">Table</DocLink> inside a single page, and nothing else.
+
+As soon as a page is a destination, provide `getPageUrl` and the pages become real links. They can then be crawled by a search engine, opened in a new tab, bookmarked and restored on reload, which is what an anonymous listing (a products list, a public catalogue, a documentation index) needs.
+
+Because those pages navigate, they are rendered with the <DocLink to="/components/link">Link</DocLink> style rather than the <DocLink to="/components/button">Button</DocLink> style: a button looks like a button, a link looks like a link.
+
+<Canvas story="LinksVsButtons" source="none" />
+
+What changes in link mode:
+- Every page the user can go to is a <DocLink to="/components/link">Link</DocLink> carrying an `href`
+- The active page is not a link, as there is nowhere to navigate to: it stays plain, emphasised text carrying <ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current">aria-current="page"</ExternalLink>
+- The previous and next triggers are icon links. On the first and the last page they carry no `href`, are marked `aria-disabled` and leave the tab order
+- The ellipsis is plain text, as it is a gap between two ranges of pages and not a page
+
+<Canvas story="Links" />
+
+<Message color="information" dismissible={ false } style={{ width: '100%' }}>
+  <MessageIcon name="circle-info" />
+  <MessageBody>
+    In link mode the URL holds the active page, so the component does not move on its own: pass the page read back from the URL as `page`, or as `defaultPage` when the page is rendered by the server.
+
+    The parts that are not links keep reporting through `onPageChange` and `onPageSizeChange`: the "Go to page" form submits, and the "items per page" select changes the size. Navigate to the matching URL from those callbacks.
+  </MessageBody>
+</Message>
+
 <Heading label="Navigation" level={ 2 } />
 
 <Heading label="Focus Management" level={ 3 } />
@@ -106,6 +138,8 @@ The current page Button is not interactive.
 
 Disabled navigation Buttons (e.g., “Previous” on the first page) are skipped in the tab order.
 
+When the pages are links, the same rules apply: the active page is plain text and the triggers that lead nowhere are skipped.
+
 <Heading label="General Keyboard Shortcuts" level={ 3 } />
 
 Pressing <Kbd>Tab</Kbd> moves focus forward through all interactive elements in the **Pagination** (Select, Buttons).
@@ -114,11 +148,28 @@ Pressing <Kbd>Shift</Kbd> + <Kbd>Tab</Kbd> moves focus backward.
 
 Pressing <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> on a page button, "Previous", or "Next" triggers the corresponding page change.
 
+When the pages are links, <Kbd>Enter</Kbd> follows the link, as on any anchor; <Kbd>Space</Kbd> scrolls the page instead.
+
 The "items per page" Select uses the same keyboard shortcuts as the standard Select component.
 
 <Heading label="Accessibility" level={ 2 } />
 
 **Pagination** component should be properly identified, and correct labels must be implemented to ensure it is accessible to assistive technologies.
+
+<Heading label="Choosing between Buttons and links" level={ 3 } />
+
+The choice is not a matter of style: it tells assistive technologies what activating a page does, and it is announced as such.
+
+Use the default **Buttons** when the pages are internal to the page the user is already on: activating one swaps a portion of the content, the URL does not change, and the user stays where they are. A screen reader announces a button, and the user expects to remain on the page.
+
+Use **links**, through `getPageUrl`, when a page is a destination of its own: activating one leaves the current document for another URL. A screen reader announces a link, and the user expects to be taken elsewhere. Rendering that as a Button would announce the wrong thing, and it would also deny the behaviours users expect from a link: opening in a new tab, copying the address, going back.
+
+<Message color="warning" dismissible={ false } style={{ width: '100%' }}>
+  <MessageIcon name="triangle-exclamation" />
+  <MessageBody>
+    A page that navigates must never be a Button, and a page that only swaps content must never be a link. Announcing the wrong role sends the user somewhere they did not expect, or keeps them from getting where they wanted.
+  </MessageBody>
+</Message>
 
 <Heading label="Identifying the Pagination with aria-label" level={ 3 } />
 

--- a/packages/docs/src/content/components/pagination/documentation.mdx
+++ b/packages/docs/src/content/components/pagination/documentation.mdx
@@ -106,7 +106,7 @@ Allows users to directly select a page from an number input.
 
 Where the **Pagination** is used to move between actual pages, each with an URL of its own, the pages must be links rather than Buttons.
 
-By default a page is a <DocLink to="/components/button">Button</DocLink>: activating it swaps the content in place, and nothing outside the component knows about it. That fits a paginated <DocLink to="/components/table">Table</DocLink> inside a single page, and nothing else.
+By default a page is a <DocLink to="/components/button">Button</DocLink>: activating it swaps the content in place, and nothing outside the component knows about it. That fits for example a paginated <DocLink to="/components/table">Table</DocLink>.
 
 As soon as a page is a destination, provide `getPageUrl` and the pages become real links.
 
@@ -120,15 +120,25 @@ What changes in link mode:
 
 <Heading label="Wiring link mode" level={ 4 } />
 
-In link mode the URL holds the active page. Following a link changes the URL, and the component renders whatever the URL says: read the page back from it and pass it as `page`.
+In link mode the URL holds the state of the **Pagination**, the active page and the number of items per page alike. Following a link changes the URL, and the component renders whatever the URL says: read both back from it and pass them as `page` and `pageSize`.
 
 <Canvas story="Links" />
 
 
 Two consequences follow from the URL being in charge:
 
-- **`onPageChange` does not fire when a link is followed.** The browser already did the work, and the new page is in the URL. It still fires for the controls that are not links, the "Go to page" form for one, which have no href to follow: navigate to the matching URL from there. The same goes for `onPageSizeChange`.
-- **Never derive `page` from a callback during a click.** There is nothing to derive it from any more, which is the point: were the component to move mid-click, it would rewrite the previous / next href before the browser followed it, and the user would land one page further than the link they clicked.
+- **`onPageChange` does not fire when a link is followed.** The browser already did the work, and the new page is in the URL. It still fires for the controls that are not links, which have no href to follow: navigate to the matching URL from there. The same goes for `onPageSizeChange`.
+-  **Never derive `page` from a callback during a click.** There is nothing to derive it from any more, which is the point: were the component to move mid-click, it would rewrite the previous / next href before the browser followed it, and the user would land one page further than the link they clicked.
+
+<Heading label="The controls that are not links" level={ 4 } />
+
+Two controls carry no destination and cannot navigate on their own: the "Go to page" form and the items per page <DocLink to="/components/select">Select</DocLink>. In link mode they report what the user asked for and wait, exactly as the pages do. The application turns that into an URL and navigates.
+
+<Canvas story="LinksWithAllControls" />
+
+The **Pagination** does not move meanwhile, and that is deliberate. Were the items per page **Select** to apply the new size on its own, it would rebuild every `href` around a size the URL does not have yet, and the active page would fall outside a range that just shrank: the bar would show pages that no longer exist while the list beside it had not changed.
+
+Changing the size almost always means going back to the first page, as the page the user was on rarely survives the new range. That call belongs to the application, which is the one building the URL.
 
 <Heading label="Handing navigation to a router" level={ 4 } />
 
@@ -137,8 +147,6 @@ Two consequences follow from the URL being in charge:
 A single page application does want more, as a full document load would throw its state away. Pass the link component of your routing library as `linkAs`, and the pages navigate inside the app instead. It receives the built URL as `href`, so `next/link` takes it as is, while React Router's `Link` wants it as `to`:
 
 <Canvas story="WithReactRouter" />
-
-The triggers that lead nowhere, "Previous" on the first page for one, stay plain anchors: they carry no destination to hand over.
 
 <Heading label="Navigation" level={ 2 } />
 

--- a/packages/docs/src/content/components/pagination/documentation.mdx
+++ b/packages/docs/src/content/components/pagination/documentation.mdx
@@ -1,4 +1,4 @@
-_A **Pagination** component allows users to navigate through large sets of data by dividing the content into multiple pages._
+_A **Pagination** component splits a long list into numbered pages and lets users move between them, whether a page is a portion of the current view or a destination with an URL of its own._
 
 <Canvas story="Overview" source="none" />
 
@@ -8,18 +8,18 @@ _A **Pagination** component allows users to navigate through large sets of data 
               figmaLink="https://www.figma.com/design/9jDDTcR4a9jPRFcdjawAlf/ODS---UI-Kit?node-id=47-7743"
               githubUrl="https://github.com/ovh/design-system/tree/master/packages/ods-react/src/components/pagination"
               name="Pagination">
-  The **Pagination** component is used to divide content into discrete pages and provide navigation controls to move between them.
+  The **Pagination** component divides a list into discrete pages and provides the controls to move between them, keeping a large set of items browsable without overwhelming the interface.
 
-  This component enhances usability by allowing users to browse through large sets of data without overwhelming the interface.
+  A page can be a portion of the current view, swapped in place without leaving the page, or a page of its own.
 
-  **Pagination** can include various controls like next/previous buttons and page numbers.
+  **Pagination** can include various controls like next/previous controls, page numbers, an items per page selector and a go-to-page input.
 </IdentityCard>
 
 <Heading label="Usage" level={ 2 } />
 
-A **Pagination** component is used in two situations :
-* To navigate among a <DocLink to="/components/table">Table</DocLink> component
-* To browse in a set of items (products list, ...)
+A **Pagination** component is used in two situations, and each one calls for a different kind of control :
+* To navigate among a <DocLink to="/components/table">Table</DocLink> component, or any content swapped inside the page the user is already on.
+* To browse a set of items spread over pages of their own, each with an URL (products list, public catalogue, documentation index, ...), see "Pages as links" below.
 
 <Heading label="Dos & Don'ts" level={ 3 } />
 
@@ -28,12 +28,13 @@ A **Pagination** component is used in two situations :
     '- Don\'t use Pagination when the total content fits into a single page',
     '- Avoid Pagination if the number of pages is unpredictable or constantly changing. In those cases, consider infinite scrolling or "Load more" patterns instead',
     '- Don\'t make Pagination the only method of navigation if users might need to filter or search within the dataset',
+    '- Don\'t render a page that navigates as a Button, nor a page that only swaps content as a link: the role is what assistive technologies announce',
   ]}
   dos={[
-    '- Use Pagination when users need to navigate through large datasets in a structured and orderly way',
+    '- Use Pagination when users need to move through a long list in a structured and orderly way',
     '- Ensure Pagination is used when the total number of pages is known or predictable',
-    '- Display a reasonable number of items per page (typically around 20–30) to balance readability and navigation',
-    '- Use Next/Previous buttons and page numbers to help users track their position within the dataset',
+    '- Display a reasonable number of items per page (typically around 20 to 30) to balance readability and navigation',
+    '- Use Next/Previous controls and page numbers to help users track their position in the list',
     '- Turn the pages into links when each page has its own URL, so that they can be crawled, opened in a new tab and restored on reload',
   ]}
 />
@@ -79,21 +80,23 @@ By default, 10 items per page are displayed, but it can be set to match your nee
 
 <Heading label="Amount of pages" level={ 3 } />
 
-A maximum of 6 numbered page <DocLink to="/components/button">Buttons</DocLink> can be visible at once, with a minimum of 1.
+A maximum of 6 numbered pages can be visible at once, with a minimum of 1.
 
-Arrow Buttons are always visible, no matter what the amount of pages.
+The previous and next controls are always visible, no matter what the amount of pages.
 
 Depending on the current page number and the amount of pages, here are the different displays of the whole component:
-- If amount of pages is less than 7, all numbered page <DocLink to="/components/button">Buttons</DocLink> can be visible at once
+- If amount of pages is less than 7, all numbered pages can be visible at once
 - If amount of pages is 7 or more :
-- If current page is the 4th one or less, the first 5 numbered <DocLink to="/components/button">Buttons</DocLink> are present, then an ellipsis and the last numbered <DocLink to="/components/button">Button</DocLink> corresponding of the amount of pages
-- If current page is the 4th to last or more, the first page <DocLink to="/components/button">Button</DocLink> is displayed followed by an ellipsis and the last 5 numbered <DocLink to="/components/button">Buttons</DocLink>
-- If current page is between the previous bounds are displayed, in order :
-- the first page <DocLink to="/components/button">Button</DocLink>,
+- If current page is the 4th one or less, the first 5 numbered pages are present, then an ellipsis and the last numbered page corresponding of the amount of pages
+- If current page is the 4th to last or more, the first page is displayed followed by an ellipsis and the last 5 numbered pages
+- If current page is between the previous bounds, are displayed, in order :
+- the first page,
 - an ellipsis,
-- 3 numbered <DocLink to="/components/button">Buttons</DocLink>, corresponding to : previous-to-current / current / next-to-current page,
+- 3 numbered pages, corresponding to : previous-to-current / current / next-to-current page,
 - an ellipsis,
-- the last numbered <DocLink to="/components/button">Button</DocLink>
+- the last numbered page
+
+Those counts hold whatever the pages are made of: they are rendered as <DocLink to="/components/button">Buttons</DocLink> or as <DocLink to="/components/link">Links</DocLink> depending on what activating one does, as described in "Pages as links" below.
 
 <Heading label="Go to page" level={ 3 } />
 
@@ -105,7 +108,7 @@ Where the **Pagination** is used to move between actual pages, each with an URL 
 
 By default a page is a <DocLink to="/components/button">Button</DocLink>: activating it swaps the content in place, and nothing outside the component knows about it. That fits a paginated <DocLink to="/components/table">Table</DocLink> inside a single page, and nothing else.
 
-As soon as a page is a destination, provide `getPageUrl` and the pages become real links. They can then be crawled by a search engine, opened in a new tab, bookmarked and restored on reload, which is what an anonymous listing (a products list, a public catalogue, a documentation index) needs.
+As soon as a page is a destination, provide `getPageUrl` and the pages become real links.
 
 Because those pages navigate, they are rendered with the <DocLink to="/components/link">Link</DocLink> style rather than the <DocLink to="/components/button">Button</DocLink> style: a button looks like a button, a link looks like a link.
 
@@ -114,19 +117,28 @@ Because those pages navigate, they are rendered with the <DocLink to="/component
 What changes in link mode:
 - Every page the user can go to is a <DocLink to="/components/link">Link</DocLink> carrying an `href`
 - The active page is not a link, as there is nowhere to navigate to: it stays plain, emphasised text carrying <ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current">aria-current="page"</ExternalLink>
-- The previous and next triggers are icon links. On the first and the last page they carry no `href`, are marked `aria-disabled` and leave the tab order
-- The ellipsis is plain text, as it is a gap between two ranges of pages and not a page
+
+<Heading label="Wiring link mode" level={ 4 } />
+
+In link mode the URL holds the active page. Following a link changes the URL, and the component renders whatever the URL says: read the page back from it and pass it as `page`.
 
 <Canvas story="Links" />
 
-<Message color="information" dismissible={ false } style={{ width: '100%' }}>
-  <MessageIcon name="circle-info" />
-  <MessageBody>
-    In link mode the URL holds the active page, so the component does not move on its own: pass the page read back from the URL as `page`, or as `defaultPage` when the page is rendered by the server.
 
-    The parts that are not links keep reporting through `onPageChange` and `onPageSizeChange`: the "Go to page" form submits, and the "items per page" select changes the size. Navigate to the matching URL from those callbacks.
-  </MessageBody>
-</Message>
+Two consequences follow from the URL being in charge:
+
+- **`onPageChange` does not fire when a link is followed.** The browser already did the work, and the new page is in the URL. It still fires for the controls that are not links, the "Go to page" form for one, which have no href to follow: navigate to the matching URL from there. The same goes for `onPageSizeChange`.
+- **Never derive `page` from a callback during a click.** There is nothing to derive it from any more, which is the point: were the component to move mid-click, it would rewrite the previous / next href before the browser followed it, and the user would land one page further than the link they clicked.
+
+<Heading label="Handing navigation to a router" level={ 4 } />
+
+`getPageUrl` is enough on its own: the pages are plain anchors, and following one loads the destination the way any link does. On a server rendered site that is all you need.
+
+A single page application does want more, as a full document load would throw its state away. Pass the link component of your routing library as `linkAs`, and the pages navigate inside the app instead. It receives the built URL as `href`, so `next/link` takes it as is, while React Router's `Link` wants it as `to`:
+
+<Canvas story="WithReactRouter" />
+
+The triggers that lead nowhere, "Previous" on the first page for one, stay plain anchors: they carry no destination to hand over.
 
 <Heading label="Navigation" level={ 2 } />
 
@@ -134,21 +146,19 @@ What changes in link mode:
 
 When tabbing through the page, focus moves sequentially through all interactive elements in the **Pagination** component.
 
-The current page Button is not interactive.
+The current page is not interactive, whether it is a Button or a link.
 
-Disabled navigation Buttons (e.g., “Previous” on the first page) are skipped in the tab order.
-
-When the pages are links, the same rules apply: the active page is plain text and the triggers that lead nowhere are skipped.
+Navigation controls that lead nowhere (e.g., “Previous” on the first page) are skipped in the tab order.
 
 <Heading label="General Keyboard Shortcuts" level={ 3 } />
 
-Pressing <Kbd>Tab</Kbd> moves focus forward through all interactive elements in the **Pagination** (Select, Buttons).
+Pressing <Kbd>Tab</Kbd> moves focus forward through all interactive elements in the **Pagination** (Select, page controls).
 
 Pressing <Kbd>Shift</Kbd> + <Kbd>Tab</Kbd> moves focus backward.
 
-Pressing <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> on a page button, "Previous", or "Next" triggers the corresponding page change.
+When the pages are Buttons, pressing <Kbd>Enter</Kbd> or <Kbd>Space</Kbd> on a page, "Previous", or "Next" triggers the corresponding page change.
 
-When the pages are links, <Kbd>Enter</Kbd> follows the link, as on any anchor; <Kbd>Space</Kbd> scrolls the page instead.
+When the pages are links, <Kbd>Enter</Kbd> follows the link, as on any anchor; <Kbd>Space</Kbd> scrolls the page instead. That difference comes from the elements themselves and is what users of either one expect.
 
 The "items per page" Select uses the same keyboard shortcuts as the standard Select component.
 

--- a/packages/docs/stories/components/pagination/pagination.stories.tsx
+++ b/packages/docs/stories/components/pagination/pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
-import { Pagination, PaginationPageChangeDetail, PaginationPageSelector, PaginationPageSizeSelector, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
+import { Pagination, PaginationPageChangeDetail, PaginationPageSelector, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
 import { excludeFromDemoControls } from '../../support/controls';
 import { staticSourceRenderConfig } from '../../support/source';
 
@@ -109,6 +109,59 @@ export const ItemsPerPage: Story = {
   ),
 };
 
+export const Links: Story = {
+  globals: {
+    imports: `import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { useState } from 'react';`,
+  },
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: { ...staticSourceRenderConfig() },
+    },
+  },
+  render: ({}) => {
+    const [page, setPage] = useState(1);
+
+    function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
+      return `#page-${page}-size-${pageSize}`;
+    }
+
+    return (
+      <Pagination
+        getPageUrl={ getPageUrl }
+        onPageChange={ ({ page }) => setPage(page) }
+        page={ page }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    );
+  },
+};
+
+export const LinksVsButtons: Story = {
+  globals: {
+    imports: `import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';`,
+  },
+  tags: ['!dev'],
+  render: ({}) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', alignItems: 'flex-start' }}>
+      <Pagination
+        defaultPage={ 4 }
+        getPageUrl={ ({ page }: PaginationPageUrlDetail) => `#page-${page}` }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+
+      <Pagination
+        defaultPage={ 4 }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    </div>
+  ),
+};
+
 export const Overview: Story = {
   tags: ['!dev'],
   parameters: {
@@ -154,16 +207,27 @@ export const SiblingCount: Story = {
 
 export const WithTooltipLabels: Story = {
   globals: {
-    imports: `import { Pagination, PaginationPages } from '@ovhcloud/ods-react';`,
+    imports: `import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';`,
   },
   tags: ['!dev'],
   render: ({}) => (
-    <Pagination
-      labelTooltipPrev="Go to previous page"
-      labelTooltipNext="Go to next page"
-      totalItems={ 500 }>
-      <PaginationPages />
-    </Pagination>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', alignItems: 'flex-start' }}>
+      <Pagination
+        labelTooltipPrev="Go to previous page"
+        labelTooltipNext="Go to next page"
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+
+      <Pagination
+        getPageUrl={ ({ page }: PaginationPageUrlDetail) => `#page-${page}` }
+        labelTooltipPrev="Go to previous page"
+        labelTooltipNext="Go to next page"
+        page={ 1 }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    </div>
   ),
 };
 

--- a/packages/docs/stories/components/pagination/pagination.stories.tsx
+++ b/packages/docs/stories/components/pagination/pagination.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import React, { type ComponentPropsWithRef, useState } from 'react';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
-import { Pagination, PaginationPageChangeDetail, PaginationPageSelector, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
+import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
+import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
 import { excludeFromDemoControls } from '../../support/controls';
 import { staticSourceRenderConfig } from '../../support/source';
 
@@ -122,8 +122,6 @@ import { useSearchParams } from 'react-router-dom';`,
     },
   },
   render: ({}) => {
-    // The page is read back from the URL, never from onPageChange: the links move the URL, and
-    // the component renders what the URL says.
     const [searchParams] = useSearchParams();
 
     function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
@@ -135,6 +133,7 @@ import { useSearchParams } from 'react-router-dom';`,
         aria-label="Products pagination"
         getPageUrl={ getPageUrl }
         page={ Number(searchParams.get('page') ?? 1) }
+        pageSize={ Number(searchParams.get('size') ?? 10) }
         totalItems={ 500 }>
         <PaginationPages />
       </Pagination>
@@ -161,7 +160,6 @@ import { Link as RouterLink, useSearchParams } from 'react-router-dom';`,
       return `?page=${page}&size=${pageSize}`;
     }
 
-    // The Pagination hands the built URL over as `href`; React Router's Link takes it as `to`.
     function PaginationLink({ href, ...props }: ComponentPropsWithRef<'a'>) {
       return (
         <RouterLink
@@ -178,6 +176,57 @@ import { Link as RouterLink, useSearchParams } from 'react-router-dom';`,
         page={ Number(searchParams.get('page') ?? 1) }
         totalItems={ 500 }>
         <PaginationPages />
+      </Pagination>
+    );
+  },
+};
+
+export const LinksWithAllControls: Story = {
+  globals: {
+    imports: `import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';`,
+  },
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: { ...staticSourceRenderConfig() },
+    },
+  },
+  render: ({}) => {
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const page = Number(searchParams.get('page') ?? 1);
+    const pageSize = Number(searchParams.get('size') ?? 10);
+
+    function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
+      return `?page=${page}&size=${pageSize}`;
+    }
+
+    // The pages are links and navigate on their own.
+    // The two controls below are not, and have no href for the browser to follow:
+    // they report the state they want, and the application navigates to the URL that describes it - the same URL getPageUrl builds for the links.
+    function handlePageChange({ page, pageSize }: PaginationPageChangeDetail) {
+      navigate(getPageUrl({ page, pageSize }));
+    }
+
+    function handlePageSizeChange({ pageSize }: PaginationPageSizeChangeDetail) {
+      navigate(getPageUrl({ page: 1, pageSize }));
+    }
+
+    return (
+      <Pagination
+        aria-label="Products pagination"
+        getPageUrl={ getPageUrl }
+        onPageChange={ handlePageChange }
+        onPageSizeChange={ handlePageSizeChange }
+        page={ page }
+        pageSize={ pageSize }
+        totalItems={ 500 }>
+        <PaginationPageSizeSelector />
+
+        <PaginationPages />
+
+        <PaginationPageSelector />
       </Pagination>
     );
   },

--- a/packages/docs/stories/components/pagination/pagination.stories.tsx
+++ b/packages/docs/stories/components/pagination/pagination.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
+import React, { type ComponentPropsWithRef, useState } from 'react';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Pagination, PaginationPageChangeDetail, PaginationPageSelector, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages, type PaginationProp } from '../../../../ods-react/src/components/pagination/src';
 import { excludeFromDemoControls } from '../../support/controls';
 import { staticSourceRenderConfig } from '../../support/source';
@@ -112,7 +113,7 @@ export const ItemsPerPage: Story = {
 export const Links: Story = {
   globals: {
     imports: `import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
-import { useState } from 'react';`,
+import { useSearchParams } from 'react-router-dom';`,
   },
   tags: ['!dev'],
   parameters: {
@@ -121,17 +122,60 @@ import { useState } from 'react';`,
     },
   },
   render: ({}) => {
-    const [page, setPage] = useState(1);
+    // The page is read back from the URL, never from onPageChange: the links move the URL, and
+    // the component renders what the URL says.
+    const [searchParams] = useSearchParams();
 
     function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
-      return `#page-${page}-size-${pageSize}`;
+      return `?page=${page}&size=${pageSize}`;
     }
 
     return (
       <Pagination
+        aria-label="Products pagination"
         getPageUrl={ getPageUrl }
-        onPageChange={ ({ page }) => setPage(page) }
-        page={ page }
+        page={ Number(searchParams.get('page') ?? 1) }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    );
+  },
+};
+
+export const WithReactRouter: Story = {
+  globals: {
+    imports: `import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { type ComponentPropsWithRef } from 'react';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';`,
+  },
+  tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: { ...staticSourceRenderConfig() },
+    },
+  },
+  render: ({}) => {
+    const [searchParams] = useSearchParams();
+
+    function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
+      return `?page=${page}&size=${pageSize}`;
+    }
+
+    // The Pagination hands the built URL over as `href`; React Router's Link takes it as `to`.
+    function PaginationLink({ href, ...props }: ComponentPropsWithRef<'a'>) {
+      return (
+        <RouterLink
+          to={ href ?? '' }
+          { ...props } />
+      );
+    }
+
+    return (
+      <Pagination
+        aria-label="Products pagination"
+        getPageUrl={ getPageUrl }
+        linkAs={ PaginationLink }
+        page={ Number(searchParams.get('page') ?? 1) }
         totalItems={ 500 }>
         <PaginationPages />
       </Pagination>
@@ -148,7 +192,7 @@ export const LinksVsButtons: Story = {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', alignItems: 'flex-start' }}>
       <Pagination
         defaultPage={ 4 }
-        getPageUrl={ ({ page }: PaginationPageUrlDetail) => `#page-${page}` }
+        getPageUrl={ ({ page, pageSize }: PaginationPageUrlDetail) => `?page=${page}&size=${pageSize}` }
         totalItems={ 500 }>
         <PaginationPages />
       </Pagination>
@@ -220,10 +264,10 @@ export const WithTooltipLabels: Story = {
       </Pagination>
 
       <Pagination
-        getPageUrl={ ({ page }: PaginationPageUrlDetail) => `#page-${page}` }
+        defaultPage={ 1 }
+        getPageUrl={ ({ page, pageSize }: PaginationPageUrlDetail) => `?page=${page}&size=${pageSize}` }
         labelTooltipPrev="Go to previous page"
         labelTooltipNext="Go to next page"
-        page={ 1 }
         totalItems={ 500 }>
         <PaginationPages />
       </Pagination>

--- a/packages/examples/nextjs-app/src/app/products/ProductPagination.tsx
+++ b/packages/examples/nextjs-app/src/app/products/ProductPagination.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
 import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
 import { type JSX } from 'react';
 
 interface ProductPaginationProp {
@@ -14,8 +15,25 @@ function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
 }
 
 /* The only client island of the page. `next/link` takes the built URL as `href`, which is the
-   prop the Pagination already hands over, so it goes in as is with no adapter. */
+   prop the Pagination already hands over, so it goes in as is with no adapter.
+
+   The page and the size come down from the server component, which read them off the query
+   string. Nothing is held in state here: the URL is the state. */
 export function ProductPagination({ page, pageSize, totalItems }: ProductPaginationProp): JSX.Element {
+  const router = useRouter();
+
+  /* The pages are links and navigate on their own. The two controls below are not, and have no
+     href for the browser to follow: they report, and the application pushes the URL they
+     describe - the same URL getPageUrl builds for the links. */
+  function handlePageChange({ page, pageSize }: PaginationPageChangeDetail): void {
+    router.push(getPageUrl({ page, pageSize }));
+  }
+
+  function handlePageSizeChange({ pageSize }: PaginationPageSizeChangeDetail): void {
+    // Back to the first page: the page the user was on rarely exists under the new size.
+    router.push(getPageUrl({ page: 1, pageSize }));
+  }
+
   return (
     <Pagination
       aria-label="Products pagination"
@@ -23,10 +41,16 @@ export function ProductPagination({ page, pageSize, totalItems }: ProductPaginat
       labelTooltipNext="Go to next page"
       labelTooltipPrev="Go to previous page"
       linkAs={ NextLink }
+      onPageChange={ handlePageChange }
+      onPageSizeChange={ handlePageSizeChange }
       page={ page }
       pageSize={ pageSize }
       totalItems={ totalItems }>
+      <PaginationPageSizeSelector />
+
       <PaginationPages />
+
+      <PaginationPageSelector />
     </Pagination>
   );
 }

--- a/packages/examples/nextjs-app/src/app/products/ProductPagination.tsx
+++ b/packages/examples/nextjs-app/src/app/products/ProductPagination.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import NextLink from 'next/link';
+import { type JSX } from 'react';
+
+interface ProductPaginationProp {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+}
+
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `/products?page=${page}&size=${pageSize}`;
+}
+
+/* The only client island of the page. `next/link` takes the built URL as `href`, which is the
+   prop the Pagination already hands over, so it goes in as is with no adapter. */
+export function ProductPagination({ page, pageSize, totalItems }: ProductPaginationProp): JSX.Element {
+  return (
+    <Pagination
+      aria-label="Products pagination"
+      getPageUrl={ getPageUrl }
+      labelTooltipNext="Go to next page"
+      labelTooltipPrev="Go to previous page"
+      linkAs={ NextLink }
+      page={ page }
+      pageSize={ pageSize }
+      totalItems={ totalItems }>
+      <PaginationPages />
+    </Pagination>
+  );
+}

--- a/packages/examples/nextjs-app/src/app/products/page.tsx
+++ b/packages/examples/nextjs-app/src/app/products/page.tsx
@@ -1,32 +1,34 @@
 import { type JSX } from 'react';
 import { ProductPagination } from './ProductPagination';
 
-const PAGE_SIZE = 10;
 const TOTAL_ITEMS = 200;
 
 interface ProductsPageProp {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string, size?: string }>;
 }
 
-/* A server component: the page number comes from the URL, the list is rendered on the server, and
-   the pagination ships its links in the initial HTML. Nothing here waits for JavaScript, which is
-   the whole point of the pages being links: a crawler sees every page of the listing. */
+/* A server component: the page number and the size come from the URL, the list is rendered on the
+   server, and the pagination ships its links in the initial HTML. Nothing here waits for
+   JavaScript, which is the whole point of the pages being links: a crawler sees every page of the
+   listing. */
 export default async function ProductsPage({ searchParams }: ProductsPageProp): Promise<JSX.Element> {
-  const { page: rawPage } = await searchParams;
+  const { page: rawPage, size: rawSize } = await searchParams;
   const page = Number(rawPage ?? 1);
-  const firstItem = (page - 1) * PAGE_SIZE + 1;
+  const pageSize = Number(rawSize ?? 10);
+  const firstItem = (page - 1) * pageSize + 1;
+  const lastItem = Math.min(firstItem + pageSize - 1, TOTAL_ITEMS);
 
   return (
     <main>
       <h1>Products</h1>
 
       <p>
-        Page { page } of { TOTAL_ITEMS / PAGE_SIZE }, rendered on the server.
+        Page { page } of { Math.ceil(TOTAL_ITEMS / pageSize) }, rendered on the server.
       </p>
 
       <ul>
         {
-          Array.from({ length: PAGE_SIZE }, (_, index) => (
+          Array.from({ length: lastItem - firstItem + 1 }, (_, index) => (
             <li key={ index }>Product { firstItem + index }</li>
           ))
         }
@@ -34,7 +36,7 @@ export default async function ProductsPage({ searchParams }: ProductsPageProp): 
 
       <ProductPagination
         page={ page }
-        pageSize={ PAGE_SIZE }
+        pageSize={ pageSize }
         totalItems={ TOTAL_ITEMS } />
     </main>
   );

--- a/packages/examples/nextjs-app/src/app/products/page.tsx
+++ b/packages/examples/nextjs-app/src/app/products/page.tsx
@@ -1,0 +1,41 @@
+import { type JSX } from 'react';
+import { ProductPagination } from './ProductPagination';
+
+const PAGE_SIZE = 10;
+const TOTAL_ITEMS = 200;
+
+interface ProductsPageProp {
+  searchParams: Promise<{ page?: string }>;
+}
+
+/* A server component: the page number comes from the URL, the list is rendered on the server, and
+   the pagination ships its links in the initial HTML. Nothing here waits for JavaScript, which is
+   the whole point of the pages being links: a crawler sees every page of the listing. */
+export default async function ProductsPage({ searchParams }: ProductsPageProp): Promise<JSX.Element> {
+  const { page: rawPage } = await searchParams;
+  const page = Number(rawPage ?? 1);
+  const firstItem = (page - 1) * PAGE_SIZE + 1;
+
+  return (
+    <main>
+      <h1>Products</h1>
+
+      <p>
+        Page { page } of { TOTAL_ITEMS / PAGE_SIZE }, rendered on the server.
+      </p>
+
+      <ul>
+        {
+          Array.from({ length: PAGE_SIZE }, (_, index) => (
+            <li key={ index }>Product { firstItem + index }</li>
+          ))
+        }
+      </ul>
+
+      <ProductPagination
+        page={ page }
+        pageSize={ PAGE_SIZE }
+        totalItems={ TOTAL_ITEMS } />
+    </main>
+  );
+}

--- a/packages/examples/react-router-app/src/app/App.tsx
+++ b/packages/examples/react-router-app/src/app/App.tsx
@@ -2,6 +2,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@ovhcloud/ods-react'
 import { type ReactElement } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { Link } from './components/link/Link';
+import { ProductList } from './components/pagination/ProductList';
 import style from './app.module.scss';
 
 const NB_PAGES = 4; // Change this to test the breadcrumb behaviour
@@ -38,8 +39,12 @@ function App(): ReactElement {
       <Link to="page1">Manual link to Page 1</Link>
       <br />
       <Link to="page2">Manual link to Page 2</Link>
+      <br />
+      <Link to="products?page=1&size=10">Paginated product list</Link>
 
       <Routes>
+        <Route element={ <ProductList /> } path="products" />
+
         {
           Pages.map((Page, idx) => (
             <Route

--- a/packages/examples/react-router-app/src/app/components/pagination/PaginationLink.tsx
+++ b/packages/examples/react-router-app/src/app/components/pagination/PaginationLink.tsx
@@ -1,0 +1,15 @@
+import { type ComponentPropsWithRef, type ReactElement } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+
+/* The Pagination builds the URL itself and hands it over as `href`; React Router's Link expects
+   it as `to`. Mapping one onto the other is all it takes for the pages to navigate inside the
+   app: a plain anchor would work too, but it would reload the whole document on every page. */
+function PaginationLink({ href, ...props }: ComponentPropsWithRef<'a'>): ReactElement {
+  return (
+    <RouterLink
+      to={ href ?? '' }
+      { ...props } />
+  );
+}
+
+export { PaginationLink };

--- a/packages/examples/react-router-app/src/app/components/pagination/ProductList.tsx
+++ b/packages/examples/react-router-app/src/app/components/pagination/ProductList.tsx
@@ -1,11 +1,14 @@
-import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
 import { type ReactElement, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PaginationLink } from './PaginationLink';
 import style from './productList.module.scss';
 
-const PAGE_SIZE = 10;
 const TOTAL_ITEMS = 200;
+
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `/products?page=${page}&size=${pageSize}`;
+}
 
 /* Counts how many times the module was evaluated. A client side navigation keeps the module
    alive, so this stays at 1; a full document load resets it. It is the plain way to see, in the
@@ -14,37 +17,48 @@ let moduleLoads = 0;
 
 function ProductList(): ReactElement {
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  // The whole state of the pagination is read back from the URL, nothing is held beside it.
   const page = Number(searchParams.get('page') ?? 1);
+  const pageSize = Number(searchParams.get('size') ?? 10);
 
   useEffect(() => {
     moduleLoads += 1;
   }, []);
 
-  function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
-    return `/products?page=${page}&size=${pageSize}`;
+  /* The pages are links, so they navigate on their own. The two controls below are not, and have
+     no href for the browser to follow: they report, and the application navigates to the URL
+     they describe - the same URL getPageUrl builds for the links. */
+  function handlePageChange({ page, pageSize }: PaginationPageChangeDetail): void {
+    navigate(getPageUrl({ page, pageSize }));
   }
 
-  const firstItem = (page - 1) * PAGE_SIZE + 1;
+  function handlePageSizeChange({ pageSize }: PaginationPageSizeChangeDetail): void {
+    // Back to the first page: the page the user was on rarely exists under the new size.
+    navigate(getPageUrl({ page: 1, pageSize }));
+  }
+
+  const firstItem = (page - 1) * pageSize + 1;
+  const lastItem = Math.min(firstItem + pageSize - 1, TOTAL_ITEMS);
 
   return (
     <div className={ style['product-list'] }>
       <h1>Products</h1>
 
       <p>
-        Page { page } of { TOTAL_ITEMS / PAGE_SIZE }, showing items { firstItem } to{ ' ' }
-        { firstItem + PAGE_SIZE - 1 }.
+        Page { page } of { Math.ceil(TOTAL_ITEMS / pageSize) }, showing items { firstItem } to{ ' ' }
+        { lastItem }.
       </p>
 
       <ul>
         {
-          Array.from({ length: PAGE_SIZE }, (_, index) => (
+          Array.from({ length: lastItem - firstItem + 1 }, (_, index) => (
             <li key={ index }>Product { firstItem + index }</li>
           ))
         }
       </ul>
 
-      {/* The page lives in the URL: it is read back from the query string, never held in state.
-          `linkAs` hands the navigation to React Router, so moving between pages does not reload
+      {/* `linkAs` hands the navigation to React Router, so moving between pages does not reload
           the document. Drop it and every page becomes a plain anchor: still correct, but a full
           page load each time. */}
       <Pagination
@@ -53,10 +67,16 @@ function ProductList(): ReactElement {
         labelTooltipNext="Go to next page"
         labelTooltipPrev="Go to previous page"
         linkAs={ PaginationLink }
+        onPageChange={ handlePageChange }
+        onPageSizeChange={ handlePageSizeChange }
         page={ page }
-        pageSize={ PAGE_SIZE }
+        pageSize={ pageSize }
         totalItems={ TOTAL_ITEMS }>
+        <PaginationPageSizeSelector />
+
         <PaginationPages />
+
+        <PaginationPageSelector />
       </Pagination>
 
       <p

--- a/packages/examples/react-router-app/src/app/components/pagination/ProductList.tsx
+++ b/packages/examples/react-router-app/src/app/components/pagination/ProductList.tsx
@@ -1,0 +1,73 @@
+import { Pagination, type PaginationPageUrlDetail, PaginationPages } from '@ovhcloud/ods-react';
+import { type ReactElement, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { PaginationLink } from './PaginationLink';
+import style from './productList.module.scss';
+
+const PAGE_SIZE = 10;
+const TOTAL_ITEMS = 200;
+
+/* Counts how many times the module was evaluated. A client side navigation keeps the module
+   alive, so this stays at 1; a full document load resets it. It is the plain way to see, in the
+   browser, whether the pagination navigates within the app or reloads it. */
+let moduleLoads = 0;
+
+function ProductList(): ReactElement {
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get('page') ?? 1);
+
+  useEffect(() => {
+    moduleLoads += 1;
+  }, []);
+
+  function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+    return `/products?page=${page}&size=${pageSize}`;
+  }
+
+  const firstItem = (page - 1) * PAGE_SIZE + 1;
+
+  return (
+    <div className={ style['product-list'] }>
+      <h1>Products</h1>
+
+      <p>
+        Page { page } of { TOTAL_ITEMS / PAGE_SIZE }, showing items { firstItem } to{ ' ' }
+        { firstItem + PAGE_SIZE - 1 }.
+      </p>
+
+      <ul>
+        {
+          Array.from({ length: PAGE_SIZE }, (_, index) => (
+            <li key={ index }>Product { firstItem + index }</li>
+          ))
+        }
+      </ul>
+
+      {/* The page lives in the URL: it is read back from the query string, never held in state.
+          `linkAs` hands the navigation to React Router, so moving between pages does not reload
+          the document. Drop it and every page becomes a plain anchor: still correct, but a full
+          page load each time. */}
+      <Pagination
+        aria-label="Products pagination"
+        getPageUrl={ getPageUrl }
+        labelTooltipNext="Go to next page"
+        labelTooltipPrev="Go to previous page"
+        linkAs={ PaginationLink }
+        page={ page }
+        pageSize={ PAGE_SIZE }
+        totalItems={ TOTAL_ITEMS }>
+        <PaginationPages />
+      </Pagination>
+
+      <p
+        className={ style['product-list__probe'] }
+        data-testid="probe">
+        Mounts since the document was loaded: <strong>{ moduleLoads + 1 }</strong>
+        { ' ' }-{ ' ' }
+        a client side navigation makes this grow, a full reload sends it back to 1.
+      </p>
+    </div>
+  );
+}
+
+export { ProductList };

--- a/packages/examples/react-router-app/src/app/components/pagination/productList.module.scss
+++ b/packages/examples/react-router-app/src/app/components/pagination/productList.module.scss
@@ -1,0 +1,13 @@
+.product-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+
+  &__probe {
+    border-left: 3px solid var(--ods-theme-primary-color);
+    padding-left: 8px;
+    color: var(--ods-theme-text-color);
+    font-size: 14px;
+  }
+}

--- a/packages/ods-react/src/components/pagination/src/components/pagination-button-with-tooltip/PaginationButtonWithTooltip.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-button-with-tooltip/PaginationButtonWithTooltip.tsx
@@ -1,5 +1,6 @@
 import { type FC, type JSX, type ReactNode } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../tooltip/src';
+import { usePagination } from '../../contexts/usePagination';
 
 interface PaginationButtonWithTooltipProp {
   children: ReactNode;
@@ -9,15 +10,28 @@ interface PaginationButtonWithTooltipProp {
 const PaginationButtonWithTooltip: FC<PaginationButtonWithTooltipProp> = ({
   children,
   tooltip,
-}): JSX.Element =>
-  tooltip ? (
+}): JSX.Element => {
+  const { getPageUrl } = usePagination();
+
+  if (!tooltip) {
+    return <>{ children }</>;
+  }
+
+  return (
     <Tooltip>
-      <TooltipTrigger asChild>{ children }</TooltipTrigger>
+      {/* TooltipTrigger carries role="button", which is right for the Button the trigger usually
+          is, and wrong for the anchor it becomes in link mode: it would announce a link as a
+          button, the very thing link mode exists to avoid. */}
+      <TooltipTrigger
+        asChild
+        role={ getPageUrl ? undefined : 'button' }>
+        { children }
+      </TooltipTrigger>
+
       <TooltipContent>{ tooltip }</TooltipContent>
     </Tooltip>
-  ) : (
-    <>{ children }</>
   );
+};
 
 export {
   PaginationButtonWithTooltip,

--- a/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
@@ -1,6 +1,9 @@
 import { Pagination as VendorPagination, usePaginationContext } from '@ark-ui/react/pagination';
-import { type FC, type JSX } from 'react';
+import classNames from 'classnames';
+import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
 import { BUTTON_VARIANT, Button } from '../../../../button/src';
+import { Link } from '../../../../link/src';
+import { usePagination } from '../../contexts/usePagination';
 import style from './paginationItem.module.scss';
 
 interface PaginationItemProp {
@@ -11,12 +14,66 @@ interface PaginationItemProp {
   };
 }
 
+/** @internal The anchor attributes Ark puts on an item in link mode, dropped by the active page. */
+type PaginationCurrentPageProp = ComponentPropsWithRef<'span'> & Pick<ComponentPropsWithRef<'a'>, 'href' | 'type'>;
+
+/**
+ * The active page in link mode. It keeps the identity Ark puts on the item - `aria-current`,
+ * `data-selected`, the label - but drops everything that would make it actionable: there is
+ * nowhere to navigate to, so it reads as plain, emphasised text rather than as a link.
+ * @internal
+ */
+const PaginationCurrentPage: FC<PaginationCurrentPageProp> = forwardRef(({
+  children,
+  className,
+  href,
+  onClick,
+  tabIndex,
+  type,
+  ...props
+}, ref): JSX.Element => (
+  <span
+    className={ classNames(style['pagination-item__current'], className) }
+    ref={ ref }
+    { ...props }>
+    { children }
+  </span>
+));
+
+PaginationCurrentPage.displayName = 'PaginationCurrentPage';
+
 const PaginationItem: FC<PaginationItemProp> = ({
   disabled,
   index,
   page,
 }): JSX.Element => {
   const { page: currentPage } = usePaginationContext();
+  const { getPageUrl } = usePagination();
+  const isCurrentPage = currentPage === page.value;
+
+  // Link mode. The item lives inside a plain box holding the rhythm of the bar, so that the link
+  // hugs its digits: its underline would otherwise run far wider than the page number.
+  if (getPageUrl) {
+    return (
+      <span className={ classNames(style['pagination-item'], style['pagination-item--link']) }>
+        <VendorPagination.Item
+          asChild
+          key={ index }
+          type="page"
+          { ...page }>
+          {
+            isCurrentPage
+              ? <PaginationCurrentPage>{ page.value }</PaginationCurrentPage>
+              : <Link
+                className={ style['pagination-item__link'] }
+                disabled={ disabled }>
+                { page.value }
+              </Link>
+          }
+        </VendorPagination.Item>
+      </span>
+    );
+  }
 
   return (
     <VendorPagination.Item
@@ -27,7 +84,7 @@ const PaginationItem: FC<PaginationItemProp> = ({
       { ...page }>
       <Button
         disabled={ disabled }
-        variant={ currentPage === page.value ? BUTTON_VARIANT.default : BUTTON_VARIANT.ghost }>
+        variant={ isCurrentPage ? BUTTON_VARIANT.default : BUTTON_VARIANT.ghost }>
         { page.value }
       </Button>
     </VendorPagination.Item>

--- a/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-item/PaginationItem.tsx
@@ -48,7 +48,7 @@ const PaginationItem: FC<PaginationItemProp> = ({
   page,
 }): JSX.Element => {
   const { page: currentPage } = usePaginationContext();
-  const { getPageUrl } = usePagination();
+  const { getPageUrl, linkAs } = usePagination();
   const isCurrentPage = currentPage === page.value;
 
   // Link mode. The item lives inside a plain box holding the rhythm of the bar, so that the link
@@ -65,6 +65,7 @@ const PaginationItem: FC<PaginationItemProp> = ({
             isCurrentPage
               ? <PaginationCurrentPage>{ page.value }</PaginationCurrentPage>
               : <Link
+                as={ linkAs }
                 className={ style['pagination-item__link'] }
                 disabled={ disabled }>
                 { page.value }

--- a/packages/ods-react/src/components/pagination/src/components/pagination-item/paginationItem.module.scss
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-item/paginationItem.module.scss
@@ -1,12 +1,64 @@
+@use '../../../../../style/link';
+
+// The rhythm of the whole bar, shared by the page buttons, the page links and the ellipsis.
+$ods-pagination-item-size: 40px;
+
 .pagination-item {
   display: flex;
   justify-content: center;
-  width: 40px;
+  width: $ods-pagination-item-size;
 
   &[data-selected] {
     &:not(:disabled) {
       border-color: var(--ods-theme-border-color-selected);
       background-color: var(--ods-theme-background-color-selected);
+    }
+  }
+
+  // Link mode: the item is only a box holding the rhythm of the bar, the link inside hugs its
+  // digits so that its underline never runs wider than the page number it belongs to.
+  &--link {
+    align-items: center;
+    width: auto;
+    min-width: $ods-pagination-item-size;
+    height: $ods-pagination-item-size;
+  }
+
+  // The link keeps hugging its digits, so that the Link underline stays the width of the page
+  // number. The target is carried by an invisible overlay instead, at the size of a page button:
+  // a pseudo element belongs to its anchor for hit testing, so the whole cell is clickable
+  // without the box, and therefore the underline, ever growing past the text.
+  &__link {
+    &::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 100%;
+      min-width: $ods-pagination-item-size;
+      height: $ods-pagination-item-size;
+      content: "";
+    }
+  }
+
+  // The active page is not a link: there is nowhere to navigate to. It reads as plain text and
+  // stays out of the tab order. It borrows the geometry of the Link underline, but permanent and
+  // twice as thick, so that "you are here" never reads as "hovered".
+  &__current {
+    display: inline-flex;
+    position: relative;
+    align-items: center;
+    color: var(--ods-theme-text-color);
+    font-weight: link.$ods-link-font-weight;
+
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      background-color: currentcolor;
+      width: 100%;
+      height: 2px;
+      content: "";
     }
   }
 }

--- a/packages/ods-react/src/components/pagination/src/components/pagination-page-selector/PaginationPageSelector.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-page-selector/PaginationPageSelector.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { type ComponentPropsWithRef, type FC, type FormEvent, type JSX, type ReactNode, forwardRef, useId } from 'react';
 import { BUTTON_SIZE, Button } from '../../../../button/src';
 import { INPUT_TYPE, Input } from '../../../../input/src';
+import { usePagination } from '../../contexts/usePagination';
 import style from './paginationPageSelector.module.scss';
 
 interface PaginationPageSelectorProp extends ComponentPropsWithRef<'form'> {
@@ -24,6 +25,7 @@ const PaginationPageSelector: FC<PaginationPageSelectorProp> = forwardRef(({
   submitLabel = 'Go',
   ...props
 }, ref): JSX.Element => {
+  const { getPageUrl, itemsPerPage, onPageChange } = usePagination();
   const { page, setPage, totalPages } = usePaginationContext();
   const textId = useId();
 
@@ -33,9 +35,20 @@ const PaginationPageSelector: FC<PaginationPageSelectorProp> = forwardRef(({
     const formData = new FormData(event.target as HTMLFormElement);
     const newPage = Number(formData.get(INPUT_NAME));
 
-    if (!isNaN(newPage) && newPage !== page) {
-      setPage(Math.max(Math.min(newPage, totalPages), 1));
+    if (isNaN(newPage) || newPage === page) {
+      return;
     }
+
+    const target = Math.max(Math.min(newPage, totalPages), 1);
+
+    // This form is not a link: in link mode it has no href for the browser to follow, so it is
+    // the one control that reports the wanted page and lets the application navigate to it.
+    if (getPageUrl) {
+      onPageChange?.({ page: target, pageSize: itemsPerPage });
+      return;
+    }
+
+    setPage(target);
   }
 
   return (

--- a/packages/ods-react/src/components/pagination/src/components/pagination-page-selector/PaginationPageSelector.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-page-selector/PaginationPageSelector.tsx
@@ -29,6 +29,12 @@ const PaginationPageSelector: FC<PaginationPageSelectorProp> = forwardRef(({
   const { page, setPage, totalPages } = usePaginationContext();
   const textId = useId();
 
+  // Warned at render time rather than in an effect, as link mode is meant for server rendered
+  // listings where an effect never runs.
+  if (getPageUrl && !onPageChange) {
+    console.warn('getPageUrl renders the pages as links, so the URL holds the active page. This form has no link to follow: please handle onPageChange and navigate to the matching URL, otherwise submitting a page does nothing.');
+  }
+
   function handleSubmit(event: FormEvent): void {
     event.preventDefault();
     event.stopPropagation();

--- a/packages/ods-react/src/components/pagination/src/components/pagination-page-size-selector/PaginationPageSizeSelector.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-page-size-selector/PaginationPageSizeSelector.tsx
@@ -20,8 +20,14 @@ const PaginationPageSizeSelector: FC<PaginationPageSizeSelectorProp> = forwardRe
   ...props
 }, ref): JSX.Element => {
   const { count: totalItems, pageSize } = usePaginationContext();
-  const { handlePageSizeChange } = usePagination();
+  const { getPageUrl, handlePageSizeChange, onPageSizeChange } = usePagination();
   const textId = useId();
+
+  // Warned at render time rather than in an effect, as link mode is meant for server rendered
+  // listings where an effect never runs.
+  if (getPageUrl && !onPageSizeChange) {
+    console.warn('getPageUrl renders the pages as links, so the URL holds the number of items per page. This selector has no link to follow: please handle onPageSizeChange and navigate to the matching URL, otherwise picking a size does nothing.');
+  }
 
   function handleValueChange(detail: SelectValueChangeDetail): void {
     if (detail.value[0]) {
@@ -36,9 +42,9 @@ const PaginationPageSizeSelector: FC<PaginationPageSizeSelectorProp> = forwardRe
       ref={ ref }
       { ...props }>
       <Select
-        defaultValue={ [pageSize.toString()] }
         items={ PAGINATION_PER_PAGE_OPTIONS as SelectItem[] }
-        onValueChange={ handleValueChange }>
+        onValueChange={ handleValueChange }
+        value={ [pageSize.toString()] }>
         <SelectControl aria-labelledby={ textId } />
         <SelectContent />
       </Select>

--- a/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
@@ -1,8 +1,9 @@
-import { Pagination as VendorPagination } from '@ark-ui/react/pagination';
+import { Pagination as VendorPagination, usePaginationContext } from '@ark-ui/react/pagination';
 import classNames from 'classnames';
-import { type ComponentPropsWithRef, type FC, type JSX, forwardRef } from 'react';
+import { type ComponentPropsWithRef, type FC, type JSX, type ReactNode, forwardRef } from 'react';
 import { BUTTON_VARIANT, Button } from '../../../../button/src';
 import { ICON_NAME, Icon } from '../../../../icon/src';
+import { Link } from '../../../../link/src';
 import { usePagination } from '../../contexts/usePagination';
 import { PaginationButtonWithTooltip } from '../pagination-button-with-tooltip/PaginationButtonWithTooltip';
 import { PaginationItem } from '../pagination-item/PaginationItem';
@@ -10,11 +11,29 @@ import style from './paginationPages.module.scss';
 
 interface PaginationPagesProp extends ComponentPropsWithRef<'div'> {}
 
+/**
+ * In link mode the trigger hugs its chevron, the way an icon only Link does, so that its
+ * underline is the width of the glyph. A cell then holds the slot of a page button around it.
+ * @internal
+ */
+const PaginationTriggerCell: FC<{ children: ReactNode, isLink: boolean }> = ({
+  children,
+  isLink,
+}): JSX.Element => isLink
+  ? <span className={ style['pagination-pages__cell'] }>{ children }</span>
+  : <>{ children }</>;
+
 const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
   className,
   ...props
 }, ref): JSX.Element => {
-  const { disabled, labelTooltipNext, labelTooltipPrev } = usePagination();
+  const { disabled, getPageUrl, labelTooltipNext, labelTooltipPrev } = usePagination();
+  const { nextPage, previousPage } = usePaginationContext();
+  const isLink = !!getPageUrl;
+  // In link mode zag drops the href at the boundaries but never marks the trigger disabled, as
+  // an anchor takes no `disabled` attribute. Link turns it into the `aria-disabled` contract.
+  const isPrevDisabled = isLink ? (disabled || !previousPage) : disabled;
+  const isNextDisabled = isLink ? (disabled || !nextPage) : disabled;
 
   return (
     <div
@@ -22,13 +41,23 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
       data-ods="pagination-pages"
       ref={ ref }
       { ...props }>
-      <PaginationButtonWithTooltip tooltip={ labelTooltipPrev }>
-        <VendorPagination.PrevTrigger asChild>
-          <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
-            <Icon name={ ICON_NAME.chevronLeft } />
-          </Button>
-        </VendorPagination.PrevTrigger>
-      </PaginationButtonWithTooltip>
+      <PaginationTriggerCell isLink={ isLink }>
+        <PaginationButtonWithTooltip tooltip={ labelTooltipPrev }>
+          <VendorPagination.PrevTrigger asChild>
+            {
+              isLink
+                ? <Link
+                  className={ style['pagination-pages__trigger'] }
+                  disabled={ isPrevDisabled }>
+                  <Icon name={ ICON_NAME.chevronLeft } />
+                </Link>
+                : <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
+                  <Icon name={ ICON_NAME.chevronLeft } />
+                </Button>
+            }
+          </VendorPagination.PrevTrigger>
+        </PaginationButtonWithTooltip>
+      </PaginationTriggerCell>
 
       <VendorPagination.Context>
         { (pagination) =>
@@ -40,24 +69,39 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
                 asChild
                 index={ index }
                 key={ index }>
-                <Button
-                  disabled
-                  variant={ BUTTON_VARIANT.ghost }>
-                  &#8230;
-                </Button>
+                {
+                  isLink
+                    // Not a page, so nothing to link to: a gap between two ranges of links.
+                    ? <span className={ style['pagination-pages__ellipsis'] }>&#8230;</span>
+                    : <Button
+                      disabled
+                      variant={ BUTTON_VARIANT.ghost }>
+                      &#8230;
+                    </Button>
+                }
               </VendorPagination.Ellipsis>
             ),
           )
         }
       </VendorPagination.Context>
 
-      <PaginationButtonWithTooltip tooltip={ labelTooltipNext }>
-        <VendorPagination.NextTrigger asChild>
-          <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
-            <Icon name={ ICON_NAME.chevronRight } />
-          </Button>
-        </VendorPagination.NextTrigger>
-      </PaginationButtonWithTooltip>
+      <PaginationTriggerCell isLink={ isLink }>
+        <PaginationButtonWithTooltip tooltip={ labelTooltipNext }>
+          <VendorPagination.NextTrigger asChild>
+            {
+              isLink
+                ? <Link
+                  className={ style['pagination-pages__trigger'] }
+                  disabled={ isNextDisabled }>
+                  <Icon name={ ICON_NAME.chevronRight } />
+                </Link>
+                : <Button disabled={ disabled } variant={ BUTTON_VARIANT.ghost }>
+                  <Icon name={ ICON_NAME.chevronRight } />
+                </Button>
+            }
+          </VendorPagination.NextTrigger>
+        </PaginationButtonWithTooltip>
+      </PaginationTriggerCell>
     </div>
   );
 });

--- a/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-pages/PaginationPages.tsx
@@ -27,13 +27,17 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
   className,
   ...props
 }, ref): JSX.Element => {
-  const { disabled, getPageUrl, labelTooltipNext, labelTooltipPrev } = usePagination();
+  const { disabled, getPageUrl, labelTooltipNext, labelTooltipPrev, linkAs } = usePagination();
   const { nextPage, previousPage } = usePaginationContext();
   const isLink = !!getPageUrl;
   // In link mode zag drops the href at the boundaries but never marks the trigger disabled, as
   // an anchor takes no `disabled` attribute. Link turns it into the `aria-disabled` contract.
   const isPrevDisabled = isLink ? (disabled || !previousPage) : disabled;
   const isNextDisabled = isLink ? (disabled || !nextPage) : disabled;
+  // A trigger that leads nowhere carries no href, so it is left a plain anchor: handing an
+  // undefined destination to a routing library is at best meaningless, and next/link throws on it.
+  const prevLinkAs = isPrevDisabled ? undefined : linkAs;
+  const nextLinkAs = isNextDisabled ? undefined : linkAs;
 
   return (
     <div
@@ -47,6 +51,7 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
             {
               isLink
                 ? <Link
+                  as={ prevLinkAs }
                   className={ style['pagination-pages__trigger'] }
                   disabled={ isPrevDisabled }>
                   <Icon name={ ICON_NAME.chevronLeft } />
@@ -71,7 +76,6 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
                 key={ index }>
                 {
                   isLink
-                    // Not a page, so nothing to link to: a gap between two ranges of links.
                     ? <span className={ style['pagination-pages__ellipsis'] }>&#8230;</span>
                     : <Button
                       disabled
@@ -91,6 +95,7 @@ const PaginationPages: FC<PaginationPagesProp> = forwardRef(({
             {
               isLink
                 ? <Link
+                  as={ nextLinkAs }
                   className={ style['pagination-pages__trigger'] }
                   disabled={ isNextDisabled }>
                   <Icon name={ ICON_NAME.chevronRight } />

--- a/packages/ods-react/src/components/pagination/src/components/pagination-pages/paginationPages.module.scss
+++ b/packages/ods-react/src/components/pagination/src/components/pagination-pages/paginationPages.module.scss
@@ -1,7 +1,46 @@
+// The rhythm of the whole bar, shared with the pagination items.
+$ods-pagination-trigger-size: 40px;
+
 @layer ods-molecules {
   .pagination-pages {
     display: flex;
     flex-direction: row;
     align-items: center;
+
+    // Link mode. The cell holds the slot of a page button, so that the trigger inside can hug
+    // its chevron: an icon only Link is underlined like any other, and that underline has to be
+    // the width of the glyph rather than of the slot around it.
+    &__cell {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: $ods-pagination-trigger-size;
+      height: $ods-pagination-trigger-size;
+    }
+
+    // The target, carried by an invisible overlay so that the box, and therefore the underline,
+    // never grows past the chevron. Same mechanism as a page, see paginationItem.module.scss.
+    &__trigger {
+      &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 100%;
+        min-width: $ods-pagination-trigger-size;
+        height: $ods-pagination-trigger-size;
+        content: "";
+      }
+    }
+
+    // Link mode. The ellipsis is a gap between two ranges of pages, not a page: plain muted text.
+    &__ellipsis {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: $ods-pagination-trigger-size;
+      height: $ods-pagination-trigger-size;
+      color: var(--ods-theme-text-color-disabled);
+    }
   }
 }

--- a/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
@@ -18,7 +18,7 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
   withPageSizeSelector,
   ...props
 }, ref): JSX.Element => {
-  const { currentPage, handlePageChange, itemsPerPage } = usePagination();
+  const { currentPage, getPageUrl, handlePageChange, itemsPerPage } = usePagination();
 
   useEffect(() => {
     if (!children) {
@@ -32,11 +32,13 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
       count={ totalItems }
       data-ods="pagination"
       defaultPage={ defaultPage }
+      getPageUrl={ getPageUrl }
       onPageChange={ handlePageChange }
       page={ currentPage }
       pageSize={ itemsPerPage }
       ref={ ref }
       siblingCount={ siblingCount }
+      type={ getPageUrl ? 'link' : 'button' }
       { ...props }>
       {/* [Deprecated] remove non children default render on next major release */}
       {
@@ -57,6 +59,7 @@ const PaginationRoot: FC<PaginationProp> = forwardRef(({
 const Pagination: FC<PaginationProp> = forwardRef(({
   defaultPage,
   disabled,
+  getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
   onPageChange,
@@ -70,6 +73,7 @@ const Pagination: FC<PaginationProp> = forwardRef(({
     <PaginationProvider
       defaultPage={ defaultPage }
       disabled={ disabled }
+      getPageUrl={ getPageUrl }
       labelTooltipNext={ labelTooltipNext }
       labelTooltipPrev={ labelTooltipPrev }
       onPageChange={ onPageChange }

--- a/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/components/pagination/Pagination.tsx
@@ -62,6 +62,7 @@ const Pagination: FC<PaginationProp> = forwardRef(({
   getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
+  linkAs,
   onPageChange,
   onPageSizeChange,
   page,
@@ -76,6 +77,7 @@ const Pagination: FC<PaginationProp> = forwardRef(({
       getPageUrl={ getPageUrl }
       labelTooltipNext={ labelTooltipNext }
       labelTooltipPrev={ labelTooltipPrev }
+      linkAs={ linkAs }
       onPageChange={ onPageChange }
       onPageSizeChange={ onPageSizeChange }
       page={ page }

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -17,6 +17,11 @@ interface PaginationPageSizeChangeDetail {
   pageSize: number,
 }
 
+interface PaginationPageUrlDetail {
+  page: number;
+  pageSize: number;
+}
+
 interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   /**
    * The initial active page. Use when you don't need to control the active page of the pagination.
@@ -26,6 +31,13 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
    * Whether the component is disabled.
    */
   disabled?: boolean;
+  /**
+   * Build the URL of a given page.
+   * Providing it turns the pages and the previous / next triggers into links, so that they can be
+   * crawled, opened in a new tab and restored on reload. They then look like the Link component,
+   * as they navigate, instead of the Button component.
+   */
+  getPageUrl?: (detail: PaginationPageUrlDetail) => string;
   /**
    * The tooltip label on the "next page" button.
    */
@@ -73,7 +85,7 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   withPageSizeSelector?: boolean;
 }
 
-interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'labelTooltipNext' | 'labelTooltipPrev' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
+interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'getPageUrl' | 'labelTooltipNext' | 'labelTooltipPrev' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
   children: ReactNode;
 }
 
@@ -90,6 +102,7 @@ function PaginationProvider({
   children,
   defaultPage,
   disabled,
+  getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
   onPageChange,
@@ -103,6 +116,12 @@ function PaginationProvider({
   const isControlled = page !== undefined;
   const currentPage = isControlled && page ? page : internalPage;
 
+  // Warned at render time, not in an effect: link mode exists for server rendered listings, and
+  // an effect never runs on the server - which is exactly where the mistake is made.
+  if (getPageUrl && page === undefined && defaultPage === undefined) {
+    console.warn('getPageUrl renders the pages as links, so the URL holds the active page. Please provide a controlled `page` read back from the URL, or a `defaultPage` when the page is rendered by the server, otherwise the pagination stays on page 1.');
+  }
+
   useEffect(() => {
     if (!isControlled) {
       setInternalPage(defaultPage ?? 1);
@@ -110,7 +129,10 @@ function PaginationProvider({
   }, [defaultPage, isControlled, itemsPerPage, totalItems]);
 
   function handlePageChange(detail: PaginationPageChangeDetail): void {
-    if (!isControlled) {
+    // In link mode the URL holds the page, so the component must not move on its own: React
+    // flushes a click synchronously, and a page change would rewrite the trigger href before
+    // the browser follows it, sending the user one page too far.
+    if (!isControlled && !getPageUrl) {
       setInternalPage(detail.page);
     }
     onPageChange?.(detail);
@@ -129,6 +151,7 @@ function PaginationProvider({
       currentPage,
       defaultPage,
       disabled,
+      getPageUrl,
       handlePageChange,
       handlePageSizeChange,
       itemsPerPage,
@@ -154,6 +177,7 @@ export {
   type PaginationContextType,
   type PaginationPageChangeDetail,
   type PaginationPageSizeChangeDetail,
+  type PaginationPageUrlDetail,
   PaginationProvider,
   type PaginationRootProp,
   type PaginationTotalItemsLabelRenderer,

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -68,6 +68,8 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   page?: number;
   /**
    * The number of items per page.
+   * Along `getPageUrl` it is read on every render rather than only on mount, as the URL is then
+   * what holds the size: the component renders it instead of keeping a size of its own.
    */
   pageSize?: number;
   /**
@@ -120,10 +122,14 @@ function PaginationProvider({
   pageSize = 10,
   totalItems,
 }: PaginationProviderProp): JSX.Element {
-  const [itemsPerPage, setItemsPerPage] = useState<number>(pageSize);
+  const [internalItemsPerPage, setInternalItemsPerPage] = useState<number>(pageSize);
   const [internalPage, setInternalPage] = useState<number>(defaultPage ?? 1);
   const isControlled = page !== undefined;
   const currentPage = isControlled && page ? page : internalPage;
+  // Link mode: the URL owns the page size the way it owns the page, so the component renders the
+  // prop rather than a size of its own. Holding it internally would rebuild every href with a
+  // size the URL does not have yet, and leave the active page outside the new range.
+  const itemsPerPage = getPageUrl ? pageSize : internalItemsPerPage;
 
   // Warned at render time, not in an effect: link mode exists for server rendered listings, and
   // an effect never runs on the server - which is exactly where the mistake is made.
@@ -158,7 +164,11 @@ function PaginationProvider({
   function handlePageSizeChange(value: string): void {
     const numericValue = Number(value);
 
-    setItemsPerPage(numericValue);
+    // Link mode: the size is reported and nothing else, on the same grounds as the page. The
+    // application navigates to the matching URL, and the new size comes back as a prop.
+    if (!getPageUrl) {
+      setInternalItemsPerPage(numericValue);
+    }
 
     onPageSizeChange?.({ pageSize: numericValue });
   }

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 
-import { type ComponentPropsWithRef, type JSX, type ReactNode, createContext, useEffect, useState } from 'react';
+import { type ComponentPropsWithRef, type ElementType, type JSX, type ReactNode, createContext, useEffect, useState } from 'react';
 import { useContext } from '../../../../utils/context';
 
 /** @internal DEPRECATED: remove on next major version */
@@ -47,6 +47,14 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
    */
   labelTooltipPrev?: string;
   /**
+   * \@default-value='a'
+   * Pass a component you may want to use to render the page links.
+   * Only used along `getPageUrl`. Useful to hand the navigation over to a routing library, which
+   * a plain anchor would bypass with a full page load: the component receives the built URL as
+   * `href` and maps it to whatever prop it expects.
+   */
+  linkAs?: ElementType;
+  /**
    * Callback fired when the active page changes.
    */
   onPageChange?: (detail: PaginationPageChangeDetail) => void;
@@ -85,7 +93,7 @@ interface PaginationRootProp extends ComponentPropsWithRef<'nav'> {
   withPageSizeSelector?: boolean;
 }
 
-interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'getPageUrl' | 'labelTooltipNext' | 'labelTooltipPrev' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
+interface PaginationProviderProp extends Pick<PaginationRootProp, 'defaultPage' | 'disabled' | 'getPageUrl' | 'labelTooltipNext' | 'labelTooltipPrev' | 'linkAs' | 'onPageChange' | 'onPageSizeChange' | 'page' | 'pageSize' | 'totalItems'> {
   children: ReactNode;
 }
 
@@ -105,6 +113,7 @@ function PaginationProvider({
   getPageUrl,
   labelTooltipNext,
   labelTooltipPrev,
+  linkAs,
   onPageChange,
   onPageSizeChange,
   page,
@@ -157,6 +166,7 @@ function PaginationProvider({
       itemsPerPage,
       labelTooltipNext,
       labelTooltipPrev,
+      linkAs,
       onPageChange,
       onPageSizeChange,
       page,

--- a/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
+++ b/packages/ods-react/src/components/pagination/src/contexts/usePagination.tsx
@@ -138,12 +138,20 @@ function PaginationProvider({
   }, [defaultPage, isControlled, itemsPerPage, totalItems]);
 
   function handlePageChange(detail: PaginationPageChangeDetail): void {
-    // In link mode the URL holds the page, so the component must not move on its own: React
-    // flushes a click synchronously, and a page change would rewrite the trigger href before
-    // the browser follows it, sending the user one page too far.
-    if (!isControlled && !getPageUrl) {
+    // Link mode: the URL owns the active page, and following a link is the only way to change it.
+    // Nothing is reported here, on purpose. React flushes a click synchronously, so a consumer
+    // moving the page from this callback would rewrite the trigger href before the browser
+    // follows it and land the user one page further than the link they clicked. Leaving the
+    // component untouched during the click makes that impossible rather than merely discouraged.
+    // The controls that are not links report on their own, see PaginationPageSelector.
+    if (getPageUrl) {
+      return;
+    }
+
+    if (!isControlled) {
       setInternalPage(detail.page);
     }
+
     onPageChange?.(detail);
   }
 

--- a/packages/ods-react/src/components/pagination/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/pagination/src/dev.stories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import style from './dev.module.css';
-import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, PaginationPages } from '.';
+import { Pagination, type PaginationPageChangeDetail, PaginationPageSelector, type PaginationPageSizeChangeDetail, PaginationPageSizeSelector, type PaginationPageUrlDetail, PaginationPages } from '.';
 
 export default {
   component: Pagination,
@@ -114,6 +114,55 @@ export const Disabled = () => (
       totalItems={ 500 } />
   </>
 );
+
+export const Links = () => {
+  const [page, setPage] = useState(1);
+
+  // A hash so that following a link does not take the storybook iframe off the story.
+  function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
+    return `#page-${page}-size-${pageSize}`;
+  }
+
+  return (
+    <>
+      <p>Link mode: the pages navigate, so they look like a Link.</p>
+
+      <Pagination
+        getPageUrl={ getPageUrl }
+        labelTooltipNext="Go to next page"
+        labelTooltipPrev="Go to prev page"
+        onPageChange={ ({ page }) => setPage(page) }
+        page={ page }
+        totalItems={ 500 }>
+        <PaginationPageSizeSelector />
+
+        <PaginationPages />
+
+        <PaginationPageSelector />
+      </Pagination>
+
+      <hr />
+      <p>Link mode, disabled</p>
+
+      <Pagination
+        defaultPage={ 4 }
+        disabled
+        getPageUrl={ getPageUrl }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+
+      <hr />
+      <p>Button mode, for comparison</p>
+
+      <Pagination
+        defaultPage={ 4 }
+        totalItems={ 500 }>
+        <PaginationPages />
+      </Pagination>
+    </>
+  );
+};
 
 export const Refs = () => {
   const paginationRef = useRef(null);

--- a/packages/ods-react/src/components/pagination/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/pagination/src/dev.stories.tsx
@@ -120,10 +120,10 @@ function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
   return `#page-${page}-size-${pageSize}`;
 }
 
-function readPageFromHash() {
-  const match = window.location.hash.match(/^#page-(\d+)-size-\d+$/);
+function readFromHash() {
+  const match = window.location.hash.match(/^#page-(\d+)-size-(\d+)$/);
 
-  return match ? Number(match[1]) : 1;
+  return match ? { page: Number(match[1]), pageSize: Number(match[2]) } : { page: 1, pageSize: 10 };
 }
 
 // Only reached by the controls that are not links: the "Go to page" form and the size selector.
@@ -132,12 +132,13 @@ function navigateToPage(page: number, pageSize: number) {
 }
 
 export const Links = () => {
-  // The page is read back from the URL, never from onPageChange: the URL is what the links move.
-  const [page, setPage] = useState(readPageFromHash);
+  // The page and the size are read back from the URL, never from the callbacks: the URL is what
+  // the links move, and the rest of the bar navigates to it.
+  const [{ page, pageSize }, setLocation] = useState(readFromHash);
 
   useEffect(() => {
     function sync() {
-      setPage(readPageFromHash());
+      setLocation(readFromHash());
     }
 
     window.addEventListener('hashchange', sync);
@@ -154,7 +155,9 @@ export const Links = () => {
         labelTooltipNext="Go to next page"
         labelTooltipPrev="Go to prev page"
         onPageChange={ ({ page, pageSize }) => navigateToPage(page, pageSize) }
+        onPageSizeChange={ ({ pageSize }) => navigateToPage(1, pageSize) }
         page={ page }
+        pageSize={ pageSize }
         totalItems={ 500 }>
         <PaginationPageSizeSelector />
 

--- a/packages/ods-react/src/components/pagination/src/dev.stories.tsx
+++ b/packages/ods-react/src/components/pagination/src/dev.stories.tsx
@@ -115,13 +115,35 @@ export const Disabled = () => (
   </>
 );
 
-export const Links = () => {
-  const [page, setPage] = useState(1);
+// A hash so that following a link does not take the storybook iframe off the story.
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
+  return `#page-${page}-size-${pageSize}`;
+}
 
-  // A hash so that following a link does not take the storybook iframe off the story.
-  function getPageUrl({ page, pageSize }: PaginationPageUrlDetail) {
-    return `#page-${page}-size-${pageSize}`;
-  }
+function readPageFromHash() {
+  const match = window.location.hash.match(/^#page-(\d+)-size-\d+$/);
+
+  return match ? Number(match[1]) : 1;
+}
+
+// Only reached by the controls that are not links: the "Go to page" form and the size selector.
+function navigateToPage(page: number, pageSize: number) {
+  window.location.hash = getPageUrl({ page, pageSize });
+}
+
+export const Links = () => {
+  // The page is read back from the URL, never from onPageChange: the URL is what the links move.
+  const [page, setPage] = useState(readPageFromHash);
+
+  useEffect(() => {
+    function sync() {
+      setPage(readPageFromHash());
+    }
+
+    window.addEventListener('hashchange', sync);
+
+    return () => window.removeEventListener('hashchange', sync);
+  }, []);
 
   return (
     <>
@@ -131,7 +153,7 @@ export const Links = () => {
         getPageUrl={ getPageUrl }
         labelTooltipNext="Go to next page"
         labelTooltipPrev="Go to prev page"
-        onPageChange={ ({ page }) => setPage(page) }
+        onPageChange={ ({ page, pageSize }) => navigateToPage(page, pageSize) }
         page={ page }
         totalItems={ 500 }>
         <PaginationPageSizeSelector />

--- a/packages/ods-react/src/components/pagination/src/index.ts
+++ b/packages/ods-react/src/components/pagination/src/index.ts
@@ -3,4 +3,4 @@ export { PaginationPageSelector, type PaginationPageSelectorProp } from './compo
 export { PaginationPageSizeSelector, type PaginationPageSizeSelectorProp } from './components/pagination-page-size-selector/PaginationPageSizeSelector';
 export { PaginationPages, type PaginationPagesProp } from './components/pagination-pages/PaginationPages';
 export { PAGINATION_PER_PAGE } from './constants/pagination-per-page';
-export { type PaginationPageChangeDetail, type PaginationPageSizeChangeDetail } from './contexts/usePagination';
+export { type PaginationPageChangeDetail, type PaginationPageSizeChangeDetail, type PaginationPageUrlDetail } from './contexts/usePagination';

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
@@ -1,0 +1,123 @@
+import 'jest-puppeteer';
+import { gotoStory } from '../../../../helpers/test';
+
+describe('Pagination navigation', () => {
+  describe('link mode', () => {
+    it('should navigate when a page link is activated', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const target = await page.waitForSelector('[data-part="item"]:not([aria-current="page"])');
+      const href = await target?.evaluate((el: Element) => el.getAttribute('href'));
+
+      expect(href).toBe('#page-2-size-10');
+
+      await target?.click();
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#page-2-size-10');
+    });
+
+    it('should follow the next trigger to the page it points at', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+      const href = await trigger?.evaluate((el: Element) => el.getAttribute('href'));
+
+      expect(href).toBe('#page-2-size-10');
+
+      await trigger?.click();
+
+      expect(await page.evaluate(() => window.location.hash)).toBe(href);
+    });
+
+    it('should walk the pages with the triggers when the page comes from the url', async() => {
+      await gotoStory(page, 'navigation/link-from-url');
+      await page.waitForSelector('[data-testid="link-from-url"]');
+
+      async function activate(part: string): Promise<string | null | undefined> {
+        const trigger = await page.waitForSelector(`[data-part="${part}"]`);
+
+        await trigger?.click();
+
+        return page.evaluate(() => window.location.hash);
+      }
+
+      expect(await activate('next-trigger')).toBe('#page-2-size-10');
+      expect(await activate('next-trigger')).toBe('#page-3-size-10');
+      expect(await activate('prev-trigger')).toBe('#page-2-size-10');
+    });
+
+    it('should hit a page from anywhere in its cell, not only on the digits', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const target = await page.waitForSelector('[data-part="item"]:not([aria-current="page"])');
+      // The corner of the 40px cell: several pixels clear of the digits, on the overlay only.
+      const corner = await target?.evaluate((el: Element) => {
+        const { left, top } = (el.parentElement as HTMLElement).getBoundingClientRect();
+
+        return { x: left + 2, y: top + 2 };
+      });
+
+      await page.mouse.click(corner!.x, corner!.y);
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#page-2-size-10');
+    });
+
+    it('should hit a trigger from anywhere in its cell, not only on the chevron', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+      const corner = await trigger?.evaluate((el: Element) => {
+        const { left, top } = (el.parentElement as HTMLElement).getBoundingClientRect();
+
+        return { x: left + 2, y: top + 2 };
+      });
+
+      await page.mouse.click(corner!.x, corner!.y);
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('#page-2-size-10');
+    });
+
+    it('should not navigate when the active page is activated', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      await page.click('[data-part="item"][aria-current="page"]');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('');
+    });
+
+    it('should not navigate when the inert previous trigger is clicked', async() => {
+      await gotoStory(page, 'navigation/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      await page.click('[data-part="prev-trigger"]');
+
+      expect(await page.evaluate(() => window.location.hash)).toBe('');
+    });
+
+    it('should keep the inert previous trigger out of the tab order', async() => {
+      await gotoStory(page, 'navigation/link');
+
+      const trigger = await page.waitForSelector('[data-part="prev-trigger"]');
+
+      await page.keyboard.press('Tab');
+
+      expect(await trigger?.evaluate((el: Element) => document.activeElement === el)).toBe(false);
+    });
+
+    it('should keep the active page out of the tab order, the way a current page is', async() => {
+      await gotoStory(page, 'navigation/link');
+
+      const current = await page.waitForSelector('[data-part="item"][aria-current="page"]');
+
+      await page.keyboard.press('Tab');
+      await page.keyboard.press('Tab');
+
+      expect(await current?.evaluate((el: Element) => document.activeElement === el)).toBe(false);
+    });
+  });
+});

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
@@ -109,6 +109,39 @@ describe('Pagination navigation', () => {
       expect(await page.evaluate(() => window.location.hash)).toBe('');
     });
 
+    it('should report the wanted size and stay put until the application navigates', async() => {
+      await gotoStory(page, 'navigation/link-size-selection');
+      await page.waitForSelector('[data-testid="link-size-selection"]');
+
+      function readBar(): Promise<{ current: string | null, next: string | null, prev: string | null, size: string }> {
+        return page.evaluate(() => ({
+          current: document.querySelector('[data-scope="pagination"][data-part="item"][aria-current="page"]')?.textContent ?? null,
+          next: document.querySelector('[data-part="next-trigger"]')?.getAttribute('href') ?? null,
+          prev: document.querySelector('[data-part="prev-trigger"]')?.getAttribute('href') ?? null,
+          size: document.querySelector('[data-ods="pagination-page-size-selector"] [data-part="trigger"]')?.textContent ?? '',
+        }));
+      }
+
+      const before = await readBar();
+
+      expect(before).toEqual({ current: '18', next: '#page-19-size-10', prev: '#page-17-size-10', size: '10' });
+
+      const trigger = await page.waitForSelector('[data-ods="pagination-page-size-selector"] [data-scope="select"][data-part="trigger"]');
+
+      await trigger?.click();
+
+      const option = await page.waitForSelector('[data-scope="select"][data-part="item"][data-value="100"]', { visible: true });
+
+      await option?.click();
+
+      expect(await page.evaluate(() => (window as unknown as { __pageSizeChanges?: unknown[] }).__pageSizeChanges ?? []))
+        .toEqual([{ pageSize: 100 }]);
+      // Moving on its own would rebuild every href with a size the URL does not have yet, drop
+      // the active page out of the new range, and point the triggers at pages that no longer exist.
+      expect(await readBar()).toEqual(before);
+      expect(await page.evaluate(() => (window as unknown as { __pageChanges?: unknown[] }).__pageChanges ?? [])).toEqual([]);
+    });
+
     it('should not navigate when the active page is activated', async() => {
       await gotoStory(page, 'navigation/link');
       await page.waitForSelector('[data-testid="link"]');

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
@@ -81,6 +81,34 @@ describe('Pagination navigation', () => {
       expect(await page.evaluate(() => window.location.hash)).toBe('#page-2-size-10');
     });
 
+    it('should stay silent when a link is followed, as the URL is the only signal', async() => {
+      await gotoStory(page, 'navigation/link-reporting');
+      await page.waitForSelector('[data-testid="link-reporting"]');
+
+      const target = await page.waitForSelector('[data-part="item"]:not([aria-current="page"])');
+
+      await target?.click();
+
+      // A hash navigation keeps the document alive, so the recorder survives the click.
+      expect(await page.evaluate(() => window.location.hash)).toMatch(/^#page-\d+-size-10$/);
+      // Reporting here would let the application move the page during the click, which rewrites
+      // the trigger href before the browser follows it and lands the user one page too far.
+      expect(await page.evaluate(() => (window as unknown as { __pageChanges?: unknown[] }).__pageChanges ?? [])).toEqual([]);
+    });
+
+    it('should report the wanted page from the go-to-page form, which is not a link', async() => {
+      await gotoStory(page, 'navigation/link-reporting');
+      await page.waitForSelector('[data-testid="link-reporting"]');
+
+      await page.type('[data-ods="pagination-page-selector"] input', '7');
+      await page.click('[data-ods="pagination-page-selector"] button[type="submit"]');
+
+      expect(await page.evaluate(() => (window as unknown as { __pageChanges?: unknown[] }).__pageChanges ?? []))
+        .toEqual([{ page: 7, pageSize: 10 }]);
+      // The form has no href to follow, so the application is the one that navigates.
+      expect(await page.evaluate(() => window.location.hash)).toBe('');
+    });
+
     it('should not navigate when the active page is activated', async() => {
       await gotoStory(page, 'navigation/link');
       await page.waitForSelector('[data-testid="link"]');

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.e2e.ts
@@ -109,6 +109,22 @@ describe('Pagination navigation', () => {
       expect(await page.evaluate(() => window.location.hash)).toBe('');
     });
 
+    it('should keep the triggers announced as links when they carry a tooltip', async() => {
+      await gotoStory(page, 'navigation/link-with-tooltips');
+      await page.waitForSelector('[data-testid="link-with-tooltips"]');
+
+      const triggers = await page.evaluate(() =>
+        [...document.querySelectorAll('[data-ods="tooltip-trigger"]')]
+          .map((el) => ({ href: el.getAttribute('href'), role: el.getAttribute('role'), tag: el.tagName })));
+
+      // The tooltip trigger is a Button in the default mode, and lends it its role. On an anchor
+      // that role would announce a link as a button, which is what link mode exists to avoid.
+      expect(triggers).toEqual([
+        { href: '#page-2-size-10', role: null, tag: 'A' },
+        { href: '#page-4-size-10', role: null, tag: 'A' },
+      ]);
+    });
+
     it('should report the wanted size and stay put until the application navigates', async() => {
       await gotoStory(page, 'navigation/link-size-selection');
       await page.waitForSelector('[data-testid="link-size-selection"]');

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
@@ -1,0 +1,57 @@
+import { type JSX, useEffect, useState } from 'react';
+import { Pagination, PaginationPages, type PaginationPageUrlDetail } from '../../src';
+
+export default {
+  component: Pagination,
+  title: 'Tests navigation',
+};
+
+const PAGE_SIZE = 10;
+
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `#page-${page}-size-${pageSize}`;
+}
+
+function readPageFromHash(): number {
+  const match = window.location.hash.match(/^#page-(\d+)-size-\d+$/);
+
+  return match ? Number(match[1]) : 1;
+}
+
+// The realistic wiring of link mode: the URL holds the page, the component only renders it.
+function LinkFromUrl(): JSX.Element {
+  const [page, setPage] = useState(readPageFromHash);
+
+  useEffect(() => {
+    function sync(): void {
+      setPage(readPageFromHash());
+    }
+
+    window.addEventListener('hashchange', sync);
+
+    return () => window.removeEventListener('hashchange', sync);
+  }, []);
+
+  return (
+    <Pagination
+      data-testid="link-from-url"
+      getPageUrl={ getPageUrl }
+      page={ page }
+      pageSize={ PAGE_SIZE }
+      totalItems={ 200 }>
+      <PaginationPages />
+    </Pagination>
+  );
+}
+
+export const link = () => (
+  <Pagination
+    data-testid="link"
+    defaultPage={ 1 }
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const linkFromUrl = () => <LinkFromUrl />;

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
@@ -1,5 +1,5 @@
 import { type JSX, useEffect, useState } from 'react';
-import { Pagination, PaginationPageSelector, PaginationPages, type PaginationPageUrlDetail } from '../../src';
+import { Pagination, PaginationPageSelector, PaginationPageSizeSelector, PaginationPages, type PaginationPageUrlDetail } from '../../src';
 
 export default {
   component: Pagination,
@@ -73,5 +73,30 @@ export const linkReporting = () => (
     <PaginationPages />
 
     <PaginationPageSelector />
+  </Pagination>
+);
+
+// The size selector has no link to follow either. Sits on the last page of the range so that a
+// bigger size would leave the active page outside of it.
+export const linkSizeSelection = () => (
+  <Pagination
+    data-testid="link-size-selection"
+    getPageUrl={ getPageUrl }
+    onPageChange={ (detail) => {
+      const store = window as unknown as { __pageChanges?: unknown[] };
+
+      store.__pageChanges = [...(store.__pageChanges ?? []), detail];
+    } }
+    onPageSizeChange={ (detail) => {
+      const store = window as unknown as { __pageSizeChanges?: unknown[] };
+
+      store.__pageSizeChanges = [...(store.__pageSizeChanges ?? []), detail];
+    } }
+    page={ 18 }
+    pageSize={ PAGE_SIZE }
+    totalItems={ 200 }>
+    <PaginationPageSizeSelector />
+
+    <PaginationPages />
   </Pagination>
 );

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
@@ -1,5 +1,5 @@
 import { type JSX, useEffect, useState } from 'react';
-import { Pagination, PaginationPages, type PaginationPageUrlDetail } from '../../src';
+import { Pagination, PaginationPageSelector, PaginationPages, type PaginationPageUrlDetail } from '../../src';
 
 export default {
   component: Pagination,
@@ -55,3 +55,23 @@ export const link = () => (
 );
 
 export const linkFromUrl = () => <LinkFromUrl />;
+
+// Records every page change reported to the application, so that a test can tell which controls
+// report and which ones stay silent because the browser already followed a link.
+export const linkReporting = () => (
+  <Pagination
+    data-testid="link-reporting"
+    getPageUrl={ getPageUrl }
+    onPageChange={ (detail) => {
+      const store = window as unknown as { __pageChanges?: unknown[] };
+
+      store.__pageChanges = [...(store.__pageChanges ?? []), detail];
+    } }
+    page={ 3 }
+    pageSize={ PAGE_SIZE }
+    totalItems={ 200 }>
+    <PaginationPages />
+
+    <PaginationPageSelector />
+  </Pagination>
+);

--- a/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/navigation/pagination.stories.tsx
@@ -54,6 +54,20 @@ export const link = () => (
   </Pagination>
 );
 
+// The tooltip labels wrap the triggers in a TooltipTrigger, which is where the role comes from.
+export const linkWithTooltips = () => (
+  <Pagination
+    data-testid="link-with-tooltips"
+    getPageUrl={ getPageUrl }
+    labelTooltipNext="Go to next page"
+    labelTooltipPrev="Go to previous page"
+    page={ 3 }
+    pageSize={ PAGE_SIZE }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
 export const linkFromUrl = () => <LinkFromUrl />;
 
 // Records every page change reported to the application, so that a test can tell which controls

--- a/packages/ods-react/src/components/pagination/tests/rendering/pagination.e2e.ts
+++ b/packages/ods-react/src/components/pagination/tests/rendering/pagination.e2e.ts
@@ -9,6 +9,181 @@ describe('Pagination rendering', () => {
     expect(await page.waitForSelector('[data-ods="pagination"]')).not.toBeNull();
   });
 
+  describe('link mode', () => {
+    it('should render the pages a user can go to as links, not as buttons', async() => {
+      await gotoStory(page, 'rendering/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const items = await page.$$('[data-part="item"]:not([aria-current="page"])');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        href: el.getAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tagName: el.tagName,
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+
+      rendered.forEach(({ href, ods, tagName }) => {
+        expect(tagName).toBe('A');
+        expect(ods).toBe('link');
+        expect(href).toMatch(/^#page-\d+-size-10$/);
+      });
+    });
+
+    it('should render the active page as plain text, as there is nowhere to navigate to', async() => {
+      await gotoStory(page, 'rendering/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const current = await page.$$('[data-part="item"][aria-current="page"]');
+
+      expect(current.length).toBe(1);
+
+      const rendered = await current[0].evaluate((el: Element) => ({
+        hasHref: el.hasAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tabIndex: (el as HTMLElement).tabIndex,
+        tagName: el.tagName,
+        textContent: el.textContent,
+      }));
+
+      expect(rendered.tagName).toBe('SPAN');
+      expect(rendered.textContent).toBe('1');
+      expect(rendered.hasHref).toBe(false);
+      // Neither a link nor a button: it is not actionable, so it is not styled as one.
+      expect(rendered.ods).toBeNull();
+      expect(rendered.tabIndex).toBe(-1);
+    });
+
+    it('should underline the digits only, never the cell around them', async() => {
+      await gotoStory(page, 'rendering/link');
+      await page.waitForSelector('[data-testid="link"]');
+
+      const items = await page.$$('[data-part="item"]');
+      const measured = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        cell: (el.parentElement as HTMLElement).getBoundingClientRect().width,
+        text: el.getBoundingClientRect().width,
+        underline: parseFloat(window.getComputedStyle(el, '::after').width),
+      }))));
+
+      expect(measured.length).toBeGreaterThan(0);
+
+      // The underline belongs to the page number, not to the 40px cell it sits in.
+      measured.forEach(({ cell, text, underline }) => {
+        expect(underline).toBeCloseTo(text, 1);
+        expect(underline).toBeLessThan(cell);
+      });
+    });
+
+    it('should underline the chevron of a trigger, the way an icon only link is underlined', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+      const measured = await trigger?.evaluate((el: Element) => ({
+        cell: (el.parentElement as HTMLElement).getBoundingClientRect().width,
+        glyph: el.getBoundingClientRect().width,
+        underline: parseFloat(window.getComputedStyle(el, '::after').width),
+      }));
+
+      // An icon only Link keeps its underline, at the width of the glyph and not of the cell.
+      expect(measured?.underline).toBeGreaterThan(0);
+      expect(measured?.underline).toBeCloseTo(measured!.glyph, 1);
+      expect(measured?.underline).toBeLessThan(measured!.cell);
+    });
+
+    it('should render every page as a button without a page url builder', async() => {
+      await gotoStory(page, 'rendering/pages');
+      await page.waitForSelector('[data-testid="pages"]');
+
+      const items = await page.$$('[data-part="item"]');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        href: el.getAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tagName: el.tagName,
+        type: el.getAttribute('type'),
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+
+      rendered.forEach(({ href, ods, tagName, type }) => {
+        expect(tagName).toBe('BUTTON');
+        expect(ods).toBe('button');
+        expect(type).toBe('button');
+        expect(href).toBeNull();
+      });
+    });
+
+    it('should render the previous trigger as an inert link on the first page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const trigger = await page.waitForSelector('[data-part="prev-trigger"]');
+      const rendered = await trigger?.evaluate((el: Element) => ({
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        hasHref: el.hasAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tabIndex: el.getAttribute('tabindex'),
+        tagName: el.tagName,
+      }));
+
+      expect(rendered?.tagName).toBe('A');
+      expect(rendered?.ods).toBe('link');
+      expect(rendered?.hasHref).toBe(false);
+      expect(rendered?.ariaDisabled).toBe('true');
+      expect(rendered?.tabIndex).toBe('-1');
+    });
+
+    it('should render the next trigger as a link to the next page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const trigger = await page.waitForSelector('[data-part="next-trigger"]');
+      const rendered = await trigger?.evaluate((el: Element) => ({
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        href: el.getAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tagName: el.tagName,
+      }));
+
+      expect(rendered?.tagName).toBe('A');
+      expect(rendered?.ods).toBe('link');
+      expect(rendered?.href).toBe('#page-2-size-10');
+      expect(rendered?.ariaDisabled).toBeNull();
+    });
+
+    it('should apply the disabled contract of Link to every page when the pagination is disabled', async() => {
+      await gotoStory(page, 'rendering/link-disabled');
+      await page.waitForSelector('[data-testid="link-disabled"]');
+
+      const items = await page.$$('[data-part="item"]:not([aria-current="page"])');
+      const rendered = await Promise.all(items.map((item) => item.evaluate((el: Element) => ({
+        ariaDisabled: el.getAttribute('aria-disabled'),
+        tabIndex: el.getAttribute('tabindex'),
+        tagName: el.tagName,
+      }))));
+
+      expect(rendered.length).toBeGreaterThan(0);
+
+      rendered.forEach(({ ariaDisabled, tabIndex, tagName }) => {
+        expect(tagName).toBe('A');
+        expect(ariaDisabled).toBe('true');
+        expect(tabIndex).toBe('-1');
+      });
+    });
+
+    it('should render the ellipsis as plain text, as it is a gap and not a page', async() => {
+      await gotoStory(page, 'rendering/link');
+
+      const ellipsis = await page.waitForSelector('[data-part="ellipsis"]');
+      const rendered = await ellipsis?.evaluate((el: Element) => ({
+        hasHref: el.hasAttribute('href'),
+        ods: el.getAttribute('data-ods'),
+        tagName: el.tagName,
+      }));
+
+      expect(rendered?.tagName).toBe('SPAN');
+      expect(rendered?.ods).toBeNull();
+      expect(rendered?.hasHref).toBe(false);
+    });
+  });
+
   describe('custom style', () => {
     it('should render with custom style applied', async() => {
       await gotoStory(page, 'rendering/custom-style');

--- a/packages/ods-react/src/components/pagination/tests/rendering/pagination.stories.tsx
+++ b/packages/ods-react/src/components/pagination/tests/rendering/pagination.stories.tsx
@@ -1,15 +1,48 @@
-import { Pagination } from '../../src';
+import { Pagination, PaginationPages, type PaginationPageUrlDetail } from '../../src';
 
 export default {
   component: Pagination,
   title: 'Tests rendering',
 };
 
+function getPageUrl({ page, pageSize }: PaginationPageUrlDetail): string {
+  return `#page-${page}-size-${pageSize}`;
+}
+
 export const customStyle = () => (
   <Pagination
     totalItems={20}
     data-testid="custom-style"
     style={{ height: '42px' }} />
+);
+
+export const link = () => (
+  <Pagination
+    data-testid="link"
+    defaultPage={ 1 }
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const linkDisabled = () => (
+  <Pagination
+    data-testid="link-disabled"
+    defaultPage={ 1 }
+    disabled
+    getPageUrl={ getPageUrl }
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
+);
+
+export const pages = () => (
+  <Pagination
+    data-testid="pages"
+    totalItems={ 200 }>
+    <PaginationPages />
+  </Pagination>
 );
 
 export const render = () => (


### PR DESCRIPTION
## Pagination: pages as links

Where a page is a destination of its own, the **Pagination** should render links, not Buttons. Provide `getPageUrl` and it does, styled as a `Link` rather than a `Button`: a button looks like a button, a link looks like a link.

```tsx
<Pagination
  getPageUrl={ ({ page, pageSize }) => `/products?page=${page}&size=${pageSize}` }
  page={ page }
  pageSize={ pageSize }
  totalItems={ 200 }>
  <PaginationPageSizeSelector />
  <PaginationPages />
  <PaginationPageSelector />
</Pagination>
```

**What it buys you.** Pages that can be crawled, opened in a new tab, copied and restored on reload, announced as links by a screen reader, and shipped in the server rendered HTML. The active page is not a link, since there is nowhere to go: it stays emphasised text carrying `aria-current="page"`.

**The contract.** In link mode the URL owns the state, the page and the size alike. The component renders what it is given and never moves on its own, which is what makes the whole thing safe: were it to move mid-click, it would rewrite the next href before the browser followed it and land the user one page further than the link they clicked. `onPageChange` and `onPageSizeChange` therefore fire only for the two controls that carry no destination, the "Go to page" form and the items per page Select, and the application navigates from there.

**`linkAs`** is optional. Plain anchors are enough for a server rendered site; pass your router's link component and the pages navigate inside the app instead. Triggers that lead nowhere keep no `linkAs`, as an undefined destination is meaningless to a router.

**Design.** The link hugs its digits so the underline is text width, while an invisible 40x40 overlay keeps the click target of the Button version. Same treatment for the chevrons, matching an icon only `Link`.

### Verifying

- 24 e2e tests, rendering and navigation, including the two contract cases and the hit areas.
- Two runnable applications: `packages/examples/react-router-app` (client navigation, with a counter showing the document is never reloaded) and `packages/examples/nextjs-app` (server component, links present in the initial HTML).
- Full walkthrough checked on both: page link, size change, "Go to page", out of range input, and the back button.

No change to the default Button mode.